### PR TITLE
baseid now factors in worldid | flinger range validation factors in toroidal map wrap-around

### DIFF
--- a/server/src/controllers/base/load/modes/baseModeAttack.ts
+++ b/server/src/controllers/base/load/modes/baseModeAttack.ts
@@ -35,40 +35,30 @@ export const baseModeAttack = async (user: User, baseid: string) => {
   });
 
   if (!cell) {
-    // Create a cell record when attacking tribe bases
+    // Find the existing world record
     const world = await ORMContext.em.findOne(World, {
       uuid: userSave.worldid,
     });
 
     if (!world) throw new Error("No world found.");
 
-    const baseIdBigInt = BigInt(baseid);
-    const baseIdStr = baseIdBigInt.toString();
-
-    // Derive cellX and cellY from specific positions (based on the structure of baseid)
-    const cellX = parseInt(baseIdStr.slice(1, 4));
-    const cellY = parseInt(baseIdStr.slice(4));
+    // Derive cellX and cellY from baseid
+    const cellX = parseInt(baseid.slice(4, 7));
+    const cellY = parseInt(baseid.slice(7, 10));
 
     const noise = generateNoise(world.uuid);
+    const terrainHeight = getTerrainHeight(noise, cellX, cellY);
 
-    cell = new WorldMapCell(
-      world,
-      cellX,
-      cellY,
-      getTerrainHeight(noise, cellX, cellY),
-      {
-        base_id: baseIdBigInt,
-        uid: save.saveuserid,
-        base_type: MapRoomCell.WM,
-      }
-    );
-
-    cell.base_id = BigInt(save.baseid);
+    // Create a new cell record
+    cell = new WorldMapCell(world, cellX, cellY, terrainHeight);
+    cell.uid = save.saveuserid;
+    cell.base_type = MapRoomCell.WM;
+    cell.base_id = BigInt(baseid);
   }
-  
+
   save.cell = cell;
   save.worldid = userSave.worldid;
-  save.attackid = Math.floor(Math.random() * 99999) + 1; // I hate this.
+  save.attackid = Math.floor(Math.random() * 99999) + 1;
   await ORMContext.em.persistAndFlush([cell, save]);
 
   return await validateRange(user, save, baseid);

--- a/server/src/controllers/maproom/v2/cells/wildMonsterCell.ts
+++ b/server/src/controllers/maproom/v2/cells/wildMonsterCell.ts
@@ -2,19 +2,28 @@ import { WorldMapCell } from "../../../../models/worldmapcell.model";
 import { Tribes } from "../../../../enums/Tribes";
 import { calculateTribeLevel } from "../../../../services/maproom/v2/calculateTribeLevel";
 import { MapRoomCell } from "../../../../enums/MapRoom";
+import { worldIdToNumber } from "../../../../utils/worldIdtoNumber";
 
 export const wildMonsterCell = async (cell: WorldMapCell, worldId: string) => {
-  const tribeIndex = (cell.x + cell.y) % Tribes.length;
+  const [cellX, cellY] = [cell.x, cell.y];
+
+  const tribeIndex = (cellX + cellY) % Tribes.length;
+  const worldIdNumber = worldIdToNumber(worldId);
   const tribe = Tribes[tribeIndex];
 
-  let baseId = 1000000 + cell.y + cell.x * 1000;
+  // Create baseid from current worldid, cellX, and cellY
+  // TODO: Find a better way to generate baseid, this is awful.
+  const baseid = `${worldIdNumber.toString().padStart(4, "0")}${cellX
+    .toString()
+    .padStart(3, "0")}${cellY.toString().padStart(3, "0")}`;
+
   const level = calculateTribeLevel(cell.x, cell.y, worldId, tribe);
 
   return {
-    uid: baseId,
+    uid: 0,
     b: MapRoomCell.WM,
     i: cell.terrainHeight,
-    bid: baseId,
+    bid: baseid,
     n: Tribes[tribeIndex],
     l: level,
     dm: cell?.save?.damage || 0,

--- a/server/src/models/worldmapcell.model.ts
+++ b/server/src/models/worldmapcell.model.ts
@@ -14,21 +14,13 @@ import { Save } from "./save.model";
 @Index({ properties: ["world_id", "x", "y"] })
 @Entity({ tableName: "world_map_cell" })
 export class WorldMapCell {
-  constructor(
-    world?: World,
-    x?: number,
-    y?: number,
-    terrainHeight?: number,
-    optional = { base_id: BigInt(0), uid: 0, base_type: 0 }
-  ) {
+  
+  constructor(world?: World, x?: number, y?: number, terrainHeight?: number) {
     this.world = world;
     this.world_id = world?.uuid;
     this.x = x;
     this.y = y;
     this.terrainHeight = terrainHeight;
-    this.base_type = optional.base_type;
-    this.base_id = optional.base_id;
-    this.uid = optional.uid;
   }
 
   @FrontendKey

--- a/server/src/services/maproom/v2/validateRange.ts
+++ b/server/src/services/maproom/v2/validateRange.ts
@@ -1,3 +1,4 @@
+import { MapRoom } from "../../../enums/MapRoom";
 import { IncidentReport } from "../../../models/incidentreport";
 import { Save } from "../../../models/save.model";
 import { User } from "../../../models/user.model";
@@ -89,10 +90,18 @@ const calculateDistance = (
   cellY: number,
   baseX: number,
   baseY: number
-) =>
-  Math.round(
-    Math.sqrt(Math.pow(baseX - cellX, 2) + Math.pow(baseY - cellY, 2))
-  );
+) => {
+  // Calculate the straight-line distances
+  const deltaX = Math.abs(baseX - cellX);
+  const deltaY = Math.abs(baseY - cellY);
+
+  // Wrap-around distances (for toroidal map)
+  const wrappedDeltaX = Math.min(deltaX, MapRoom.WIDTH - deltaX);
+  const wrappedDeltaY = Math.min(deltaY, MapRoom.HEIGHT - deltaY);
+
+  // Use the smaller wrapped distances to calculate true distance
+  return Math.round(Math.sqrt(wrappedDeltaX ** 2 + wrappedDeltaY ** 2));
+};
 
 const getMainYardRange = (flinger: number) => {
   switch (flinger) {

--- a/server/src/utils/worldIdtoNumber.ts
+++ b/server/src/utils/worldIdtoNumber.ts
@@ -4,8 +4,8 @@
  * @param {string} worldId - The world ID to be converted.
  * @returns {number} The numerical representation of the world ID.
  */
-export const worldIdToNumber = (worldId: string) => {
-  let utf8Encode = new TextEncoder();
-  let test = utf8Encode.encode(worldId);
-  return [...test.values()].reduce((val, res) => val + res, 0);
+export const worldIdToNumber = (worldId: string): number => {
+  return new TextEncoder()
+    .encode(worldId)
+    .reduce((sum, byte) => sum + byte, 0);
 };


### PR DESCRIPTION
## Fixes in this PR:

- In `wildMonsterCell.ts` the `baseid` is now generated using the current `worldid` as a number. This allows for multiple worlds to exist independently without identical `baseid` conflicts.

-  Flinger range validation was not taking into account the fact that the world wraps at the edges; for example, if a base is located at co-ordinate 0 x 0, then it cannot attack a cell at co-ordinate 1 x 799, as technically this is out of range.

- Additional cleanup, particularly in the `WorldMapCell` model, which sees the removal of optional constructor params, instead these are assigned directly before persisting to database.

- Slight performance improvements to the `worldidToNumber` converter.

<br>

## TODOs and Considerations:

- The way we are generating the current `baseid` (see wildMonsterCell.ts) and deriving the cellX and cellY from it in `baseModeAttack.ts` is pretty crap, there is a lot of conversations and stupid shit, but it works for now. Will clean up later.

FYI: @EvenBiggerManGhark 