### PR TITLE
Auto Bank Resources Counting Towards Player Level

### DIFF
--- a/client/scripts/com/monsters/autobanking/AutoBankManager.as
+++ b/client/scripts/com/monsters/autobanking/AutoBankManager.as
@@ -334,7 +334,8 @@ package com.monsters.autobanking
                }
                _loc4_++;
             }
-            BASE.PointsAdd(Math.ceil(_loc5_.Get() * 0.375));
+            //Comented so autobank doesnt give you xp, main base resource production still gives you xp
+            //BASE.PointsAdd(Math.ceil(_loc5_.Get() * 0.375));
          }
          else if(MapRoomManager.instance.isInMapRoom3)
          {


### PR DESCRIPTION
### Summary

Removes XP gain from autobanking.

### Details

- This is a **one-line fix** addressing the issue listed in the issues tab.
- Seems like the behavior might have been intentional — it's oddly specific.

Are we certain this wasn’t how it worked in the original game?