### PR TITLE
Fix outpost resource production text

### DIFF
--- a/client/scripts/BRESOURCE.as
+++ b/client/scripts/BRESOURCE.as
@@ -293,6 +293,10 @@ package
          if(_lvl.Get() < _buildingProps.costs.length)
          {
             _loc9_ = _buildingProps.produce[_lvl.Get()] / _buildingProps.cycleTime[_lvl.Get()] * 60 * 60;
+            if(BASE.isOutpost)
+            {
+               _loc9_ = AdjustProduction(GLOBAL._currentCell,_loc9_);
+            }
             _loc10_ = _loc4_;
             _loc2_ = int(_buildingProps.capacity[_lvl.Get()]);
             if(BASE.isOutpost)


### PR DESCRIPTION
The first value `#v1#` of the [upgrade description for resource buildings](https://github.com/bym-refitted/backyard-monsters-refitted/blob/d4e045a81306887dec3bdae006d30cc707825b31/server/public/gamestage/assets/english.json#L1588) is affected by the outpost modifier, but the second value `#v2#` isn't:

https://github.com/bym-refitted/backyard-monsters-refitted/blob/2a666de02d9b97e1812e02991edb620fc763e862/client/scripts/BRESOURCE.as#L308-L311

https://github.com/bym-refitted/backyard-monsters-refitted/blob/2a666de02d9b97e1812e02991edb620fc763e862/client/scripts/BRESOURCE.as#L232-L236

https://github.com/bym-refitted/backyard-monsters-refitted/blob/2a666de02d9b97e1812e02991edb620fc763e862/client/scripts/BRESOURCE.as#L295

This PR fixes the upgrade description in outposts by using the adjusted production value for `#v2#`.

[Bug report](https://discord.com/channels/1126689848426774572/1305067556402495521)