### PR TITLE
Remove Leftover Code Muting the Game on Start - Bug Fix

### DIFF
--- a/client/scripts/SOUNDS.as
+++ b/client/scripts/SOUNDS.as
@@ -147,7 +147,6 @@ package
          if (!_setup)
          {
             _setup = true;
-            _muted = 0;
             if (_mutedMusic == 0)
             {
                _musicVolume = 0.7;


### PR DESCRIPTION
Apparently the game didn't save the state of the sound setting because of this one leftover line from testing by the OG devs.
This removes that line, and fixes the bug.