### PR TITLE
Fix: Landscape flip

### DIFF
--- a/android/bym-refitted.xml
+++ b/android/bym-refitted.xml
@@ -13,7 +13,7 @@
         <systemChrome>standard</systemChrome>
         <fullScreen>true</fullScreen>
         <aspectRatio>landscape</aspectRatio>
-        <!-- <autoOrients>true</autoOrients> -->
+        <autoOrients>false</autoOrients>
         <visible>true</visible>
         <width>720</width>
         <height>1280</height>
@@ -42,7 +42,7 @@
            <supports-screens android:normalScreens="true"/>
            <uses-feature android:required="true" android:name="android.hardware.touchscreen.multitouch"/>
            <application android:enabled="true" android:hardwareAccelerated="true" android:targetSdkVersion="35">
-               <activity android:excludeFromRecents="false">
+               <activity android:excludeFromRecents="false" android:screenOrientation="landscape">
                    <intent-filter>
                        <action android:name="android.intent.action.MAIN"/>
                        <category android:name= "android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
This change removes the commented out autoOrients and sets it explicitly to the default value.
It also sets the ndroid:screenOrientation. This should allow the android app to flip to reverse-landscape as well. 
It still prevents portrait modes, but this should allow for players to flip their phone around in case their charger position forces them to play upside down. 

I have not tested the change yet, but I wanted to put up the PR for visibility first. 