### PR TITLE
fix(takover-price): set price based on empire value

### DIFF
--- a/server/src/controllers/maproom/v2/cells/userCell.ts
+++ b/server/src/controllers/maproom/v2/cells/userCell.ts
@@ -61,6 +61,7 @@ export const userCell = async (ctx: Context, cell: WorldMapCell) => {
       bid: cell.base_id,
       aid: 0,
       i: cell.terrainHeight,
+      v: cellSave?.empirevalue || 1,
       mine: mine ? 1 : 0,
       f: cellSave?.flinger || 0,
       c: cellSave?.catapult || 0,


### PR DESCRIPTION
Before it's 0 because the server don't return any value for `v` field, and client can't calculate it, so we just need return any number with minimum value of 1, so it can be calculated, here's takeover price of another player's outpost with only outpost building inside, so the empire value is 1

Before Fix:
<img width="742" alt="Screen Shot 2024-11-30 at 22 54 55" src="https://github.com/user-attachments/assets/4e118831-8f8f-47f1-9387-ba3294cbcee6">

After Fix:
<img width="758" alt="Screen Shot 2024-11-30 at 22 58 10" src="https://github.com/user-attachments/assets/88ad8f89-526c-4929-a7c0-d13a89ae2ef4">

Regular Kit empire value is 3,222,316, the takeover price is 8,750,000
Ultra Kit empire value is 41,526,414, the takeover price is 54,750,000.
