### PR TITLE
Resolved townhall resolution mechanism in balancedReward.ts.

### DIFF
--- a/server/src/controllers/base/load/balancedReward.ts
+++ b/server/src/controllers/base/load/balancedReward.ts
@@ -54,13 +54,15 @@ export const balancedReward = async (userSave: Save) => {
   }
 
   if (townHall && townHall.l >= 7) {
-    let champ = userSave.champion;
+    // sometimes the champion variable is an object instead of a string,
+    // so the JSON.parse call runs into an error that "[object Object]" is not valid JSON.
+    let championRawData = userSave.champion;
     let championData = [];
-    if(typeof champ === "string") {
+    if(typeof championRawData === "string") {
       championData = JSON.parse(userSave.champion || "[]");
     }
     else {
-      championData = champ;
+      championData = championRawData;
     }
 
     if (Object.keys(userSave.krallen).length === 0) {

--- a/server/src/controllers/base/load/balancedReward.ts
+++ b/server/src/controllers/base/load/balancedReward.ts
@@ -42,8 +42,6 @@ function parseTownhallFromBuildingData(buildingData: FieldData) {
  * @returns {Promise<void>} A promise that resolves when the balanced rewards are added.
  */
 export const balancedReward = async (userSave: Save) => {
-  // TODO: For some reason, the townhall in some rare cases is not the first building ("0") in the buildingdata object.
-  // Instead it can be identifed by the "t" property in the buildingdata object being 14.
   const townHall = parseTownhallFromBuildingData(userSave.buildingdata);
 
   if (townHall && townHall.l >= 6) {


### PR DESCRIPTION
@React-1 just citing your message...

> Description:
>
>This fix will help reduce a lot of tickets, it has to do with user's not getting rewards at certain town hall levels, such as Korath, Krallen, >Diamond Spurtz Cannon.
>
>Details:
>
>These rewards are handled on the server, in the file balancedRewards.ts
>
>The issue comes from the fact that the script checks for the first key in the object being "0" since this building should always be the Town >Hall, and checks the "l" property on that object being the level of the Town Hall. If its above a certain level, insert the reward into the >database.
>
>The oversight was trusting the Backyard Monsters game client to always make sure the first building is the Town Hall. For some odd reason, the >people who report the issue, don't have a first key ("0") in their buildingdata, instead their Town Hall is some random key like "1776"

Also see my comment below regarding the champion data code changes