### PR TITLE
fix(outpost-level): populate user with save for other user

### DIFF
--- a/server/src/controllers/maproom/v2/cells/userCell.ts
+++ b/server/src/controllers/maproom/v2/cells/userCell.ts
@@ -30,7 +30,7 @@ export const userCell = async (ctx: Context, cell: WorldMapCell) => {
     // Get the cell owner, either the current user or another user
     const cellOwner = mine
       ? currentUser
-      : await ORMContext.em.findOne(User, { userid: cell.uid });
+      : await ORMContext.em.findOne(User, { userid: cell.uid }, { populate: ["save"] });
 
     if (!cellOwner || !cellOwner.save) {
       errorLog(`Cell owner save data is missing. Save: ${cellOwner.save}`);


### PR DESCRIPTION
when loading the map room and  there are multiple requests to `/worldmapv2/getarea`, some outpost doesn't showing the outpost level correctly (usually not happening in the first request).

to fix this, if the current cell is other player's outpost, we should populate User.save so we can calculate the level
Before fix:
<img width="751" alt="Screen Shot 2024-12-12before" src="https://github.com/user-attachments/assets/ff600fa4-66f1-4a8b-9e70-a1240b5bd82c" />


After fix:
<img width="748" alt="Screen Shot 2024-12-12after" src="https://github.com/user-attachments/assets/9d1b9402-ff1a-4819-b871-b5b82c9f2c5d" />
