### PR TITLE
Fix Visuals Errors On  HATCHERYCCPOPUP.as

### DIFF
--- a/client/scripts/HATCHERYCCPOPUP.as
+++ b/client/scripts/HATCHERYCCPOPUP.as
@@ -222,16 +222,17 @@ package
       _loc12_ -> damageShown, idk why damage text is render in a different way than the other stats
       _loc2_ -> removed since it does nothing
       _loc4_ -> creatures
-      _loc3_ -> removed since it was not needed, changed to param1
+      _loc3_ -> removed since it was not needed, changed to param1 (creatureID)
       _loc13_ -> level
-      
+      param1 -> creatureID
+
       added v2 var so inferno monsters show their cost in magma not goo
       */
-      public function MonsterInfoB(param1:String) : void
+      public function MonsterInfoB(creatureID:String) : void
       {
          var currentCreature:String = null;
          var damageShown:int = 0;
-         var creature:Object = CREATURELOCKER._creatures[param1];
+         var creature:Object = CREATURELOCKER._creatures[creatureID];
          var speed:Number = 0;
          var health:int = 0;
          var damage:int = 0;
@@ -265,14 +266,14 @@ package
                cStorage = CREATURES.GetProperty(currentCreature,"cStorage");
             }
          }
-         damageShown = CREATURES.GetProperty(param1,"damage");
+         damageShown = CREATURES.GetProperty(creatureID,"damage");
          TweenLite.to(mcMonsterInfo.bSpeed.mcBar,0.4,{
-            "width":100 / speed * CREATURES.GetProperty(param1,"speed"),
+            "width":100 / speed * CREATURES.GetProperty(creatureID,"speed"),
             "ease":Circ.easeInOut,
             "delay":0
          });
          TweenLite.to(mcMonsterInfo.bHealth.mcBar,0.4,{
-            "width":100 / health * CREATURES.GetProperty(param1,"health"),
+            "width":100 / health * CREATURES.GetProperty(creatureID,"health"),
             "ease":Circ.easeInOut,
             "delay":0.05
          });
@@ -282,22 +283,22 @@ package
             "delay":0.1
          });
          TweenLite.to(mcMonsterInfo.bResource.mcBar,0.4,{
-            "width":100 / cResource * CREATURES.GetProperty(param1,"cResource"),
+            "width":100 / cResource * CREATURES.GetProperty(creatureID,"cResource"),
             "ease":Circ.easeInOut,
             "delay":0.15
          });
          TweenLite.to(mcMonsterInfo.bStorage.mcBar,0.4,{
-            "width":100 / cStorage * CREATURES.GetProperty(param1,"cStorage"),
+            "width":100 / cStorage * CREATURES.GetProperty(creatureID,"cStorage"),
             "ease":Circ.easeInOut,
             "delay":0.2
          });
          TweenLite.to(mcMonsterInfo.bTime.mcBar,0.4,{
-            "width":100 / cTime * CREATURES.GetProperty(param1,"cTime"),
+            "width":100 / cTime * CREATURES.GetProperty(creatureID,"cTime"),
             "ease":Circ.easeInOut,
             "delay":0.25
          });
-         mcMonsterInfo.tSpeed.htmlText = KEYS.Get("mon_statsspeed",{"v1":CREATURES.GetProperty(param1,"speed")});
-         mcMonsterInfo.tHealth.htmlText = GLOBAL.FormatNumber(CREATURES.GetProperty(param1,"health"));
+         mcMonsterInfo.tSpeed.htmlText = KEYS.Get("mon_statsspeed",{"v1":CREATURES.GetProperty(creatureID,"speed")});
+         mcMonsterInfo.tHealth.htmlText = GLOBAL.FormatNumber(CREATURES.GetProperty(creatureID,"health"));
          if(damageShown > 0)
          {
             mcMonsterInfo.tDamage.htmlText = damageShown;
@@ -310,24 +311,24 @@ package
                ? KEYS.Get(BRESOURCE.GetResourceNameKey(7)) 
                : KEYS.Get(BRESOURCE.GetResourceNameKey(3));
          mcMonsterInfo.tResource.htmlText = KEYS.Get("mon_att_costvalue",{
-            "v1":GLOBAL.FormatNumber(CREATURES.GetProperty(param1,"cResource")),
+            "v1":GLOBAL.FormatNumber(CREATURES.GetProperty(creatureID,"cResource")),
             "v2":v2
          });
-         mcMonsterInfo.tStorage.htmlText = KEYS.Get("mon_att_housingvalue",{"v1":CREATURES.GetProperty(param1,"cStorage")});
-         mcMonsterInfo.tTime.htmlText = GLOBAL.ToTime(CREATURES.GetProperty(param1,"cTime"),true);
+         mcMonsterInfo.tStorage.htmlText = KEYS.Get("mon_att_housingvalue",{"v1":CREATURES.GetProperty(creatureID,"cStorage")});
+         mcMonsterInfo.tTime.htmlText = GLOBAL.ToTime(CREATURES.GetProperty(creatureID,"cTime"),true);
          var level:int = 1;
-         if(Boolean(GLOBAL.player.m_upgrades[param1]) && GLOBAL.player.m_upgrades[param1].level > 1)
+         if(Boolean(GLOBAL.player.m_upgrades[creatureID]) && GLOBAL.player.m_upgrades[creatureID].level > 1)
          {
-            level = int(GLOBAL.player.m_upgrades[param1].level);
+            level = int(GLOBAL.player.m_upgrades[creatureID].level);
          }
          mcMonsterInfo.tDescription.htmlText = "<b>" + KEYS.Get("hatcherypopup_level",{"v1":level}) + " " + KEYS.Get(creature.name) + "</b><br>" + KEYS.Get(creature.description);
-         if(Boolean(CREATURELOCKER._lockerData[param1]) && CREATURELOCKER._lockerData[param1].t == 2)
+         if(Boolean(CREATURELOCKER._lockerData[creatureID]) && CREATURELOCKER._lockerData[creatureID].t == 2)
          {
             mcMonsterInfo.mcLocked.visible = false;
          }
          else
          {
-            mcMonsterInfo.mcLocked.tText.htmlText = "<b>" + KEYS.Get("hat_unlockinlocker",{"v1":KEYS.Get(CREATURELOCKER._creatures[param1].name)}) + "</b>";
+            mcMonsterInfo.mcLocked.tText.htmlText = "<b>" + KEYS.Get("hat_unlockinlocker",{"v1":KEYS.Get(CREATURELOCKER._creatures[creatureID].name)}) + "</b>";
             mcMonsterInfo.mcLocked.visible = true;
          }
          this.MonsterInfoShow();

--- a/client/scripts/HATCHERYCCPOPUP.as
+++ b/client/scripts/HATCHERYCCPOPUP.as
@@ -210,111 +210,124 @@ package
             MonsterInfoB(n);
          };
       }
+
+      /* 
+      _loc5_ -> speed, also change to a Number since max speed its not an int
+      _loc6_ -> health
+      _loc7_ -> damage
+      _loc8_ -> cTime
+      _loc9_ -> cResource
+      _loc10_ -> cStorage
+      _loc11_ -> currentCreature
+      _loc12_ -> damageShown, idk why damage text is render in a different way than the other stats
+      _loc2_ -> removed since it does nothing
+      _loc4_ -> creatures
+      _loc3_ -> removed since it was not needed, changed to param1
+      _loc13_ -> level
       
+      added v2 var so inferno monsters show their cost in magma not goo
+      */
       public function MonsterInfoB(param1:String) : void
       {
-         var _loc11_:String = null;
-         var _loc12_:int = 0;
-         var _loc2_:int = 1;
-         while(_loc2_ <= 13)
+         var currentCreature:String = null;
+         var damageShown:int = 0;
+         var creature:Object = CREATURELOCKER._creatures[param1];
+         var speed:Number = 0;
+         var health:int = 0;
+         var damage:int = 0;
+         var cTime:int = 0;
+         var cResource:int = 0;
+         var cStorage:int = 0;
+         for(currentCreature in CREATURELOCKER._creatures)
          {
-            _loc2_++;
-         }
-         var _loc3_:String = param1;
-         var _loc4_:Object = CREATURELOCKER._creatures[_loc3_];
-         var _loc5_:int = 0;
-         var _loc6_:int = 0;
-         var _loc7_:int = 0;
-         var _loc8_:int = 0;
-         var _loc9_:int = 0;
-         var _loc10_:int = 0;
-         for(_loc11_ in CREATURELOCKER._creatures)
-         {
-            if(CREATURES.GetProperty(_loc11_,"speed") > _loc5_)
+            if(CREATURES.GetProperty(currentCreature,"speed") > speed)
             {
-               _loc5_ = CREATURES.GetProperty(_loc11_,"speed");
+               speed = CREATURES.GetProperty(currentCreature,"speed");
             }
-            if(CREATURES.GetProperty(_loc11_,"health") > _loc6_)
+            if(CREATURES.GetProperty(currentCreature,"health") > health)
             {
-               _loc6_ = CREATURES.GetProperty(_loc11_,"health");
+               health = CREATURES.GetProperty(currentCreature,"health");
             }
-            if(CREATURES.GetProperty(_loc11_,"damage") > _loc7_)
+            if(CREATURES.GetProperty(currentCreature,"damage") > damage)
             {
-               _loc7_ = CREATURES.GetProperty(_loc11_,"damage");
+               damage = CREATURES.GetProperty(currentCreature,"damage");
             }
-            if(CREATURES.GetProperty(_loc11_,"cTime") > _loc8_)
+            if(CREATURES.GetProperty(currentCreature,"cTime") > cTime)
             {
-               _loc8_ = CREATURES.GetProperty(_loc11_,"cTime");
+               cTime = CREATURES.GetProperty(currentCreature,"cTime");
             }
-            if(CREATURES.GetProperty(_loc11_,"cResource") > _loc9_)
+            if(CREATURES.GetProperty(currentCreature,"cResource") > cResource)
             {
-               _loc9_ = CREATURES.GetProperty(_loc11_,"cResource");
+               cResource = CREATURES.GetProperty(currentCreature,"cResource");
             }
-            if(CREATURES.GetProperty(_loc11_,"cStorage") > _loc10_)
+            if(CREATURES.GetProperty(currentCreature,"cStorage") > cStorage)
             {
-               _loc10_ = CREATURES.GetProperty(_loc11_,"cStorage");
+               cStorage = CREATURES.GetProperty(currentCreature,"cStorage");
             }
          }
-         _loc12_ = CREATURES.GetProperty(_loc3_,"damage");
+         damageShown = CREATURES.GetProperty(param1,"damage");
          TweenLite.to(mcMonsterInfo.bSpeed.mcBar,0.4,{
-            "width":100 / _loc5_ * CREATURES.GetProperty(_loc3_,"speed"),
+            "width":100 / speed * CREATURES.GetProperty(param1,"speed"),
             "ease":Circ.easeInOut,
             "delay":0
          });
          TweenLite.to(mcMonsterInfo.bHealth.mcBar,0.4,{
-            "width":100 / _loc6_ * CREATURES.GetProperty(_loc3_,"health"),
+            "width":100 / health * CREATURES.GetProperty(param1,"health"),
             "ease":Circ.easeInOut,
             "delay":0.05
          });
          TweenLite.to(mcMonsterInfo.bDamage.mcBar,0.4,{
-            "width":100 / _loc7_ * Math.abs(_loc12_),
+            "width":100 / damage * Math.abs(damageShown),
             "ease":Circ.easeInOut,
             "delay":0.1
          });
          TweenLite.to(mcMonsterInfo.bResource.mcBar,0.4,{
-            "width":100 / _loc9_ * CREATURES.GetProperty(_loc3_,"cResource"),
+            "width":100 / cResource * CREATURES.GetProperty(param1,"cResource"),
             "ease":Circ.easeInOut,
             "delay":0.15
          });
          TweenLite.to(mcMonsterInfo.bStorage.mcBar,0.4,{
-            "width":100 / _loc10_ * CREATURES.GetProperty(_loc3_,"cStorage"),
+            "width":100 / cStorage * CREATURES.GetProperty(param1,"cStorage"),
             "ease":Circ.easeInOut,
             "delay":0.2
          });
          TweenLite.to(mcMonsterInfo.bTime.mcBar,0.4,{
-            "width":100 / _loc8_ * CREATURES.GetProperty(_loc3_,"cTime"),
+            "width":100 / cTime * CREATURES.GetProperty(param1,"cTime"),
             "ease":Circ.easeInOut,
             "delay":0.25
          });
-         mcMonsterInfo.tSpeed.htmlText = KEYS.Get("mon_statsspeed",{"v1":CREATURES.GetProperty(_loc3_,"speed")});
-         mcMonsterInfo.tHealth.htmlText = GLOBAL.FormatNumber(CREATURES.GetProperty(_loc3_,"health"));
-         if(_loc12_ > 0)
+         mcMonsterInfo.tSpeed.htmlText = KEYS.Get("mon_statsspeed",{"v1":CREATURES.GetProperty(param1,"speed")});
+         mcMonsterInfo.tHealth.htmlText = GLOBAL.FormatNumber(CREATURES.GetProperty(param1,"health"));
+         if(damageShown > 0)
          {
-            mcMonsterInfo.tDamage.htmlText = _loc12_;
+            mcMonsterInfo.tDamage.htmlText = damageShown;
          }
          else
          {
-            mcMonsterInfo.tDamage.htmlText = -_loc12_ + " (" + KEYS.Get("str_heal") + ")";
+            mcMonsterInfo.tDamage.htmlText = -damageShown + " (" + KEYS.Get("str_heal") + ")";
          }
+         var v2:String = (creature.id.charAt(0) == "I") 
+               ? KEYS.Get(BRESOURCE.GetResourceNameKey(7)) 
+               : KEYS.Get(BRESOURCE.GetResourceNameKey(3));
          mcMonsterInfo.tResource.htmlText = KEYS.Get("mon_att_costvalue",{
-            "v1":GLOBAL.FormatNumber(CREATURES.GetProperty(_loc3_,"cResource")),
-            "v2":KEYS.Get(BRESOURCE.GetResourceNameKey(3))
+            "v1":GLOBAL.FormatNumber(CREATURES.GetProperty(param1,"cResource")),
+            "v2":v2
          });
-         mcMonsterInfo.tStorage.htmlText = KEYS.Get("mon_att_housingvalue",{"v1":CREATURES.GetProperty(_loc3_,"cStorage")});
-         mcMonsterInfo.tTime.htmlText = GLOBAL.ToTime(CREATURES.GetProperty(_loc3_,"cTime"),true);
-         var _loc13_:int = 1;
-         if(Boolean(GLOBAL.player.m_upgrades[_loc3_]) && GLOBAL.player.m_upgrades[_loc3_].level > 1)
+         mcMonsterInfo.tStorage.htmlText = KEYS.Get("mon_att_housingvalue",{"v1":CREATURES.GetProperty(param1,"cStorage")});
+         mcMonsterInfo.tTime.htmlText = GLOBAL.ToTime(CREATURES.GetProperty(param1,"cTime"),true);
+         var level:int = 1;
+         if(Boolean(GLOBAL.player.m_upgrades[param1]) && GLOBAL.player.m_upgrades[param1].level > 1)
          {
-            _loc13_ = int(GLOBAL.player.m_upgrades[_loc3_].level);
+            level = int(GLOBAL.player.m_upgrades[param1].level);
          }
-         mcMonsterInfo.tDescription.htmlText = "<b>" + KEYS.Get("hatcherypopup_level",{"v1":_loc13_}) + " " + KEYS.Get(_loc4_.name) + "</b><br>" + KEYS.Get(_loc4_.description);
-         if(Boolean(CREATURELOCKER._lockerData[_loc3_]) && CREATURELOCKER._lockerData[_loc3_].t == 2)
+         mcMonsterInfo.tDescription.htmlText = "<b>" + KEYS.Get("hatcherypopup_level",{"v1":level}) + " " + KEYS.Get(creature.name) + "</b><br>" + KEYS.Get(creature.description);
+         if(Boolean(CREATURELOCKER._lockerData[param1]) && CREATURELOCKER._lockerData[param1].t == 2)
          {
             mcMonsterInfo.mcLocked.visible = false;
          }
          else
          {
-            mcMonsterInfo.mcLocked.tText.htmlText = "<b>" + KEYS.Get("hat_unlockinlocker",{"v1":KEYS.Get(CREATURELOCKER._creatures[_loc3_].name)}) + "</b>";
+            mcMonsterInfo.mcLocked.tText.htmlText = "<b>" + KEYS.Get("hat_unlockinlocker",{"v1":KEYS.Get(CREATURELOCKER._creatures[param1].name)}) + "</b>";
             mcMonsterInfo.mcLocked.visible = true;
          }
          this.MonsterInfoShow();

--- a/client/scripts/HATCHERYCCPOPUP.as
+++ b/client/scripts/HATCHERYCCPOPUP.as
@@ -212,21 +212,15 @@ package
       }
 
       /* 
-      _loc5_ -> speed, also change to a Number since max speed its not an int
-      _loc6_ -> health
-      _loc7_ -> damage
-      _loc8_ -> cTime
-      _loc9_ -> cResource
-      _loc10_ -> cStorage
-      _loc11_ -> currentCreature
-      _loc12_ -> damageShown, idk why damage text is render in a different way than the other stats
-      _loc2_ -> removed since it does nothing
-      _loc4_ -> creatures
-      _loc3_ -> removed since it was not needed, changed to param1 (creatureID)
-      _loc13_ -> level
-      param1 -> creatureID
-
-      added v2 var so inferno monsters show their cost in magma not goo
+       * This function has been rewritten.
+       * 
+       * @autor: matiasbais
+       * 
+       * @changes: Renamed local registers to readable names and removed unused logic
+       * Added 'v2' variables to display magma/goo depending on monster type
+       * Updated speed variable to a Number type to be able to handle floting point values
+       * 
+       * @param {String} creatureID - the current creature's ID passed to MonsterInfoB
       */
       public function MonsterInfoB(creatureID:String) : void
       {

--- a/client/scripts/HATCHERYPOPUP.as
+++ b/client/scripts/HATCHERYPOPUP.as
@@ -131,108 +131,118 @@ package
             MonsterInfoB(n);
          };
       }
+
+      /* 
+       * This function has been rewritten.
+       * 
+       * @autor: matiasbais
+       * 
+       * @changes: Renamed local registers to readable names and removed unused logic
+       * 
+       * @param {String} creatureID - the current creature's ID passed to MonsterInfoB
+      */
       
-      public function MonsterInfoB(param1:int) : void
+      public function MonsterInfoB(creatureID:int) : void
       {
-         var _loc10_:String = null;
-         var _loc11_:int = 0;
-         var _loc2_:String = BASE.isInfernoMainYardOrOutpost ? "IC" + param1 : "C" + param1;
-         var _loc3_:Object = CREATURELOCKER._creatures[_loc2_];
-         ImageCache.GetImageWithCallBack("monsters/" + _loc2_ + "-portrait.jpg",this.IconLoaded,true,1,"",[this.portrait1]);
-         var _loc4_:Number = 0;
-         var _loc5_:int = 0;
-         var _loc6_:int = 0;
-         var _loc7_:int = 0;
-         var _loc8_:int = 0;
-         var _loc9_:int = 0;
-         for(_loc10_ in CREATURELOCKER._creatures)
+         var currentCreature:String = null;
+         var damageShown:int = 0;
+         var creatureStringID:String = BASE.isInfernoMainYardOrOutpost ? "IC" + creatureID : "C" + creatureID;
+         var creature:Object = CREATURELOCKER._creatures[creatureStringID];
+         ImageCache.GetImageWithCallBack("monsters/" + creatureStringID + "-portrait.jpg",this.IconLoaded,true,1,"",[this.portrait1]);
+         var speed:Number = 0;
+         var health:int = 0;
+         var damage:int = 0;
+         var cTime:int = 0;
+         var cResource:int = 0;
+         var cStorage:int = 0;
+         for(currentCreature in CREATURELOCKER._creatures)
          {
-            if(CREATURES.GetProperty(_loc10_,"speed") > _loc4_)
+            if(CREATURES.GetProperty(currentCreature,"speed") > speed)
             {
-               _loc4_ = CREATURES.GetProperty(_loc10_,"speed");
+               speed = CREATURES.GetProperty(currentCreature,"speed");
             }
-            if(CREATURES.GetProperty(_loc10_,"health") > _loc5_)
+            if(CREATURES.GetProperty(currentCreature,"health") > health)
             {
-               _loc5_ = CREATURES.GetProperty(_loc10_,"health");
+               health = CREATURES.GetProperty(currentCreature,"health");
             }
-            if(CREATURES.GetProperty(_loc10_,"damage") > _loc6_)
+            if(CREATURES.GetProperty(currentCreature,"damage") > damage)
             {
-               _loc6_ = CREATURES.GetProperty(_loc10_,"damage");
+               damage = CREATURES.GetProperty(currentCreature,"damage");
             }
-            if(CREATURES.GetProperty(_loc10_,"cTime") > _loc7_)
+            if(CREATURES.GetProperty(currentCreature,"cTime") > cTime)
             {
-               _loc7_ = CREATURES.GetProperty(_loc10_,"cTime");
+               cTime = CREATURES.GetProperty(currentCreature,"cTime");
             }
-            if(CREATURES.GetProperty(_loc10_,"cResource") > _loc8_)
+            if(CREATURES.GetProperty(currentCreature,"cResource") > cResource)
             {
-               _loc8_ = CREATURES.GetProperty(_loc10_,"cResource");
+               cResource = CREATURES.GetProperty(currentCreature,"cResource");
             }
-            if(CREATURES.GetProperty(_loc10_,"cStorage") > _loc9_)
+            if(CREATURES.GetProperty(currentCreature,"cStorage") > cStorage)
             {
-               _loc9_ = CREATURES.GetProperty(_loc10_,"cStorage");
+               cStorage = CREATURES.GetProperty(currentCreature,"cStorage");
             }
          }
-         _loc11_ = CREATURES.GetProperty(_loc2_,"damage");
+         damageShown = CREATURES.GetProperty(creatureStringID,"damage");
          TweenLite.to(mcMonsterInfo.bSpeed.mcBar,0.4,{
-            "width":100 / _loc4_ * CREATURES.GetProperty(_loc2_,"speed"),
+            "width":100 / speed * CREATURES.GetProperty(creatureStringID,"speed"),
             "ease":Circ.easeInOut,
             "delay":0
          });
          TweenLite.to(mcMonsterInfo.bHealth.mcBar,0.4,{
-            "width":100 / _loc5_ * CREATURES.GetProperty(_loc2_,"health"),
+            "width":100 / health * CREATURES.GetProperty(creatureStringID,"health"),
             "ease":Circ.easeInOut,
             "delay":0.05
          });
          TweenLite.to(mcMonsterInfo.bDamage.mcBar,0.4,{
-            "width":100 / _loc6_ * Math.abs(_loc11_),
+            "width":100 / damage * Math.abs(damageShown),
             "ease":Circ.easeInOut,
             "delay":0.1
          });
          TweenLite.to(mcMonsterInfo.bTime.mcBar,0.4,{
-            "width":100 / _loc7_ * CREATURES.GetProperty(_loc2_,"cTime"),
+            "width":100 / cTime * CREATURES.GetProperty(creatureStringID,"cTime"),
             "ease":Circ.easeInOut,
             "delay":0.15
          });
          TweenLite.to(mcMonsterInfo.bResource.mcBar,0.4,{
-            "width":100 / _loc8_ * CREATURES.GetProperty(_loc2_,"cResource"),
+            "width":100 / cResource * CREATURES.GetProperty(creatureStringID,"cResource"),
             "ease":Circ.easeInOut,
             "delay":0.2
          });
          TweenLite.to(mcMonsterInfo.bStorage.mcBar,0.4,{
-            "width":100 / _loc9_ * CREATURES.GetProperty(_loc2_,"cStorage"),
+            "width":100 / cStorage * CREATURES.GetProperty(creatureStringID,"cStorage"),
             "ease":Circ.easeInOut,
             "delay":0.25
          });
-         mcMonsterInfo.tSpeed.htmlText = KEYS.Get("mon_statsspeed",{"v1":CREATURES.GetProperty(_loc2_,"speed")});
-         mcMonsterInfo.tHealth.htmlText = GLOBAL.FormatNumber(CREATURES.GetProperty(_loc2_,"health"));
-         if(_loc11_ > 0)
+         mcMonsterInfo.tSpeed.htmlText = KEYS.Get("mon_statsspeed",{"v1":CREATURES.GetProperty(creatureStringID,"speed")});
+         mcMonsterInfo.tHealth.htmlText = GLOBAL.FormatNumber(CREATURES.GetProperty(creatureStringID,"health"));
+         if(damageShown > 0)
          {
-            mcMonsterInfo.tDamage.htmlText = _loc11_;
+            mcMonsterInfo.tDamage.htmlText = damageShown;
          }
          else
          {
-            mcMonsterInfo.tDamage.htmlText = -_loc11_ + " (" + KEYS.Get("str_heal") + ")";
+            mcMonsterInfo.tDamage.htmlText = -damageShown + " (" + KEYS.Get("str_heal") + ")";
          }
          mcMonsterInfo.tResource.htmlText = KEYS.Get("mon_att_costvalue",{
-            "v1":GLOBAL.FormatNumber(CREATURES.GetProperty(_loc2_,"cResource")),
+            "v1":GLOBAL.FormatNumber(CREATURES.GetProperty(creatureStringID,"cResource")),
             "v2":KEYS.Get(BRESOURCE.GetResourceNameKey(3))
          });
-         mcMonsterInfo.tStorage.htmlText = KEYS.Get("mon_att_housingvalue",{"v1":CREATURES.GetProperty(_loc2_,"cStorage")});
-         mcMonsterInfo.tTime.htmlText = GLOBAL.ToTime(CREATURES.GetProperty(_loc2_,"cTime"),true);
-         var _loc12_:int = 1;
-         if(Boolean(GLOBAL.player.m_upgrades[_loc2_]) && GLOBAL.player.m_upgrades[_loc2_].level > 1)
+         mcMonsterInfo.tStorage.htmlText = KEYS.Get("mon_att_housingvalue",{"v1":CREATURES.GetProperty(creatureStringID,"cStorage")});
+         mcMonsterInfo.tTime.htmlText = GLOBAL.ToTime(CREATURES.GetProperty(creatureStringID,"cTime"),true);
+         var level:int = 1;
+         if(Boolean(GLOBAL.player.m_upgrades[creatureStringID]) && GLOBAL.player.m_upgrades[creatureStringID].level > 1)
          {
-            _loc12_ = int(GLOBAL.player.m_upgrades[_loc2_].level);
+            level = int(GLOBAL.player.m_upgrades[creatureStringID].level);
          }
-         mcMonsterInfo.tDescription.htmlText = "<b>" + KEYS.Get("hatcherypopup_level",{"v1":_loc12_}) + " " + KEYS.Get(_loc3_.name) + "</b><br>" + KEYS.Get(_loc3_.description);
-         if(Boolean(CREATURELOCKER._lockerData[_loc2_]) && CREATURELOCKER._lockerData[_loc2_].t == 2)
+         mcMonsterInfo.tDescription.htmlText = "<b>" + KEYS.Get("hatcherypopup_level",{"v1":level}) + " " + KEYS.Get(creature.name) + "</b><br>" + KEYS.Get(creature_.description);
+         if(Boolean(CREATURELOCKER._lockerData[creatureStringID]) && CREATURELOCKER._lockerData[creatureStringID].t == 2)
          {
             mcMonsterInfo.mcLocked.visible = false;
          }
          else
          {
             mcMonsterInfo.mcLocked.tText.htmlText = KEYS.Get(BASE.isInfernoMainYardOrOutpost ? "incubator_unlockinlocker" : "hat_unlockinlocker",{
-               "v1":KEYS.Get(CREATURELOCKER._creatures[_loc2_].name),
+               "v1":KEYS.Get(CREATURELOCKER._creatures[creatureStringID].name),
                "v2":KEYS.Get(GLOBAL._bHatchery._buildingProps.name)
             });
             mcMonsterInfo.mcLocked.visible = true;

--- a/client/scripts/HATCHERYPOPUP.as
+++ b/client/scripts/HATCHERYPOPUP.as
@@ -234,7 +234,7 @@ package
          {
             level = int(GLOBAL.player.m_upgrades[creatureStringID].level);
          }
-         mcMonsterInfo.tDescription.htmlText = "<b>" + KEYS.Get("hatcherypopup_level",{"v1":level}) + " " + KEYS.Get(creature.name) + "</b><br>" + KEYS.Get(creature_.description);
+         mcMonsterInfo.tDescription.htmlText = "<b>" + KEYS.Get("hatcherypopup_level",{"v1":level}) + " " + KEYS.Get(creature.name) + "</b><br>" + KEYS.Get(creature.description);
          if(Boolean(CREATURELOCKER._lockerData[creatureStringID]) && CREATURELOCKER._lockerData[creatureStringID].t == 2)
          {
             mcMonsterInfo.mcLocked.visible = false;


### PR DESCRIPTION
## 🐛 Issues Addressed

- Stats bar width was incorrectly displayed for Balthazars.
- Inferno monsters incorrectly showed their cost in Goo.

---

## 🔧 Changes Made

- Unobfuscated all variables and removed unnecessary ones in `MonsterInfoB` for better readability.
- Changed the `speed` variable from `Integer` to `Number` (max speed can be `4.5 km/h`, using `Integer` caused the value to truncate to `4` which led to the display issue).
- Added conditional logic to display `Magma` or `Goo` depending on the monster's type.

---

## 💡 Fun Fact

If you don't have an `HCC`, this error wasn't present because `HATCHERYPOPUP` already uses `Number` for the `speed` variable.


## Issues Remaining

- For inferno monsters it says Goo Cost XXX Magma Cost since that part is render in a different function.
