### PR TITLE
Bugfix: Infernal Academy can Cause Game to Lock.

### DIFF
--- a/client/scripts/ACADEMYPOPUP.as
+++ b/client/scripts/ACADEMYPOPUP.as
@@ -37,8 +37,6 @@ package
       
       private const _infernoFrameOffset:int = 6;
       
-      private const _infernoMaxMonsters:int = 9;
-      
       private var _portraitImage:DisplayObject;
       
       private var _guidePage:int = 1;
@@ -50,8 +48,8 @@ package
          if(BASE.isInfernoMainYardOrOutpost)
          {
             _monsterString = "IC";
-            _maxMonsters = this._infernoMaxMonsters;
-            if(_page > this._infernoMaxMonsters)
+            _maxMonsters = CREATURELOCKER.NUM_ICREEP_TYPE;
+            if(_page > _maxMonsters)
             {
                _page = 1;
             }


### PR DESCRIPTION
There are only 8 total Inferno monsters that exist, but in ACADEMYPOPUP.as, the amount of inferno monsters is set to 9.

In the Inferno Academy screen, if you attempt to scroll past Spurtz (ID: “IC1”) or King Wormzor (ID: “IC8”) to the 9th slot, it will appear as though nothing happened and you must scroll again to go to the next monster. If you close and re-open the academy screen while on the 9th slot, this will cause the game to lock up due to an exception, as a monster with ID “IC9” does not exist.
This lock will also happen if you had Brain selected in the Overworld Academy, since Brain is in the 9th slot on the Overworld (ID: "C9") and the game remembers what slot you left you left the Academy screen on.

The following change was made to fix this issue:

**ACADEMYPOPUP.as:** When the monster academy popup opens in the Inferno, the `_maxMonsters` variable is now set to `CREATURELOCKER.NUM_ICREEP_TYPE` (which is 8), instead of its own internal constant `_infernoMaxMonsters` (which was 9).

> [!NOTE]  
> - You could also just make `_infernoMaxMonsters` equal 8 instead of 9 to make this a 1 line change. This solution just seemed cleaner in my opinion, as its the same way the value for the total Overworld monsters is gotten.
> - Since the change makes `_infernoMaxMonsters` entirely unused, I removed it.

> [!NOTE]  
> If you are wondering why the code adds 1 when getting to total number of Overworld monsters (since `CREATURELOCKER.NUM_CREEP_TYPE` is 18 and there are supposedly 18 total overworld monsters), there are indeed 19 Overworld monster types. Slimeattikus’s fissions also count as a monster type (and they have the ID “C18”). They are simply set to have their ID skipped when viewing the academy.
