### PR TITLE
Bugfix: Infinite DAVE Statues, Decorations Pausing Workers

### DIFF
--- a/client/scripts/BDECORATION.as
+++ b/client/scripts/BDECORATION.as
@@ -35,7 +35,6 @@ package
       override public function Place(param1:MouseEvent = null) : void
       {
          super.Place(param1);
-         Constructed();
       }
       
       override public function TickFast(param1:Event = null) : void

--- a/client/scripts/INFERNOYARDPROPS.as
+++ b/client/scripts/INFERNOYARDPROPS.as
@@ -6826,6 +6826,7 @@ package
          "block":true,
          "locked":true,
          "lockedButtonOverlay":"buildingbuttons/135locked.png",
+         "cls":BDECORATION,
          "costs":[{
             "r1":new SecNum(0),
             "r2":new SecNum(0),

--- a/client/scripts/OUTPOST_YARD_PROPS.as
+++ b/client/scripts/OUTPOST_YARD_PROPS.as
@@ -6335,6 +6335,7 @@ package
          "block":true,
          "locked":true,
          "lockedButtonOverlay":"buildingbuttons/135locked.png",
+         "cls":BDECORATION,
          "costs":[{
             "r1":new SecNum(0),
             "r2":new SecNum(0),

--- a/client/scripts/YARD_PROPS.as
+++ b/client/scripts/YARD_PROPS.as
@@ -7539,6 +7539,7 @@ package
          "description":"bdg_dave_trophy_desc",
          "block":true,
          "locked":true,
+         "cls":BDECORATION,
          "lockedButtonOverlay":"buildingbuttons/135locked.png",
          "costs":[{
             "r1":new SecNum(0),


### PR DESCRIPTION
This pull request is intended to resolve two issues regarding Decoration buildings.
1. Clicking and dragging the mouse while building a Decoration object can pause upgrades (typically Town Hall upgrades) due to an ID collision.
2. Players can gain an unlimited amount of golden DAVE statues by reloading their base, which does not appear to be intended behavior.

## Changes:
### Upgrade Pausing Fix:
**BDECORATION.as:** Removed an erroneous `Constructed` function call from BDECORATION's `Place` function.

**Context:**
- BDECORATION objects extend the BFOUNDATION object.
	- The `_id` of BFOUNDATION objects is only properly set once the building is fully placed in the yard.
	- There is nothing specifically within BDECORATION that sets the building's `_id`.
- The `Constructed` function calls `QUEUE.Remove`, which removes the worker that was working on the building with given `_id`. 
 	- This function is meant to be called after a building is finished being constructed.
- The `Place` function gets called every time the player clicks, even when clicking and dragging the map.
	- The `Place` function in BFOUNDATION first verifies that the player isn't dragging the map. If the map **is** being dragged, It won't call the `Constructed` function, nor set the building's `_id`.
	- The overiding `Place` function in BDECORATION does _not_ have this check before it makes its own _extra_ `Constructed` call

> [!NOTE]
> This issue is similar to what I had described in a previous pull request, where the cause of an issue was an id collision due do buildings not getting their id set before they are fully placed. (#143)

### Unlimited DAVE Statue Fix:
**YARD_PROPS.as, OUTPOST_YARD_PROPS.as, and INFERNOYARDPROPS.as:** Added `"cls"` value to the DAVE statue prop. Value set to `BDECORATION`.

**Context:**
- `GLOBAL._buildingProps` is an array that holds every building type stored in the appropriate yard props script
	-  **YARD_PROPS.as** for the overworld main yard.
	- **INFERNOYARDPROPS.as** for the inferno yard.
	- **OUTPOST_YARD_PROPS.as** for outposts.
- In **DAVEStatueReward.as**, it uses `GLOBAL._buildingProps` to get the `"cls"` value for the dave statue prop. This is to get which class of buildings it needs to search through in order to find any currently existing DAVE statues placed in the yard.
	- Currently, the `"cls"` value for the DAVE statue prop isn't set, so it will never find any already existing statues in the yard.
	- Since it can't find any statues, it automatically places one in the player's inventory, assuming there was none in their inventory already.
	- The player's inventory is stored under `researchdata` in the database.

> [!NOTE]  
> - This change will _not_ retroactively remove any extra DAVE statues in player yards or inventories.

> An alternative, potentially cleaner solution to fix this issue would be to modify **DAVEStatueReward.as**, replacing any instance of:
>  `InstanceManager.getInstancesByClass(GLOBAL._buildingProps[DAVE_STATUE_BUILDING_PROPS_INDEX].cls)`
> with:
>  `InstanceManager.getInstancesByClass(BDECORATION)`
> Which will bypass the need to set the prop's `"cls"` value entirely.