### PR TITLE
Bugfix: Townhall Up/Downgrading, Saving Unplaced Buildings, Mushrooms Canceling Worker

### DIFF
--- a/client/scripts/BASE.as
+++ b/client/scripts/BASE.as
@@ -6359,7 +6359,7 @@ package
             {
                _loc1_ = 3;
             }
-            if(QUESTS._global.brlvl >= 8 || QUESTS._global.b6lvl >= 7 || QUESTS._global.b15lvl >= 3 || QUESTS._global.b23lvl >= 1 || QUESTS._global.b25lvl >= 1 || _loc21_ >= 3 || _loc23_ >= 2 || _loc11_ >= 2 || QUESTS._global.b19lvl > 0 || _loc3_ >= 5 || _loc2_ >= 5 || _loc13_ > 0 || _loc14_ > 0 || _loc16_ > 0 || _loc15_ > 0 || _loc20_ >= 3 || _loc19_ >= 4 || _loc17_ >= 4 || _loc13_ >= 0)
+            if(QUESTS._global.brlvl >= 8 || QUESTS._global.b6lvl >= 7 || QUESTS._global.b15lvl >= 3 || QUESTS._global.b23lvl >= 1 || QUESTS._global.b25lvl >= 1 || _loc21_ >= 3 || _loc23_ >= 2 || _loc11_ >= 2 || QUESTS._global.b19lvl > 0 || _loc3_ >= 5 || _loc2_ >= 5 || _loc13_ > 0 || _loc14_ > 0 || _loc16_ > 0 || _loc15_ > 0 || _loc20_ >= 3 || _loc19_ >= 4 || _loc17_ >= 4)
             {
                _loc1_ = 4;
             }
@@ -6406,7 +6406,7 @@ package
             {
                _loc1_ = 5;
             }
-            if(_loc29_ >= 6 || _loc23_ >= 4 || _loc18_ >= 7 || _loc30_ >= 7 || _loc31_ >= 6 || _loc32_ >= 4 || _loc27_ >= 10 || _loc2_ >= 6 || _loc4_ >= 6 || _loc5_ >= 4 || _loc6_ >= 3)
+            if(_loc29_ >= 6 || _loc23_ >= 4 || _loc18_ >= 7 || _loc30_ >= 7 || _loc31_ >= 6 || _loc32_ >= 6 || _loc27_ >= 10 || _loc2_ >= 6 || _loc4_ >= 6 || _loc6_ >= 3)
             {
                _loc1_ = 6;
             }

--- a/client/scripts/BASE.as
+++ b/client/scripts/BASE.as
@@ -5791,7 +5791,7 @@ package
          _loc4_ = 0;
          for each(_loc3_ in _loc2_)
          {
-            if(_loc3_._class != "decoration" && _loc3_._class != "enemy" && _loc3_._class != "immovable" && _loc3_._class != "trap" && (_loc1_ || _loc3_._countdownBuild.Get() <= 0))
+            if(_loc3_._class != "decoration" && _loc3_._class != "enemy" && _loc3_._class != "immovable" && _loc3_._class != "trap" && _loc3_ !== GLOBAL._newBuilding && (_loc1_ || _loc3_._countdownBuild.Get() <= 0))
             {
                _loc5_ = _loc3_._lvl.Get();
                if(_loc5_ <= 0)

--- a/client/scripts/BFOUNDATION.as
+++ b/client/scripts/BFOUNDATION.as
@@ -449,7 +449,7 @@ package
          s_totalBuildingHP = s_totalBuildingMaxHP = 0;
          for each(buildingData in building)
          {
-            if(!(buildingData is BMUSHROOM))
+            if(!(buildingData is BMUSHROOM) && !(GLOBAL._newBuilding === buildingData))
             {
                if(buildingData is ICoreBuilding)
                {
@@ -3066,7 +3066,10 @@ package
          {
             MAP.SortDepth();
          }
-         QUEUE.Remove("building" + this._id,false,this);
+         if(this._type != 7)
+         {
+            QUEUE.Remove("building" + this._id,false,this);
+         }
          BASE.BuildingDeselect();
          if(this._class == "decoration")
          {


### PR DESCRIPTION
Creating a pull request with the intent to resolve issue #135, along with a few other bugs I discovered that ended up being caused by similar issues. I have written down any relevant details regarding each change and the bugs' causes. Let me know if anything here seems wrong, needs clarification, or if you want anything done differently.

The following changes were made:

**BFOUNDATION.as:**  Added a check to `getBuildingSaveData` that excludes `GLOBAL._newBuilding` from being saved to a base's buildingData. This solves an issue where the Town Hall data was being overwritten, causing the game to replace it (Typically with a lower level one).

> Notes:
> - `GLOBAL._newBuilding` is a BFOUNDATION object that refers to the brand new building that the player is attempting to build from the "build" menu. It is cleared when the new building is placed or cancelled.
> - BFOUNDATION objects do not have an ID initialized upon creation, so its ID is treated as 0 until set manually. New buildings built by the player only have their ID set when they are first placed in the yard.
> - This means the building stored in `GLOBAL._newBuilding` will always have an ID of 0. Saving it to a base's buildingData will overwrite whatever building already had an ID of 0. In most cases, this means overwriting the Town Hall.
> - Even if `GLOBAL._newBuilding` always had a unique ID, it still should not be saved, as that would essentially place the building in the yard for free.

**BASE.as:** Added a check to `CalcBaseValue` that excludes `GLOBAL._newBuilding` from increasing a base's Empire Value

> Notes:
> - Empire Value is used to determine outpost takeover costs, and is also added to the player's XP total. Letting buildings affect those values before they are placed (and before resources are expended) does not seem like intended behavior and can potentially be exploited.

**BFOUNDATION.as:** Added a check to `RecycleC` as to not remove a worker from a non-mushroom building if the object being recycled is a mushroom. This solves an issue where workers would stop working on buildings after picking a mushroom, pausing the upgrade/build timer (Usually affecting Town Hall upgrades).

> Notes:
> - All non-mushroom buildings have an ID based on the total buildings in the yard, while a mushroom's building ID is only based on the amount of mushrooms in the yard.
> - The function `QUEUE.Remove` is responsible for removing a worker from a building and freeing them up.
> - The function is called once in MUSHROOMS.as when a mushroom is picked, using the parameter `"mushrooms" + _id`, which tells the code to remove the worker on the mushroom that has that ID. Afterward, It is called a second time in BFOUNDATION.as when the mushroom is recycled, this time using the parameter `"building" + _id`, which tells the code to remove the worker on the non-mushroom building that has that ID. So, when a mushroom is picked that has the same ID as a building that is building/upgrading, the worker on that building will act as if the build/upgrade was canceled and pause its timer.
> - A minor graphical bug still remains: when a matching id mushroom is picked, the "Building/Upgrading" overlay is briefly removed until the building's next Update function is called.
> - Ideally the way buildings are given IDs would be changed to prevent future collision issues.

**BASE.as** Removed erroneous checks in `CaluclateExpectedTownHallLevel` noted in my comments on issue #135. This solves an issue where the Town Hall can suddenly be upgraded when certain conditions are met.

> Notes:
> - This function, along with `RebuildTH`, is called every time a base is loaded to ensure a Town Hall exists and is not underleveled.
> - In the Overworld, the game detected a Town Hall level of at least 4 if there was a Wild Monster Baiter (`_loc13_`) with a level ">= 0", which is always true.
> - In the Inferno, the game detected an Under Hall level of 6 if there were four quake towers built (`_loc5_`) or a level 4+ magma tower (`_loc32_`) existed. Both can be done with a level 5 Under Hall.
> - Ideally this function and `RebuildTH` should no longer be needed, as there should be no situation where a Town Hall is removed or underleveled.