### PR TITLE
Outposts now correctly persist building data with server-side validation

### DIFF
--- a/server/src/controllers/base/save/baseSave.ts
+++ b/server/src/controllers/base/save/baseSave.ts
@@ -20,6 +20,7 @@ import { ClientSafeError } from "../../../middleware/clientSafeError";
 import { championHandler } from "./handlers/championHandler";
 import { anticheat } from "../../../scripts/anticheat/anticheat";
 import { updateResources } from "../../../services/base/updateResources";
+import { buildingDataHandler } from "./handlers/buildingDataHandler";
 
 /**
  * Controller responsible for saving the user's base data.
@@ -75,6 +76,13 @@ export const baseSave: KoaController = async (ctx) => {
         case SaveKeys.ACADEMY:
           academyHandler(ctx, baseSave);
           break;
+
+        case SaveKeys.BUILDINGDATA:
+          if (isAttack) {
+            buildingDataHandler(saveData.buildingdata, baseSave);
+          } else {
+            baseSave[SaveKeys.BUILDINGDATA] = saveData.buildingdata;
+          }
 
         case SaveKeys.CHAMPION:
           if (isAttack) {

--- a/server/src/controllers/base/save/handlers/buildingDataHandler.ts
+++ b/server/src/controllers/base/save/handlers/buildingDataHandler.ts
@@ -1,0 +1,55 @@
+import { SaveKeys } from "../../../../enums/SaveKeys";
+import { permissionErr } from "../../../../errors/errors";
+import { Save } from "../../../../models/save.model";
+
+enum Building {
+  TRAP = 24,
+  HEAVY_TRAP = 117,
+}
+
+interface BuildingData {
+  x: number;        // x coordinate
+  y: number;        // y coordinate
+  t: number;        // type
+}
+
+/**
+ * Handles building data validation during base attack save operations.
+ *
+ * This handler ensures that essential buildings aren't removed from the base.
+ * It allows trap buildings (types 24 and 117) to be removed, as this is
+ * expected gameplay behavior, but prevents other building types from decreasing in count.
+ *
+ * @param {Record<string, any>} buildingData - The new building data submitted by the client
+ * @param {Save} save - The save object of the base to be validated
+ * @returns {Promise<void>} A promise that resolves when validation is are complete
+ * @throws {Error} Throws a permission error if validation fails
+ */
+export const buildingDataHandler = async (buildingData: Record<string, any>, save: Save) => {
+  const savedBuildingData = save.buildingdata || {};
+
+  let originalBuildingCount = 0;
+  let newBuildingCount = 0;
+
+  for (const key in savedBuildingData) {
+    const building: BuildingData = savedBuildingData[key];
+
+    if (building.t !== Building.TRAP && building.t !== Building.HEAVY_TRAP) {
+      originalBuildingCount++;
+    }
+  }
+
+  for (const key in buildingData) {
+    const building: BuildingData = buildingData[key];
+
+    if (building.t !== Building.TRAP && building.t !== Building.HEAVY_TRAP) {
+      newBuildingCount++;
+    }
+  }
+
+  if (newBuildingCount < originalBuildingCount) throw permissionErr();
+
+  // TODO: Implement a more robust validation for building data
+
+  save[SaveKeys.BUILDINGDATA] = buildingData;
+};

--- a/server/src/controllers/base/save/zod/BaseSaveSchema.ts
+++ b/server/src/controllers/base/save/zod/BaseSaveSchema.ts
@@ -54,6 +54,13 @@ export const BaseSaveSchema = z.object({
     .transform((data) => (data ? JSON.stringify(JSON.parse(data)) : undefined)),
 
   /**
+   * The building data, transformed from a JSON string to an object.
+   * This property is required.
+   * @type {object | undefined}
+   */
+  buildingdata: z.string().transform((data) => JSON.parse(data)),
+
+  /**
    * The building health data, transformed from a JSON string to an object.
    * This property is optional.
    * @type {object | undefined}

--- a/server/src/enums/SaveKeys.ts
+++ b/server/src/enums/SaveKeys.ts
@@ -7,6 +7,7 @@ export enum SaveKeys {
   RESOURCES = "resources",
   IRESOURCES = "iresources",
   BUILDING_RESOURCES = "buildingresources",
+  BUILDINGDATA = "buildingdata",
   PURCHASE = "purchase",
   ACADEMY = "academy",
   CHAMPION = "champion",

--- a/server/src/models/save.model.ts
+++ b/server/src/models/save.model.ts
@@ -517,6 +517,7 @@ export class Save {
     "protected",
     "champion",
     "over",
+    "buildingdata",
     "buildinghealthdata",
     "buildingresources",
     "attackreport",


### PR DESCRIPTION
## Fixed outposts resetting during attacks
This pull request improves how building data is handled throughout the game, particularly focusing on outposts and attack validation. These changes address issues with building construction timers resetting during outpost visits while also adding protection against potential exploits.

### Key Changes:
- Added Building Data Validation: Created a specialized handler that validates building data during save operations to prevent unauthorized removal of non-trap buildings


### Benefits:
- Players can now build structures in outposts without timers resetting between attacks
- Prevents potential exploits where players might attempt to remove buildings during attacks
- Maintains expected gameplay by allowing trap removal (types 24 and 117) while protecting other structures