### PR TITLE
Balthazar: Targeting Krallen, Defense Flags, Damage Multiplier when Defending.

### DIFF
--- a/client/scripts/CREATURES.as
+++ b/client/scripts/CREATURES.as
@@ -198,6 +198,19 @@ package
          _guardianList.length = 0;
       }
       
+      public static function get _hasLivingGuardian() : Boolean
+      {
+         var idx:int = 0;
+         while(idx < _guardianList.length)
+         {
+            if(Boolean(_guardianList[idx]) && _guardianList[idx].health > 0)
+            {
+               return true;
+            }
+         }
+         return false;
+      }
+
       public static function get _guardian() : ChampionBase
       {
          var _loc1_:int = 0;

--- a/client/scripts/CREATURES.as
+++ b/client/scripts/CREATURES.as
@@ -200,10 +200,9 @@ package
       
       public static function get _hasLivingGuardian() : Boolean
       {
-         var idx:int = 0;
-         while(idx < _guardianList.length)
+         for(var idx:int = 0; idx < _guardianList.length; idx++)
          {
-            if(Boolean(_guardianList[idx]) && _guardianList[idx].health > 0)
+            if(_guardianList[idx] && _guardianList[idx].health > 0)
             {
                return true;
             }

--- a/client/scripts/com/monsters/monsters/MonsterBase.as
+++ b/client/scripts/com/monsters/monsters/MonsterBase.as
@@ -1076,20 +1076,20 @@ package com.monsters.monsters
       
       public function findHuntingTargets() : void
       {
-         var _loc4_:MonsterBase = null;
-         var _loc1_:int = 0;
-         var _loc2_:Array = [];
-         var _loc3_:Object = CREATURES._creatures;
-         for each(_loc4_ in _loc3_)
+         var monster:MonsterBase = null;
+         var amount:int = 0;
+         var targets:Array = [];
+         var allMonsters:Object = CREATURES._creatures;
+         for each(monster in allMonsters)
          {
-            if(!(_loc4_._behaviour != k_sBHVR_DEFEND && _loc4_._behaviour != k_sBHVR_BUNKER))
+            if(!(monster._behaviour != k_sBHVR_DEFEND && monster._behaviour != k_sBHVR_BUNKER))
             {
-               _loc2_.push({
-                  "creep":_loc4_,
-                  "dist":GLOBAL.QuickDistance(_loc4_._tmpPoint,this._tmpPoint)
+               targets.push({
+                  "creep":monster,
+                  "dist":GLOBAL.QuickDistance(monster._tmpPoint,this._tmpPoint)
                });
-               _loc1_++;
-               if(_loc1_ >= 10)
+               amount++;
+               if(amount >= 10)
                {
                   break;
                }
@@ -1097,22 +1097,29 @@ package com.monsters.monsters
          }
          if(Boolean(CREATURES._guardian) && CREATURES._guardian.health > 0)
          {
-            _loc2_.push({
+            targets.push({
                "creep":CREATURES._guardian,
                "dist":GLOBAL.QuickDistance(CREATURES._guardian._tmpPoint,this._tmpPoint)
             });
          }
-         if(_loc2_.length > 0)
+         if(Boolean(CREATURES._krallen) && CREATURES._krallen.health > 0)
          {
-            _loc2_.sortOn("dist",Array.NUMERIC);
-            while(_loc2_.length > 0 && _loc2_[0].creep.health <= 0)
+            targets.push({
+               "creep":CREATURES._krallen,
+               "dist":GLOBAL.QuickDistance(CREATURES._krallen._tmpPoint,this._tmpPoint)
+            });
+         }
+         if(targets.length > 0)
+         {
+            targets.sortOn("dist",Array.NUMERIC);
+            while(targets.length > 0 && targets[0].creep.health <= 0)
             {
-               _loc2_.splice(0,1);
+               targets.splice(0,1);
             }
          }
-         if(_loc2_.length > 0)
+         if(targets.length > 0)
          {
-            this._targetCreep = _loc2_[0].creep;
+            this._targetCreep = targets[0].creep;
             this._waypoints = [this._targetCreep._tmpPoint];
          }
       }
@@ -1149,7 +1156,7 @@ package com.monsters.monsters
          var _loc2_:int = getTimer();
          var _loc11_:Array = [];
          this._looking = true;
-         if(this._behaviour == k_sBHVR_HUNT && (CREATURES._creatureCount > 0 || CREATURES._guardian && CREATURES._guardian.health > 0))
+         if(this._behaviour == k_sBHVR_HUNT && (CREATURES._creatureCount > 0 || CREATURES._hasLivingGuardian))
          {
             this.findHuntingTargets();
             if(this._targetCreep)

--- a/client/scripts/com/monsters/monsters/creeps/CreepBase.as
+++ b/client/scripts/com/monsters/monsters/creeps/CreepBase.as
@@ -964,7 +964,7 @@ package com.monsters.monsters.creeps
          {
             if(!_targetCreep)
             {
-               if(_behaviour === k_sBHVR_HUNT && (CREATURES._creatureCount > 0 || CREATURES._guardian && CREATURES._guardian.health > 0) && _frameNumber % 150 == 0)
+               if(_behaviour === k_sBHVR_HUNT && (CREATURES._creatureCount > 0 || CREATURES._hasLivingGuardian) && _frameNumber % 150 == 0)
                {
                   findTarget(_targetGroup);
                }
@@ -1364,8 +1364,15 @@ package com.monsters.monsters.creeps
                }
                else
                {
+                  if(_targetGroup == 6)
+                  {
+                     damageDelt = _targetCreep.modifyHealth(-(damage*3));
+                  }
+                  else
+                  {
+                     damageDelt = _targetCreep.modifyHealth(-damage);
+                  }
                   ATTACK.Damage(_tmpPoint.x,_tmpPoint.y - 5,damageDelt,_mc.visible);
-                  damageDelt = _targetCreep.modifyHealth(-damage);
                }
                if(!_explode)
                {

--- a/client/scripts/com/monsters/monsters/creeps/inferno/Balthazar.as
+++ b/client/scripts/com/monsters/monsters/creeps/inferno/Balthazar.as
@@ -8,9 +8,17 @@ package com.monsters.monsters.creeps.inferno
    {
        
       
-      public function Balthazar(param1:String, param2:String, param3:Point, param4:Number, param5:int = 0, param6:int = 2147483647, param7:Point = null, param8:Boolean = false, param9:BFOUNDATION = null, param10:Number = 1, param11:Boolean = false, param12:MonsterBase = null)
+      public function Balthazar(id:String, behavior:String, spawn:Point, rotation:Number, level:int = 0, health:int = 2147483647, center:Point = null, friendly:Boolean = false, housing:BFOUNDATION = null, damageMult:Number = 1, easy:Boolean = false, monster:MonsterBase = null)
       {
-         super(param1,param2,param3,param4,param5,param6,param7,param8,param9,param10,param11,param12);
+         super(id,behavior,spawn,rotation,level,health,center,friendly,housing,damageMult,easy,monster);
+         if(Boolean(defenseFlags & Targeting.k_TARGETS_FLYING))
+         {
+            defenseFlags ^= Targeting.k_TARGETS_FLYING;
+         }
+         if(Boolean(defenseFlags & Targeting.k_TARGETS_GROUND))
+         {
+            defenseFlags ^= Targeting.k_TARGETS_GROUND;
+         }
          if(poweredUp())
          {
             targetMode = 1;


### PR DESCRIPTION
This pull request is intended to make the following changes to Balthazar to make them behave more as intended:
- Balthazar now actively targets Krallen like other champions.
- Balthazar can now be hit by any defense tower, including traps, ADTs, cannons, ect.
- Balthazar now has their intended x3 damage multiplier against monsters while defending from a compound/bunker.

All changes are client side. As always, let me know if anything here looks incorrect, needs clarification, or you would want done differently.

# Changes:
## Targetting Krallen:
**CREATURES.as:** Added the `_hasLivingGuardian` function. Returns true if there is an active defending champion above 0 health.
The `tickBAttack` function in **CreepBase.as**, and the `findTarget` function in **MonsterBase.as** now use this function.

**MonsterBase.as:** Modified the `findHuntingTargets` function. Renamed variables for readability. Now adds Krallen to the target list when they're present.

**Context:**
- Creating the `_hasLivingGuardian` function seemed like a cleaner solution than writing `(CREATURES._guardian && CREATURES._guardian.health > 0) || (CREATURES._krallen && CREATURES._krallen.health > 0)` in the if statements just to check if a defending champion is alive.
- An alternative, potentially cleaner solution to adding Krallen to the target list in `findHuntingTargets` would be looping through `CREATURES_guardianList` and adding anything in there that has > 0 health.

## Defense Flags:
**Balthazar.as:** Upon creation, Balthazar now has the `k_TARGETS_FLYING` and/or `k_TARGETS_GROUND` defense flags removed, if they have them.

**Context:**
- Defense Flags are used to determine whether or not a tower can target a specific monster. A tower can only target a monster if all of the monster's Defense Flags exist in the tower's Attack Flags.
	- For example a monster with the `k_TARGETS_FLYING` Defense Flag can only be targeted by towers that have the `k_TARGETS_FLYING` Attack Flag, like the Sniper Tower, or the ADT.
	- If a monster had the `k_TARGETS_FLYING` *and* `k_TARGETS_GROUND` Defense Flags, then the monster could only be targeted by a tower that has *both* of those Attack Flags. In other words, towers that can hit both Air and Ground monsters.
- When a CreepBase object is created, it is normally given the following defense flags:
	- `k_TARGETS_DEFENDERS` or `k_TARGETS_ATTACKERS` if the monster is defending a base or attacking a base respectively.
	- `k_TARGETS_FLYING` if the monster's "movement" parameter is set to "fly", otherwise it is given `k_TARGETS_GROUND`.
- By removing both the ground and flying defense flags, it doesn't matter if the tower targets only air monsters, only ground monsters, or both. Any tower would be able to hit Balthazar.
	- An alternative, potentially cleaner solution would be to clear the Balthazar's defense flags on creation and add new flags as desired.
- This means Balthazar can activate traps, be hit by ground towers (cannon, quake, laser, ect), and can be hit by air only towers (ADT).
	- This is more in line with how the wikis state Balthazar can be affected by any tower, including ADTs, and can activate traps.

## Damage Multiplier While Defending:
**CreepBase.as:** Modified `tickBDefend` function. Creatures with `_targetGroup` of 6 now deal x3 damage to their target monster.

**Context:**
- The functionality for Balthazar's damage multiplier exists in `tickBAttack` for attacking monsters. When a monster has the behavior `k_sBHVR_HUNT` and is targeting a monster, it deals x3 damage to the monster. This functionality does not exist in `tickBDefend` for defending monsters.
- Balthazar doesn't use the `k_sBHVR_HUNT` behavior when defending (They use the `k_sBHVR_DEFEND` behavior when defending like all other monsters). So, I used the `_targetGroup` parameter instead.
	- The `_targetGroup` parameter is used to determine what the monster should prioritize when attacking.
	- A target group of 6 is meant to prioritize monsters and bunkers.
	- Balthazar is the only monster with their `_targetGroup` set to 6.
- Ideally functionality made only for specific monsters would be moved out of CreepBase.as and into their own monster's class files, but that is beyond the scope of this PR.

## Videos:
Some short clips to demonstrate the code changes.
> *Flashing lights warning for the clips. Clients compiled with VSCode are unstable as per the wiki.*

> Attacking in the Overworld. The Balthazars:
> - Trigger traps (but not heavy traps)
> - Are hit by all towers
> - Activate the bunker containing ground monsters
> - Actively target krallen before moving onto buildings. (Spurtz spawned the the spurtz cannon are also actively targeted, though this feature was already present.)

https://github.com/user-attachments/assets/b01d0a59-c4b2-462f-b2d8-8c6126a05fd1

> Attacking in the Inferno. Notably the compound monsters now attack the Balthazars, and the Balthazars take damage from the quake tower.

https://github.com/user-attachments/assets/f48dfd41-55ea-4793-afec-a1a44fefdd1c

> Balthazars in an Overworld bunker. Notably having their x3 damage bonus to the attacking monsters.

https://github.com/user-attachments/assets/41b96516-9d1f-4607-82fb-4b13a5175a99

