### PR TITLE
Fix resource capacity text

### DIFF
--- a/client/scripts/BRESOURCE.as
+++ b/client/scripts/BRESOURCE.as
@@ -312,7 +312,7 @@ package
             if(!BASE.isOutpost)
             {
                _upgradeDescription += KEYS.Get("bdg_resource_upcapacity",{
-                  "v1":GLOBAL.FormatNumber(this.productionCapacity),
+                  "v1":GLOBAL.FormatNumber(_buildingProps.capacity[_lvl.Get() - 1]),
                   "v2":GLOBAL.FormatNumber(_buildingProps.capacity[_lvl.Get()])
                });
             }


### PR DESCRIPTION
Fixes the upgrade description for resource capacity:
```diff
- Capacity: Increases from 720 to 5,670
+ Capacity: Increases from 2,160 to 5,670
```

[Bug report](https://discord.com/channels/1126689848426774572/1302295995614363729)

