### PR TITLE
Fixed 'fullscreen' mode on Map Room 2 

### DIFF
--- a/client/scripts/GLOBAL.as
+++ b/client/scripts/GLOBAL.as
@@ -45,7 +45,7 @@ package
 
       public static var cdnUrl:String = "http://localhost:3001/";
 
-      public static var apiVersionSuffix:String = "v1.2.6-beta/";
+      public static var apiVersionSuffix:String = "v1.2.7-beta/";
 
       public static var connectionCounter:int;
 
@@ -997,7 +997,8 @@ package
 
       public static function get isFullScreen():Boolean
       {
-         return _ROOT.stage.displayState === StageDisplayState.FULL_SCREEN;
+         return _ROOT.stage.displayState === StageDisplayState.FULL_SCREEN ||
+            _ROOT.stage.displayState === StageDisplayState.FULL_SCREEN_INTERACTIVE;
       }
 
       public static function goFullScreen(param1:MouseEvent = null):void

--- a/client/scripts/com/monsters/maproom_advanced/MapRoomPopup.as
+++ b/client/scripts/com/monsters/maproom_advanced/MapRoomPopup.as
@@ -94,7 +94,7 @@ package com.monsters.maproom_advanced
             h = 768;
          }
          r = new Rectangle(0 - (w - 760) / 2,0 - (h - 720) / 2,w,h);
-         if(GLOBAL._ROOT.stage.displayState == StageDisplayState.FULL_SCREEN)
+         if(GLOBAL.isFullScreen)
          {
             this._fullScreen = true;
             mcFrame.x = r.x + 175;
@@ -732,7 +732,7 @@ package com.monsters.maproom_advanced
          this._cells = [];
          this._cellContainer = new MovieClip();
          this._sortArray = [];
-         if(GLOBAL._ROOT.stage.displayState == StageDisplayState.FULL_SCREEN)
+         if(GLOBAL.isFullScreen)
          {
             this._cellCountX = 18;
             this._cellCountY = 15;
@@ -763,7 +763,7 @@ package com.monsters.maproom_advanced
                mapRoomCell.depth = mapRoomCell.y * 1000 + mapRoomCell.x;
                this._sortArray.push(mapRoomCell);
                this._cellContainer.addChild(mapRoomCell);
-               if(GLOBAL._ROOT.stage.displayState == StageDisplayState.FULL_SCREEN)
+               if(GLOBAL.isFullScreen)
                {
                   mapRoomCell.Y += param1.y - 8;
                   if(param1.x % 2)
@@ -1635,7 +1635,7 @@ package com.monsters.maproom_advanced
       
       public function FullScreen() : void
       {
-         if(GLOBAL._ROOT.stage.displayState == StageDisplayState.FULL_SCREEN)
+         if(GLOBAL.isFullScreen)
          {
             this._fullScreen = true;
          }
@@ -1649,7 +1649,7 @@ package com.monsters.maproom_advanced
       public function Resize() : void
       {
          var _loc1_:Boolean = false;
-         if(GLOBAL._ROOT.stage.displayState == StageDisplayState.FULL_SCREEN)
+         if(GLOBAL.isFullScreen)
          {
             if(this._fullScreen != true)
             {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -25,7 +25,7 @@ app.proxy = true;
 export const PORT = process.env.PORT || 3001;
 export const BASE_URL = process.env.BASE_URL;
 
-export const getApiVersion = () => "v1.2.6-beta";
+export const getApiVersion = () => "v1.2.7-beta";
 
 export const ORMContext = {} as {
   orm: MikroORM;


### PR DESCRIPTION
## Changes in this pull request
It turns out the original developers did not account for a type of stage display mode when using the standalone Adobe Flash player, specifically on the Map Room window:

```ts
StageDisplayState.FULL_SCREEN_INTERACTIVE
```
Therefore, we now know that the Map Room did in fact have fullscreen capabilities in the original and it was not patched out by the devs, but instead forgotten.

The map can now enter and exit fullscreen mode:

<img width="1703" height="1191" alt="image" src="https://github.com/user-attachments/assets/fe493cf8-9534-40ca-9e9a-04bc5693f415" />
