### PR TITLE
Fix oversight where worker messes up upgrading anything that does not have a fortify property set

### DIFF
--- a/client/scripts/BFOUNDATION.as
+++ b/client/scripts/BFOUNDATION.as
@@ -2375,7 +2375,7 @@ package
             while(_loc2_ < 5)
             {
                _loc3_ = !!this._buildingProps.costs[this._lvl.Get()] ? uint(this._buildingProps.costs[this._lvl.Get()]["r" + _loc2_].Get()) : 0;
-               if (!_loc3_)
+               if (!_loc3_ && this._buildingProps.fortify_costs)
                {
                   _loc3_ = !!this._buildingProps.fortify_costs[this._fortification.Get()] ? uint(this._buildingProps.fortify_costs[this._fortification.Get()]["r" + _loc2_].Get()) : 0;
                }


### PR DESCRIPTION
Fixes a clear oversight on my end. As I didn't properly analyze the condition comparison on line 2377. It was obviously not foolproof. 

This simple addition should fix any and all current and/or future issues we may have with the builders regarding how resources get selected and delegated to the animation function.