### PR TITLE
Fixed an issue in docker-example.env. The http prefix must be present…

### DIFF
--- a/docker-example.env
+++ b/docker-example.env
@@ -7,8 +7,9 @@ ENV=local
 # The port on which the API will be accessible
 API_PORT=3001
 
-# The base url on which the api will be accessible, e.g. example.com or localhost
-BASE_URL=localhost
+# The base url on which the api will be accessible, e.g. https://example.com or http://localhost
+# The http/https prefix is MANDATORY
+BASE_URL=http://localhost
 
 # =============== DATABASE ===============
 


### PR DESCRIPTION
This fixes a problem in the docker-compose PR I did recently.

The BASE_URL for the server needs to contain the http/https prefix, otherwise the flash client will not be able to send more requests after receiving the URL for the maproom. (the flash client cannot handle URLs without https prefix)