### PR TITLE
Bugfix - balancedReward 

### DIFF
--- a/server/src/controllers/base/load/balancedReward.ts
+++ b/server/src/controllers/base/load/balancedReward.ts
@@ -54,13 +54,15 @@ export const balancedReward = async (userSave: Save) => {
   }
 
   if (townHall && townHall.l >= 7) {
-    let champ = userSave.champion;
+    // sometimes the champion variable is an object instead of a string,
+    // so the JSON.parse call runs into an error that "[object Object]" is not valid JSON.
+    let championRawData = userSave.champion;
     let championData = [];
-    if(typeof champ === "string") {
+    if(typeof championRawData === "string") {
       championData = JSON.parse(userSave.champion || "[]");
     }
     else {
-      championData = champ;
+      championData = championRawData;
     }
 
     if (Object.keys(userSave.krallen).length === 0) {

--- a/server/src/controllers/base/load/balancedReward.ts
+++ b/server/src/controllers/base/load/balancedReward.ts
@@ -15,8 +15,6 @@ import { ORMContext } from "../../../server";
  * @throws Error when townHall Object cannot be found
  */
 function parseTownhallFromBuildingData(buildingData: FieldData) {
-  let townHall: any = null;
-
   for (const key in buildingData) {
     const building = buildingData[key];
 
@@ -24,7 +22,6 @@ function parseTownhallFromBuildingData(buildingData: FieldData) {
       return building;
     }
   }
-
   return null;
 }
 

--- a/server/src/controllers/base/load/balancedReward.ts
+++ b/server/src/controllers/base/load/balancedReward.ts
@@ -42,8 +42,6 @@ function parseTownhallFromBuildingData(buildingData: FieldData) {
  * @returns {Promise<void>} A promise that resolves when the balanced rewards are added.
  */
 export const balancedReward = async (userSave: Save) => {
-  // TODO: For some reason, the townhall in some rare cases is not the first building ("0") in the buildingdata object.
-  // Instead it can be identifed by the "t" property in the buildingdata object being 14.
   const townHall = parseTownhallFromBuildingData(userSave.buildingdata);
 
   if (townHall && townHall.l >= 6) {

--- a/server/src/controllers/base/load/balancedReward.ts
+++ b/server/src/controllers/base/load/balancedReward.ts
@@ -2,7 +2,6 @@ import { KorathReward, Reward } from "../../../enums/Rewards";
 import { FieldData, Save } from "../../../models/save.model";
 import { ORMContext } from "../../../server";
 
-
 /**
  * Returns the Town Hall building object contained in the given buildingData object.
  * Throws an error if the town hall cannot be found.
@@ -16,17 +15,14 @@ import { ORMContext } from "../../../server";
  */
 function parseTownhallFromBuildingData(buildingData: FieldData) {
   let townHall: any = null;
-  for(const key in buildingData) {
-    const building = buildingData[key];
-    if(!building) {
-      continue;
-    }
-    if (building.t !== 14) continue;
 
-    townHall = building;
-    break;
+  for (const key in buildingData) {
+    const building = buildingData[key];
+
+    if (building && building.t === 14) {
+      return building;
+    }
   }
-  if (townHall) return townHall;
 
   throw new Error("Cannot find townhall in payload")
 }
@@ -56,7 +52,7 @@ export const balancedReward = async (userSave: Save) => {
     // so the JSON.parse call runs into an error that "[object Object]" is not valid JSON.
     let championRawData = userSave.champion;
     let championData = [];
-    if(typeof championRawData === "string") {
+    if (typeof championRawData === "string") {
       championData = JSON.parse(userSave.champion || "[]");
     }
     else {

--- a/server/src/controllers/base/load/balancedReward.ts
+++ b/server/src/controllers/base/load/balancedReward.ts
@@ -14,7 +14,7 @@ import { ORMContext } from "../../../server";
  * @returns the townHall object found
  * @throws Error when townHall Object cannot be found
  */
-function parseTownhallFromBuildingData(buildingData: FieldData) {
+const parseTownhallFromBuildingData = (buildingData: FieldData) => {
   for (const key in buildingData) {
     const building = buildingData[key];
 
@@ -29,7 +29,7 @@ function parseTownhallFromBuildingData(buildingData: FieldData) {
  * Parses the champing data object from the player save. The champion object may not be a string but rather an object already.
  * This function only parses the rawChampionData when it is actually a string.
  */
-function parseChampionData(rawChampionData:any) {
+const parseChampionData = (rawChampionData:any) => {
   // sometimes the champion variable is an object instead of a string,
   // so the JSON.parse call runs into an error that "[object Object]" is not valid JSON.
   if (typeof rawChampionData === "string") {
@@ -48,7 +48,7 @@ function parseChampionData(rawChampionData:any) {
  * @param {Save} userSave - The user's save data.
  * @returns {Promise<void>} A promise that resolves when the balanced rewards are added.
  */
-export const balancedReward = async (userSave: Save) => {
+export const balancedReward = async (userSave: Save): Promise<void> => {
   let rewards = userSave.rewards;
   if (rewards) {
     let korath = rewards[Reward.KORATH];

--- a/server/src/controllers/base/load/balancedReward.ts
+++ b/server/src/controllers/base/load/balancedReward.ts
@@ -28,6 +28,10 @@ function parseTownhallFromBuildingData(buildingData: FieldData) {
   return null;
 }
 
+/**
+ * Parses the champing data object from the player save. The champion object may not be a string but rather an object already.
+ * This function only parses the rawChampionData when it is actually a string.
+ */
 function parseChampionData(rawChampionData:any) {
   // sometimes the champion variable is an object instead of a string,
   // so the JSON.parse call runs into an error that "[object Object]" is not valid JSON.
@@ -48,13 +52,13 @@ function parseChampionData(rawChampionData:any) {
  * @returns {Promise<void>} A promise that resolves when the balanced rewards are added.
  */
 export const balancedReward = async (userSave: Save) => {
-  // return early if all rewards have been given already
   let rewards = userSave.rewards;
   if (rewards) {
     let korath = rewards[Reward.KORATH];
     let krallen = rewards[Reward.KRALLEN];
     let diamondSpurtz = rewards[Reward.DIAMOND_SPURTZ];
 
+    // return early if all rewards have been given already
     if (korath && krallen && diamondSpurtz) return;
   }
 


### PR DESCRIPTION
@React-1 just citing your message...

> Description:
>
>This fix will help reduce a lot of tickets, it has to do with user's not getting rewards at certain town hall levels, such as Korath, Krallen, >Diamond Spurtz Cannon.
>
>Details:
>
>These rewards are handled on the server, in the file balancedRewards.ts
>
>The issue comes from the fact that the script checks for the first key in the object being "0" since this building should always be the Town >Hall, and checks the "l" property on that object being the level of the Town Hall. If its above a certain level, insert the reward into the >database.
>
>The oversight was trusting the Backyard Monsters game client to always make sure the first building is the Town Hall. For some odd reason, the >people who report the issue, don't have a first key ("0") in their buildingdata, instead their Town Hall is some random key like "1776"

Regarding the champion object related changes: I had this an error happen to me on my local system, so I added a check that addresses it. See the comment for more details.

In general, our server seems to be very sensitive to the environment it is running in. I had to mode away from hosting the server inside docker because of errors that only happen INSIDE the container.