### PR TITLE
Add Check to Make Sure Maproom Finished Initializing (Crash Fix)

### DIFF
--- a/client/scripts/BUILDING11.as
+++ b/client/scripts/BUILDING11.as
@@ -27,6 +27,7 @@ package
       
       override public function Tick(param1:int) : void
       {
+         _initFinishedMR = true;
          if(_countdownBuild.Get() > 0 || health < maxHealth * 0.5)
          {
             _canFunction = false;

--- a/client/scripts/MAPROOM.as
+++ b/client/scripts/MAPROOM.as
@@ -130,7 +130,7 @@ package
                   }
                   else if(!_initFinishedMR)
                   {
-                     GLOBAL.Message(KEYS.Get("The Maproom is still initializing. Please wait a moment before opening it."));
+                     GLOBAL.Message(KEYS.Get("newmap_init_setup"));
                   }
                   else
                   {

--- a/client/scripts/MAPROOM.as
+++ b/client/scripts/MAPROOM.as
@@ -1,6 +1,5 @@
 package
 {
-   
    import com.monsters.ai.TRIBES;
    import com.monsters.ai.WMBASE;
    import com.monsters.mailbox.Message;
@@ -21,6 +20,8 @@ package
       public static var _lastView:int = 0;
       
       public static var _lastSort:int = 3;
+      
+      public static var _initFinishedMR:Boolean = true;
       
       public static var _lastSortReversed:int = 0;
       
@@ -45,6 +46,7 @@ package
          _open = false;
          if(GLOBAL.mode == GLOBAL.e_BASE_MODE.BUILD)
          {
+            _initFinishedMR = false;
             _visitingFriend = false;
             bridge_obj = {
                "Timestamp":GLOBAL.Timestamp,
@@ -110,7 +112,7 @@ package
                }
                if(GLOBAL._bMap)
                {
-                  if(GLOBAL._bMap._canFunction)
+                  if(GLOBAL._bMap._canFunction && _initFinishedMR)
                   {
                      GLOBAL.BlockerAdd();
                      SOUNDS.Play("click1");
@@ -125,6 +127,10 @@ package
                      {
                         ShowB();
                      }
+                  }
+                  else if(!_initFinishedMR)
+                  {
+                     GLOBAL.Message(KEYS.Get("The Maproom is still initializing. Please wait a moment before opening it."));
                   }
                   else
                   {

--- a/server/public/gamestage/assets/en.v8.json
+++ b/server/public/gamestage/assets/en.v8.json
@@ -1646,6 +1646,7 @@
     "msg_cantrecycleoutpost": "You can not Recycle your Outpost",
     "newmap_opening": "Opening Map...",
     "newmap_bm_name": "Please enter a name for this bookmark.",
+    "newmap_init_setup": "Please wait a moment while we set up the MapRoom. This should only take a few seconds."
     "newmap_bm_long": "This bookmark name is too long.",
     "newmap_bm_full": "You have too many bookmarks. Please remove one and try again.",
     "newmap_bm_done": "You have already bookmarked this location.",

--- a/server/public/gamestage/assets/en.v8.json
+++ b/server/public/gamestage/assets/en.v8.json
@@ -1646,7 +1646,7 @@
     "msg_cantrecycleoutpost": "You can not Recycle your Outpost",
     "newmap_opening": "Opening Map...",
     "newmap_bm_name": "Please enter a name for this bookmark.",
-    "newmap_init_setup": "Please wait a moment while we set up the MapRoom. This should only take a few seconds."
+    "newmap_init_setup": "Please wait a moment while we set up the MapRoom. This should only take a few seconds.",
     "newmap_bm_long": "This bookmark name is too long.",
     "newmap_bm_full": "You have too many bookmarks. Please remove one and try again.",
     "newmap_bm_done": "You have already bookmarked this location.",


### PR DESCRIPTION
Fixes a bug where opening the maproom just after placing it for the first time would crash the game.