### PR TITLE
Added validation for MapRoom access for account grace period

### DIFF
--- a/server/src/app.routes.ts
+++ b/server/src/app.routes.ts
@@ -7,7 +7,7 @@ import { baseLoad } from "./controllers/base/load/baseLoad";
 import { updateSaved } from "./controllers/base/save/updateSaved";
 import { getMapRoomCells } from "./controllers/maproom/v3/getCells";
 import { getNewMap } from "./controllers/maproom/getNewMap";
-import { auth, verifyAccountStatus } from "./middleware/auth";
+import { verifyUserAuth, verifyAccountStatus } from "./middleware/auth";
 import { relocate } from "./controllers/maproom/v3/relocate";
 import { infernoMonsters } from "./controllers/inferno/infernoMonsters";
 import { recordDebugData } from "./controllers/debug/recordDebugData";
@@ -129,13 +129,23 @@ router.post("/api/player/reset-password", resetPassword);
  * Load base data
  * @name POST /base/load
  */
-router.post("/base/load", auth, debugDataLog("Base load data"), baseLoad);
+router.post(
+  "/base/load",
+  verifyUserAuth,
+  debugDataLog("Base load data"),
+  baseLoad
+);
 
 /**
  * Save base data
  * @name POST /base/save
  */
-router.post("/base/save", auth, debugDataLog("Base save data"), baseSave);
+router.post(
+  "/base/save",
+  verifyUserAuth,
+  debugDataLog("Base save data"),
+  baseSave
+);
 
 /**
  * Update saved base data
@@ -143,7 +153,7 @@ router.post("/base/save", auth, debugDataLog("Base save data"), baseSave);
  */
 router.post(
   "/base/updatesaved",
-  auth,
+  verifyUserAuth,
   debugDataLog("Base updated save"),
   updateSaved
 );
@@ -154,7 +164,7 @@ router.post(
  */
 router.post(
   "/base/migrate",
-  auth,
+  verifyUserAuth,
   debugDataLog("Base migrate data"),
   migrateBase
 );
@@ -166,7 +176,7 @@ router.post(
 router.get(
   "/api/:apiVersion/bm/yardplanner/gettemplates",
   apiVersion,
-  auth,
+  verifyUserAuth,
   debugDataLog("Get templates"),
   getTemplates
 );
@@ -178,7 +188,7 @@ router.get(
 router.post(
   "/api/:apiVersion/bm/yardplanner/savetemplate",
   apiVersion,
-  auth,
+  verifyUserAuth,
   debugDataLog("Saving template"),
   saveTemplate
 );
@@ -190,7 +200,7 @@ router.post(
 router.post(
   "/api/:apiVersion/bm/base/load",
   apiVersion,
-  auth,
+  verifyUserAuth,
   debugDataLog("Inferno load data"),
   baseLoad
 );
@@ -202,7 +212,7 @@ router.post(
 router.post(
   "/api/:apiVersion/bm/base/save",
   apiVersion,
-  auth,
+  verifyUserAuth,
   debugDataLog("Inferno save data"),
   baseSave
 );
@@ -214,7 +224,7 @@ router.post(
 router.post(
   "/api/:apiVersion/bm/base/infernomonsters",
   apiVersion,
-  auth,
+  verifyUserAuth,
   debugDataLog("Load inferno monsters"),
   infernoMonsters
 );
@@ -225,7 +235,7 @@ router.post(
  */
 router.post(
   "/worldmapv2/getarea",
-  auth,
+  verifyUserAuth,
   verifyAccountStatus,
   debugDataLog("MR2 get area"),
   getArea
@@ -237,7 +247,7 @@ router.post(
  */
 router.post(
   "/worldmapv2/setmapversion",
-  auth,
+  verifyUserAuth,
   verifyAccountStatus,
   debugDataLog("Set maproom version"),
   setMapVersion
@@ -250,7 +260,7 @@ router.post(
 router.post(
   "/worldmapv2/takeoverCell",
   verifyAccountStatus,
-  auth,
+  verifyUserAuth,
   debugDataLog("Taking over cell"),
   takeoverCell
 );
@@ -261,7 +271,7 @@ router.post(
  */
 router.post(
   "/worldmapv2/transferassets",
-  auth,
+  verifyUserAuth,
   verifyAccountStatus,
   debugDataLog("Transferring assets"),
   transferMonsters
@@ -274,7 +284,7 @@ router.post(
 router.post(
   "/api/:apiVersion/player/savebookmarks",
   apiVersion,
-  auth,
+  verifyUserAuth,
   verifyAccountStatus,
   debugDataLog("MR2 save bookmarks"),
   saveBookmarks
@@ -286,7 +296,7 @@ router.post(
  */
 router.post(
   "/worldmapv3/initworldmap",
-  auth,
+  verifyUserAuth,
   verifyAccountStatus,
   debugDataLog("Posting MR3 init data"),
   initialPlayerCellData
@@ -298,7 +308,7 @@ router.post(
  */
 router.get(
   "/worldmapv3/initworldmap",
-  auth,
+  verifyUserAuth,
   verifyAccountStatus,
   debugDataLog("Getting MR3 init data"),
   initialPlayerCellData
@@ -310,7 +320,7 @@ router.get(
  */
 router.post(
   "/worldmapv3/getcells",
-  auth,
+  verifyUserAuth,
   verifyAccountStatus,
   debugDataLog("Get MR3 cells"),
   getMapRoomCells
@@ -322,7 +332,7 @@ router.post(
  */
 router.post(
   "/worldmapv3/relocate",
-  auth,
+  verifyUserAuth,
   verifyAccountStatus,
   debugDataLog("Relocating MR3 base"),
   relocate
@@ -334,7 +344,7 @@ router.post(
  */
 router.get(
   "/worldmapv3/setmapversion",
-  auth,
+  verifyUserAuth,
   verifyAccountStatus,
   debugDataLog("Set maproom version"),
   setMapVersion
@@ -346,7 +356,7 @@ router.get(
  */
 router.post(
   "/worldmapv3/setmapversion",
-  auth,
+  verifyUserAuth,
   verifyAccountStatus,
   debugDataLog("Set maproom version"),
   setMapVersion

--- a/server/src/controllers/base/save/baseSave.ts
+++ b/server/src/controllers/base/save/baseSave.ts
@@ -110,10 +110,7 @@ export const baseSave: KoaController = async (ctx) => {
     // ==================================== //
     
     // TODO: Revisit this
-    // if (!ctx.meetsDiscordAgeCheck) {
-    //   console.log("Hacker attempting to attack without being old enough");
-    //   throw discordNotOldEnough();
-    // }
+    // if (!ctx.meetsDiscordAgeCheck) throw discordNotOldEnough();
     
     const saveData = ctx.request.body as Record<string, any>;
 

--- a/server/src/controllers/maproom/v2/getArea.ts
+++ b/server/src/controllers/maproom/v2/getArea.ts
@@ -106,6 +106,6 @@ export const getArea: KoaController = async (ctx) => {
     };
   } else {
     ctx.status = Status.NOT_FOUND;
-    ctx.body = { message: "Map Room is not enabled on this server", error: 1 };
+    ctx.body = { error: "Map Room is not enabled on this server" };
   }
 };

--- a/server/src/controllers/maproom/v2/setMapVersion.ts
+++ b/server/src/controllers/maproom/v2/setMapVersion.ts
@@ -22,6 +22,16 @@ export const CURRENT_MAPROOM_VERSION = MapRoomVersion.V2 as MapRoomVersion;
  * @returns {Promise<void>} - A promise that resolves when the controller is complete.
  */
 export const setMapVersion: KoaController = async (ctx) => {
+  // Check if the user's Discord account is at least a week old
+  if (!ctx.meetsDiscordAgeCheck) {
+    ctx.status = Status.FORBIDDEN;
+    ctx.body = {
+      error:
+        "Discord account must be at least a week old to access this route.",
+    };
+    return;
+  }
+
   const user: User = ctx.authUser;
   await ORMContext.em.populate(user, ["save"]);
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -15,7 +15,7 @@ import JWT, { JwtPayload } from "jsonwebtoken";
  * @param {Next} next - The Koa next middleware function.
  * @throws Will throw an error if the Authorization header is missing or invalid, or if the user cannot be found.
  */
-export const auth = async (ctx: Context, next: Next) => {
+export const verifyUserAuth = async (ctx: Context, next: Next) => {
   const authHeader = ctx.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith("Bearer ")) throw authFailureErr();
@@ -79,7 +79,7 @@ export interface BymJwtPayload extends DisgustingJwtPayloadHack {
   user: {
     email: string;
     discordId?: string;
-    meetsDiscordAgeCheck?: boolean;
+    meetsDiscordAgeCheck: boolean;
   };
 }
 
@@ -94,6 +94,6 @@ export const verifyJwtToken = (token: string): BymJwtPayload => {
   try {
     return <BymJwtPayload>JWT.verify(token, process.env.SECRET_KEY);
   } catch (err) {
-    throw authFailureErr();
+    throw tokenAuthFailureErr();
   }
 };


### PR DESCRIPTION
This PR creates a guard on the `setMapVersion.ts` route to disable MapRoom access for users who's Discord account is less than 1 week old.