### PR TITLE
Bugfix: Rezghul using ability outside of battle state. Resurrecting defending monsters freezes game.

### DIFF
--- a/client/scripts/com/monsters/monsters/components/abilities/RezghulResurrectAttack.as
+++ b/client/scripts/com/monsters/monsters/components/abilities/RezghulResurrectAttack.as
@@ -18,88 +18,88 @@ package com.monsters.monsters.components.abilities
       
       private var m_resurrectRange:uint;
       
-      public function RezghulResurrectAttack(param1:uint, param2:int, param3:int, param4:uint, param5:Projectilev2, param6:Zombiefy)
+      public function RezghulResurrectAttack(projRange:uint, rechargeTime:int, targetFlags:int, resAreaRange:uint, proj:Projectilev2, zombieComponent:Zombiefy)
       {
-         super(param1,param2,param3,param5);
-         this.m_zombiefy = param6;
-         this.m_resurrectRange = param4;
+         super(projRange,rechargeTime,targetFlags,proj);
+         this.m_zombiefy = zombieComponent;
+         this.m_resurrectRange = resAreaRange;
       }
       
       override protected function getValidTargetsInRange(param1:uint, param2:Point, param3:int) : Vector.<ITargetable>
       {
-         var _loc4_:Vector.<ITargetable> = null;
-         var _loc7_:ITargetable = null;
-         var _loc5_:Array = Targeting.getDeadCreeps(param2,param1,param3);
-         var _loc6_:int = 0;
-         while(_loc6_ < _loc5_.length)
+         var targets:Vector.<ITargetable> = null;
+         var currentCreep:ITargetable = null;
+         var allDeadCreeps:Array = Targeting.getDeadCreeps(param2,param1,param3);
+         var idx:int = 0;
+         while(idx < allDeadCreeps.length)
          {
-            if(!_loc4_)
+            if(!targets)
             {
-               _loc4_ = new Vector.<ITargetable>();
+               targets = new Vector.<ITargetable>();
             }
-            if((_loc7_ = _loc5_[_loc6_].creep) is MonsterBase && k_UNRESURRECTABLE_CREATURES.indexOf(MonsterBase(_loc7_)._creatureID) == -1)
+            if((currentCreep = allDeadCreeps[idx].creep) is MonsterBase && k_UNRESURRECTABLE_CREATURES.indexOf(MonsterBase(currentCreep)._creatureID) == -1)
             {
-               _loc4_.push(_loc7_);
+               targets.push(currentCreep);
             }
-            _loc6_++;
+            idx++;
          }
-         return _loc4_;
+         return targets;
       }
       
-      override protected function fireAt(param1:ITargetable) : Projectilev2
+      override protected function fireAt(target:ITargetable) : Projectilev2
       {
-         var _loc2_:Projectilev2 = super.fireAt(param1);
-         _loc2_.addEventListener(ProjectileEvent.k_hit,this.onProjectileHit,false,0,true);
-         return _loc2_;
+         var proj:Projectilev2 = super.fireAt(target);
+         proj.addEventListener(ProjectileEvent.k_hit,this.onProjectileHit,false,0,true);
+         return proj;
       }
       
-      protected function onProjectileHit(param1:ProjectileEvent) : void
+      protected function onProjectileHit(event:ProjectileEvent) : void
       {
-         var _loc2_:Projectilev2 = param1.target as Projectilev2;
-         _loc2_.removeEventListener(ProjectileEvent.k_hit,this.onProjectileHit);
-         this.resurrectAlliesInArea(_loc2_);
+         var proj:Projectilev2 = event.target as Projectilev2;
+         proj.removeEventListener(ProjectileEvent.k_hit,this.onProjectileHit);
+         this.resurrectAlliesInArea(proj);
       }
       
-      private function resurrectAlliesInArea(param1:Projectilev2) : void
+      private function resurrectAlliesInArea(proj:Projectilev2) : void
       {
-         var _loc3_:int = 0;
-         var _loc4_:ITargetable = null;
-         var _loc2_:Vector.<ITargetable> = this.getValidTargetsInRange(this.m_resurrectRange,new Point(param1.x,param1.y),m_targetFlags);
-         if(_loc2_)
+         var idx:int = 0;
+         var currentCreep:ITargetable = null;
+         var deadCreepsInRange:Vector.<ITargetable> = this.getValidTargetsInRange(this.m_resurrectRange,new Point(proj.x,proj.y),m_targetFlags);
+         if(deadCreepsInRange)
          {
-            _loc3_ = 0;
-            while(_loc3_ < _loc2_.length)
+            idx = 0;
+            while(idx < deadCreepsInRange.length)
             {
-               if((_loc4_ = _loc2_[_loc3_]) is MonsterBase && k_UNRESURRECTABLE_CREATURES.indexOf(MonsterBase(_loc4_)._creatureID) == -1)
+               if((currentCreep = deadCreepsInRange[idx]) is MonsterBase && k_UNRESURRECTABLE_CREATURES.indexOf(MonsterBase(currentCreep)._creatureID) == -1)
                {
-                  this.resurrect(_loc4_ as MonsterBase);
+                  this.resurrect(currentCreep as MonsterBase);
                }
-               _loc3_++;
+               idx++;
             }
          }
       }
       
-      private function resurrect(param1:MonsterBase) : void
+      private function resurrect(monsterToRes:MonsterBase) : void
       {
-         var _loc2_:MonsterBase = null;
+         var newMonster:MonsterBase = null;
          if(owner._friendly)
          {
-            _loc2_ = CREATURES.Spawn(param1._creatureID,MAP._BUILDINGTOPS,param1._behaviour,new Point(param1.x,param1.y),param1._targetRotation,null,param1._house);
+            newMonster = CREATURES.Spawn(monsterToRes._creatureID,MAP._BUILDINGTOPS,monsterToRes._behaviour,new Point(monsterToRes.x,monsterToRes.y),monsterToRes._targetRotation,null,monsterToRes._house);
          }
          else
          {
-            _loc2_ = CREEPS.Spawn(param1._creatureID,MAP._BUILDINGTOPS,param1._behaviour,new Point(param1.x,param1.y),param1._targetRotation,1,false,true);
+            newMonster = CREEPS.Spawn(monsterToRes._creatureID,MAP._BUILDINGTOPS,monsterToRes._behaviour,new Point(monsterToRes.x,monsterToRes.y),monsterToRes._targetRotation,1,false,true);
          }
-         EFFECTS.Dig(int(_loc2_.x),int(_loc2_.y + 20));
-         TweenLite.from(_loc2_._graphicMC,0.8,{
-            "y":_loc2_._graphicMC.y + 20,
+         EFFECTS.Dig(int(newMonster.x),int(newMonster.y + 20));
+         TweenLite.from(newMonster._graphicMC,0.8,{
+            "y":newMonster._graphicMC.y + 20,
             "ease":Sine.easeOut,
             "overwrite":false,
-            "onComplete":_loc2_.findTarget
+            "onComplete":newMonster.findTarget
          });
-         GIBLETS.Create(new Point(_loc2_.x,_loc2_.y + 20),1,50,20,10);
-         _loc2_.addComponent(this.m_zombiefy.clone());
-         param1.corpseDeath();
+         GIBLETS.Create(new Point(newMonster.x,newMonster.y + 20),1,50,20,10);
+         newMonster.addComponent(this.m_zombiefy.clone());
+         monsterToRes.corpseDeath();
       }
    }
 }

--- a/client/scripts/com/monsters/monsters/components/abilities/RezghulResurrectAttack.as
+++ b/client/scripts/com/monsters/monsters/components/abilities/RezghulResurrectAttack.as
@@ -3,6 +3,7 @@ package com.monsters.monsters.components.abilities
    import com.monsters.events.ProjectileEvent;
    import com.monsters.interfaces.ITargetable;
    import com.monsters.monsters.MonsterBase;
+   import com.monsters.monsters.creeps.CreepBase;
    import com.monsters.projectiles.Projectilev2;
    import flash.geom.Point;
    import gs.TweenLite;
@@ -27,6 +28,10 @@ package com.monsters.monsters.components.abilities
       
       override protected function getValidTargetsInRange(param1:uint, param2:Point, param3:int) : Vector.<ITargetable>
       {
+         if(!owner.inBattleState)
+         {
+            return null;
+         }
          var targets:Vector.<ITargetable> = null;
          var currentCreep:ITargetable = null;
          var allDeadCreeps:Array = Targeting.getDeadCreeps(param2,param1,param3);
@@ -37,7 +42,7 @@ package com.monsters.monsters.components.abilities
             {
                targets = new Vector.<ITargetable>();
             }
-            if((currentCreep = allDeadCreeps[idx].creep) is MonsterBase && k_UNRESURRECTABLE_CREATURES.indexOf(MonsterBase(currentCreep)._creatureID) == -1)
+            if((currentCreep = allDeadCreeps[idx].creep) is CreepBase && k_UNRESURRECTABLE_CREATURES.indexOf(CreepBase(currentCreep)._creatureID) == -1)
             {
                targets.push(currentCreep);
             }
@@ -70,18 +75,18 @@ package com.monsters.monsters.components.abilities
             idx = 0;
             while(idx < deadCreepsInRange.length)
             {
-               if((currentCreep = deadCreepsInRange[idx]) is MonsterBase && k_UNRESURRECTABLE_CREATURES.indexOf(MonsterBase(currentCreep)._creatureID) == -1)
+               if((currentCreep = deadCreepsInRange[idx]) is CreepBase && k_UNRESURRECTABLE_CREATURES.indexOf(CreepBase(currentCreep)._creatureID) == -1)
                {
-                  this.resurrect(currentCreep as MonsterBase);
+                  this.resurrect(currentCreep as CreepBase);
                }
                idx++;
             }
          }
       }
       
-      private function resurrect(monsterToRes:MonsterBase) : void
+      private function resurrect(monsterToRes:CreepBase) : void
       {
-         var newMonster:MonsterBase = null;
+         var newMonster:CreepBase = null;
          if(owner._friendly)
          {
             newMonster = CREATURES.Spawn(monsterToRes._creatureID,MAP._BUILDINGTOPS,monsterToRes._behaviour,new Point(monsterToRes.x,monsterToRes.y),monsterToRes._targetRotation,null,monsterToRes._house);
@@ -95,7 +100,7 @@ package com.monsters.monsters.components.abilities
             "y":newMonster._graphicMC.y + 20,
             "ease":Sine.easeOut,
             "overwrite":false,
-            "onComplete":newMonster.findTarget
+            "onComplete":(newMonster._friendly ? newMonster.findDefenseTargets : newMonster.findTarget)
          });
          GIBLETS.Create(new Point(newMonster.x,newMonster.y + 20),1,50,20,10);
          newMonster.addComponent(this.m_zombiefy.clone());


### PR DESCRIPTION
This pull request is intended to resolve the following issues related to Rezghul's resurrection ability:
- Rezghul resurrecting a defending monster during an attack causes the game to freeze.
- Rezghul can use their resurrection ability outside of an attacking state (most often while inside a housing).

All changes are client side. As always, let me know if anything here looks incorrect, needs clarification, or you would want done differently.

# Changes:
**RezghulResurrectAttack.as:** 
- Changed variable names for readability. 
- Modified function `getValidTargetsInRange` to not give any targets if the monster using this ability is not in a battle state (thus the ability can _only_ be used in a battle state).
- When a defending monster is resurrected, the function `findDefenseTargets` will be called instead of `findTarget`. Attacking monsters still call `findTarget` as before.

**Context:**
- A monster is in a "battle state" when it is using any of the following behaviors:
```
	- k_sBHVR_BUFF (Fomor's attack ai)
	- k_sBHVR_HEAL (Vorg/Zafreeti attack ai)
	- k_sBHVR_HUNT (Balthazar's attack ai)
	- k_sBHVR_ATTACK (Attacking base)
	- k_sBHVR_DEFEND (Defending base)
	- k_sBHVR_BUNKER (Moving inside of a bunker)
	- k_sBHVR_BOUNCE (Behavior for the short "bounce" animation that plays when monsters are flung in)
```
	
- Attacking and defending monsters use different ai, so they also use different targeting functions (`findTarget` and `findDefenseTargets` respectively).
	- Previously, resurrected monsters only called `findTarget` regardless if they were using the attacking or defending ai.
	- `findTarget` typically returns buildings to target, which caused the game to lock due to an exception, since the defending ai expects a monster target.
	- The `findDefenseTargets` function only exists in `CreepBase` (the class used for all non-champion monsters), and not in `MonsterBase`, so the functions were changed to use `CreepBase` instead.
	
> [!NOTE]  
> There are still some minor issues present relating to Rezghul resurrecting a defending monster.
> - Resurrected monsters (and also slimeattikus's fissions) have their ai break and stand motionless forever once they can no longer find a target (even if a new valid target becomes available).
> - Rezghul can resurrect juiced monsters, and can "resurrect" monsters that walked into a bunker (even though the monster didn't technically die).
>
> However, with the change where Rezghul can only use their ability in a "battle state", there would be no practical situation where a defending monster would be resurrected. This is because currently Rezghul cannot be put in bunkers, nor do they appear in inferno compounds.