### PR TITLE
Bugfix: Champion Data Reset. AOEDamage Against Champions; King Wormzor Change.

### DIFF
--- a/client/scripts/BASE.as
+++ b/client/scripts/BASE.as
@@ -5581,7 +5581,6 @@ package
                {
                   if (isMainYardOrInfernoMainYard)
                   {
-                     yardType = EnumYardType.OUTPOST;
                      _currentCellLoc = GLOBAL._mapOutpost[0];
                      GLOBAL._currentCell = null;
                      _needCurrentCell = true;
@@ -5598,7 +5597,6 @@ package
                         {
                            if (_loc3_ < GLOBAL._mapOutpostIDs.length - 1)
                            {
-                              yardType = EnumYardType.OUTPOST;
                               _currentCellLoc = GLOBAL._mapOutpost[_loc3_ + 1];
                               GLOBAL._currentCell = null;
                               _needCurrentCell = true;

--- a/client/scripts/GLOBAL.as
+++ b/client/scripts/GLOBAL.as
@@ -1207,7 +1207,7 @@ package
                PLEASEWAIT.Hide();
                MapRoomManager.instance.ShowDelayed();
             }
-            if (BASE._needCurrentCell && GLOBAL._currentCell && !MapRoomManager.instance.isInMapRoom3)
+            if (BASE._needCurrentCell && GLOBAL._currentCell && !MapRoomManager.instance.isInMapRoom3 && BASE._saveCounterA == BASE._saveCounterB && !BASE._saving)
             {
                PLEASEWAIT.Hide();
                BASE._needCurrentCell = false;

--- a/client/scripts/com/monsters/monsters/components/abilities/AOEDamage.as
+++ b/client/scripts/com/monsters/monsters/components/abilities/AOEDamage.as
@@ -2,7 +2,7 @@ package com.monsters.monsters.components.abilities
 {
    import com.monsters.interfaces.IAttackable;
    import com.monsters.monsters.components.Component;
-   import com.monsters.monsters.creeps.CreepBase;
+   import com.monsters.monsters.MonsterBase;
    import flash.geom.Point;
    
    public class AOEDamage extends Component
@@ -47,24 +47,26 @@ package com.monsters.monsters.components.abilities
 
       private function getAllTargets(ownerLocation:Point, initialTarget:IAttackable = null):Array
       {
-         if(this.m_includeInitialTarget || !initialTarget || !(initialTarget is CreepBase || initialTarget is BFOUNDATION))
-		   {
-            if(owner._friendly && initialTarget is CreepBase)
-            {
-               // Only get creeps for friendly/defending monsters, so they don't friendly-fire their yard's buildings.
-               return Targeting.getCreepsInRange(this.m_radiusOuter,ownerLocation,this.m_targetFlags);
-            }
-			   return Targeting.getTargetsInRange(this.m_radiusOuter,ownerLocation,this.m_targetFlags);
-		   }
-         if(initialTarget is CreepBase)
+         var targetFlags:int = this.m_targetFlags;
+         var ignoreCreep:MonsterBase = null;
+         var ignoreBuilding:BFOUNDATION = null;
+         if(owner._friendly && Boolean(targetFlags & Targeting.k_TARGETS_BUILDINGS) && !(initialTarget is BFOUNDATION))
          {
-            if(owner._friendly)
-            {
-               return Targeting.getCreepsInRange(this.m_radiusOuter,ownerLocation,this.m_targetFlags,initialTarget);
-            }
-            return Targeting.getTargetsInRange(this.m_radiusOuter,ownerLocation,this.m_targetFlags,initialTarget);
+            // Defending monsters will not hit their own base's buildings unless specifically targetting them.
+            targetFlags ^= Targeting.k_TARGETS_BUILDINGS;
          }
-         return Targeting.getTargetsInRange(this.m_radiusOuter,ownerLocation,this.m_targetFlags,null,initialTarget);
+         if(!this.m_includeInitialTarget)
+         {
+            if(initialTarget is MonsterBase)
+            {
+               ignoreCreep = initialTarget
+            }
+            else if(initialTarget is BFOUNDATION)
+            {
+               ignoreBuilding = initialTarget
+            }
+         }
+         return Targeting.getTargetsInRange(this.m_radiusOuter,ownerLocation,targetFlags,ignoreCreep,ignoreBuilding);
       }
    }
 }

--- a/client/scripts/com/monsters/monsters/creeps/inferno/KingWormzer.as
+++ b/client/scripts/com/monsters/monsters/creeps/inferno/KingWormzer.as
@@ -13,14 +13,16 @@ package com.monsters.monsters.creeps.inferno
       {
          super(param1,param2,param3,param4,param5,param6,param7,param8,param9,param10,param11,param12);
          var _loc13_:* = Targeting.k_TARGETS_BUILDINGS | Targeting.k_TARGETS_GROUND;
-         if(param8)
-         {
-            _loc13_ |= Targeting.k_TARGETS_ATTACKERS;
-         }
-         else
-         {
-            _loc13_ |= Targeting.k_TARGETS_DEFENDERS;
-         }
+         // Monster targeting parameters disabled.
+         // King Wormer's splash damage did not work against monsters in the original game, and is too overpowered when re-enabled.
+         //if(param8)
+         //{
+         //   _loc13_ |= Targeting.k_TARGETS_ATTACKERS;
+         //}
+         //else
+         //{
+         //   _loc13_ |= Targeting.k_TARGETS_DEFENDERS;
+         //}
          addComponent(new AOEDamageOnAttackOncePerTarget(100,_loc13_,4));
       }
    }


### PR DESCRIPTION
This pull request is intended to do the following:
- Resolves issue #136 
- Fixes an issue where the game could become stuck saving forever when a base saves right as the player hits the "go to next outpost" button.
- Changes King Wormzor's ability to no longer damage other monsters (still damages buildings).
- Fixes an issue where Bandito and Fink dealt damage to champions twice when their ability was unlocked.

All changes are client side. As always, let me know if anything here looks incorrect, needs clarification, or you would want done differently.

# Changes:
## "Next Outpost" button:
**BASE.as:** `m_yardType` is no longer set to "Outpost" prematurely when loading the player's next outpost.
**GLOBAL.as:** Will now wait until the current base is no longer saving before attempting to load the player's next base.

**Context:**
- When the player clicks the "Next Outpost" button, the `LoadNext` function is called.
	- This would wait until the game is finished saving before "queuing" an outpost to be loaded on the next `GLOBAL` tick.
	- The next `GLOBAL` tick can potentially cause the game to save.
	- During this time, the previous base would still be loaded, but the yard type would still be set to that of an Outpost.
- If the game happens to save while the main yard is loaded, while its yard type is set to be an Outpost, one of two things happen:
	- An error occurs when trying to save autobank values due to `GLOBAL._currentCell` being null, and the game locks into a state of permanently saving.
	- The save is successful, which causes the champion data to be deleted, since outposts always save null to their champion data.

> Video of the "champion data reset" bug being replicated on my local branch. "Next Outpost" button is pressed right before monsters are juiced, causing a save while the loading screen appears.
> Champion is on the top right corner at the start of the video and is deleted when returning to the base.
> **_Mild flashing lights warning_**; versions compiled with VSCode are unstable as per the wiki.

https://github.com/user-attachments/assets/7a815fe5-c82c-40a6-a6c1-2152b4b393cd

## AOEDamage Component:
**KingWormzor.as:** Commented out attacker and defender targeting flags for king wormzor's splash damage ability. Ability will no longer damage monsters, but will still damage buildings.

**Context:**
- King Wormzor's ability to damage monsters was removed in the original game.
<img width="1256" height="57" alt="1d6b0694aff42222762226d2eac2fd9a" src="https://github.com/user-attachments/assets/e3a36f43-f427-4043-8bf1-1cdd79c62918" />

--- 
**AOEDamage.as:** Refactored `getAllTargets` function to be cleaner.
- Now uses `MonsterBase` instead of `CreepBase`.
- Can now account for monsters without attacker/defender targeting flags.

**Context:**
- The `MonsterBase` class can include champions, while `CreepBase` did not. 
	- Previously, if the monster had a champion target, since champions are not a part of `CreepBase`, the champion would always be included as a target (even when the monster's original target is set to be ignored).
	- This caused Fink and Bandito to deal more damage to champions than intended.
- Previously the function returned `Targeting.getCreepsInRange` when the monster was friendly.
	- If the monster didn't have either the attacker or defender target flags, this function would return null and cause an exception.
	- `Targeting.getTargetsInRange` always returns an array of at least length 0.
- `getAllTargets` now uses a copy of the component's `m_targetFlags` variable so the original value is not modified.
	- The function removes the "targets buildings" flag when the monster is friendly and not specifically targeting a building.