### PR TITLE
Enhancement: Local Docker Environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     ports:
       - 3001:3001
     depends_on:
-      - db
+      db:
+        condition: service_healthy
   db:
     image: mariadb:lts
     environment:
@@ -37,6 +38,14 @@ services:
       - bymr
     volumes:
       - db:/var/lib/mysql
+    healthcheck:
+      # test: mariadb-admin ping -h 127.0.0.1 --password=$MARIADB_ROOT_PASSWORD
+      test: mariadb-admin ping -h 127.0.0.1
+      start_period: 20s
+      start_interval: 1s
+      interval: 30s
+      timeout: 5s
+      retries: 30
   phpmyadmin:
     image: phpmyadmin:5
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+volumes:
+  db:
+  phpmyadmin:
+
+
+networks:
+  bymr:
+
+
+services:
+  web:
+    build: ./server
+    environment:
+      - BASE_URL=localhost
+      - PORT=3001
+      - DB_NAME=bymr
+      - DB_HOST=db
+      - DB_PORT=3306
+      - DB_USER=bymr
+      - DB_PASSWORD=bymr
+    networks:
+      - bymr
+    ports:
+      - 3001:3001
+    depends_on:
+      - db
+  db:
+    image: mariadb:lts
+    environment:
+      - MARIADB_ROOT_PASSWORD=root
+      - MARIADB_USER=bymr
+      - MARIADB_PASSWORD=bymr
+      - MARIADB_DATABASE=bymr
+    ports:
+      - 3306:3306
+    networks:
+      - bymr
+    volumes:
+      - db:/var/lib/mysql
+  phpmyadmin:
+    image: phpmyadmin:5
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - PMA_HOST=db
+    ports:
+      - 8080:80
+    networks:
+      - bymr
+    depends_on:
+      - db

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,5 @@
+.git
+
+Dockerfile*
+
+example.env

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:22-alpine
 
 RUN mkdir /app
 
@@ -8,4 +8,10 @@ COPY . /app
 
 RUN npm i
 
-ENTRYPOINT ["npm", "run", "serve"]
+RUN chmod +x scripts/*.sh
+
+# MariaDB Client needed for check if db has to be initialized. see scripts/try-init-db.sh
+RUN apk add mariadb-client
+
+ENTRYPOINT ["scripts/docker-start-web.sh"]
+# ENTRYPOINT ["npm", "run", "serve"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:latest
+
+RUN mkdir /app
+
+WORKDIR /app
+
+COPY . /app
+
+RUN npm i
+
+ENTRYPOINT ["npm", "run", "serve"]

--- a/server/scripts/docker-start-web.sh
+++ b/server/scripts/docker-start-web.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# this script assumes it is inside the server directory, not the scripts directory
+
+scripts/try-init-db.sh && npm run serve

--- a/server/scripts/try-init-db.sh
+++ b/server/scripts/try-init-db.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# READ ME!
+# This script is meant to run inside the web container of the docker-compose runtime. 
+# It checks if the most important tables exist in the database. If they do not exist, the db:init script is run
+# This script expects environment variables to be present, which are automatically passed by the docker_compose.yml file:
+# DB_HOST       => The hostname of the database 
+# DB_USER       => Database Username
+# DB_PASSWORD   => The password for the database user
+# DB_NAME       => The name of the database
+
+function sql {
+    mariadb -h $DB_HOST -u $DB_USER -p$DB_PASSWORD -D "$DB_NAME" -e "$1" -r
+    return $?
+}
+
+function tbl_exists {
+    tbl=$1
+    return sql "SELECT 1 as 'Exists' FROM $tbl LIMIT 1" > /dev/null
+}
+
+# perform the check
+ok=$(tbl_exists user && tbl_exists save && echo 1 || echo 0)
+
+if [[ $ok = "0" ]]; then
+    echo "Initializing DB"
+    npm run db:init
+else
+    echo "Database already initialized"
+fi


### PR DESCRIPTION
This patch sets up a Docker Compose environment to make local development easier by running the main services in containers.

- **docker-compose.yml**:
  - Defines three services:
    - **web**: Builds from the `server` directory, runs on port 3001, and connects to a MariaDB database.
    - **db**: Uses MariaDB, configured with the necessary database name and credentials, and includes a health check to ensure it's ready before the web service starts.
    - **phpmyadmin**: Runs phpMyAdmin on port 8080 for easy access to the database.

- **.dockerignore**:
  - Excludes unnecessary files from the Docker build, like `.git` and environment files, to speed up builds.

- **server/Dockerfile**:
  - Sets up a Node.js server environment, installs dependencies, and includes a MariaDB client to check if the database needs to be initialized.

- **Scripts**:
  - **docker-start-web.sh**: The web service entry point. Optionally sets up the database using the script `try-init-db.sh` and then starts the server.
  - **try-init-db.sh**: Checks if important tables exist in the database. If they don’t, it initializes the database by running `db:init`.

This setup enables developers to run a local server without installing all the dependencies manually.