### PR TITLE
Fix sabnox not doubleing damage to favorite building targets

### DIFF
--- a/client/scripts/com/monsters/monsters/creeps/inferno/Sabnox.as
+++ b/client/scripts/com/monsters/monsters/creeps/inferno/Sabnox.as
@@ -7,8 +7,6 @@ package com.monsters.monsters.creeps.inferno
    
    public class Sabnox extends CreepBase
    {
-       
-      
       public function Sabnox(param1:String, param2:String, param3:Point, param4:Number, param5:int = 0, param6:int = 2147483647, param7:Point = null, param8:Boolean = false, param9:BFOUNDATION = null, param10:Number = 1, param11:Boolean = false, param12:MonsterBase = null)
       {
          super(param1,param2,param3,param4,param5,param6,param7,param8,param9,param10,param11,param12);
@@ -18,6 +16,10 @@ package com.monsters.monsters.creeps.inferno
       {
          if(param1 is BFOUNDATION)
          {
+            if(_targetBuilding._class == "tower")
+            {
+               return FIREBALLS.Spawn(_tmpPoint,_targetBuilding._position,_targetBuilding,10,damage * 2,0,0,FIREBALLS.TYPE_MAGMA,this);
+            }
             return FIREBALLS.Spawn(_tmpPoint,_targetBuilding._position,_targetBuilding,10,damage,0,0,FIREBALLS.TYPE_MAGMA,this);
          }
          return FIREBALLS.Spawn2(_tmpPoint,_targetCreep._tmpPoint,_targetCreep,10,damage,0,FIREBALLS.TYPE_MAGMA,1,this);


### PR DESCRIPTION
Since Sabnox has a special type of ranged attack and doesn't function like all the rest of the melee monsters, the attack procedure happens a bit differently. 

As it goes over the FIREBALLS.as class and spawns an entity as a projectile that does the attack. This entity has no check for types of buildings just if it's a building or a monster. 
In order to keep the logic checks to a minimum I have placed the check in Sabnox.as. Since this is the only ground monster that has projectile attacks that do more damage to specific buildings, it seems fitting that it only checks for building type before spawning the projectile per Sabnox attack instead of each time a projectile is called.

*A note - People and the wiki seem to mention that it used to attack towers faster but I was unsure of this so I left the speed as is.