### PR TITLE
Fix EntityManager Type to Use PostgreSQL Driver

### DIFF
--- a/server/src/database/seeds/seedWorldMapUsers.ts
+++ b/server/src/database/seeds/seedWorldMapUsers.ts
@@ -1,6 +1,6 @@
 import bcrypt from "bcrypt";
 
-import { EntityManager } from "@mikro-orm/core";
+import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
 import { getDefaultBaseData } from "../../data/getDefaultBaseData";
 import { Save } from "../../models/save.model";
 import { User } from "../../models/user.model";
@@ -9,7 +9,7 @@ import { errorLog, logging } from "../../utils/logger";
 import { MapRoom } from "../../enums/MapRoom";
 import { BaseType } from "../../enums/Base";
 
-export const seedWorldMapUsers = async (em: EntityManager) => {
+export const seedWorldMapUsers = async (em: EntityManager<PostgreSqlDriver>) => {
   // Check if users already exist
   const existingUsers = await em.count(User, {});
   if (existingUsers > 0) {

--- a/server/src/models/infernomaproom.model.ts
+++ b/server/src/models/infernomaproom.model.ts
@@ -1,11 +1,6 @@
-import {
-  Connection,
-  Entity,
-  EntityManager,
-  IDatabaseDriver,
-  PrimaryKey,
-  Property,
-} from "@mikro-orm/core";
+import { Entity, PrimaryKey, Property } from "@mikro-orm/core";
+
+import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
 import { User } from "./user.model";
 import { NeighbourData } from "../services/maproom/inferno/createNeighbourData";
 
@@ -37,13 +32,8 @@ export class InfernoMaproom {
   @Property({ onUpdate: () => new Date() })
   lastupdateAt: Date = new Date();
 
-  public static setupMapRoom1Data = async (
-    em: EntityManager<IDatabaseDriver<Connection>>,
-    user: User
-  ) => {
-    const maproom = em.create(InfernoMaproom, {
-      userid: user.userid,
-    });
+  public static setupMapRoom1Data = async (em: EntityManager<PostgreSqlDriver>, user: User) => {
+    const maproom = em.create(InfernoMaproom, { userid: user.userid });
 
     await em.persistAndFlush(maproom);
     return maproom;

--- a/server/src/models/save.model.ts
+++ b/server/src/models/save.model.ts
@@ -1,13 +1,6 @@
-import {
-  Entity,
-  Property,
-  PrimaryKey,
-  EntityManager,
-  Connection,
-  IDatabaseDriver,
-  OneToOne,
-  Index,
-} from "@mikro-orm/core";
+import { Entity, Property, PrimaryKey, OneToOne, Index } from "@mikro-orm/core";
+
+import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
 import { FrontendKey } from "../utils/FrontendKey";
 import { getDefaultBaseData } from "../data/getDefaultBaseData";
 import { User } from "./user.model";
@@ -44,7 +37,7 @@ export class Save {
   cell: WorldMapCell;
 
   @FrontendKey
-  @Property({ type: 'bigint', default: 0 })
+  @Property({ type: "bigint", default: 0 })
   homebaseid!: number;
 
   @Index()
@@ -536,15 +529,11 @@ export class Save {
     "attackcreatures",
   ];
 
-  public static createMainSave = async (
-    em: EntityManager<IDatabaseDriver<Connection>>,
-    user: User
-  ) => {
+  public static createMainSave = async (em: EntityManager<PostgreSqlDriver>, user: User) => {
     const baseSave = em.create(Save, getDefaultBaseData(user, BaseType.MAIN));
 
-    const [{ baseid }] = await em
-      .getConnection()
-      .execute<{ baseid: string }>(NEXT_USER_BASEID);
+    const [result] = await em.execute<[{ baseid: string }]>(NEXT_USER_BASEID);
+    const baseid = result.baseid;
 
     baseSave.baseid = baseid;
     baseSave.homebaseid = parseInt(baseid, 10);
@@ -556,18 +545,11 @@ export class Save {
     return baseSave;
   };
 
-  public static createInfernoSave = async (
-    em: EntityManager<IDatabaseDriver<Connection>>,
-    user: User
-  ) => {
-    const infernoSave = em.create(
-      Save,
-      getDefaultBaseData(user, BaseType.INFERNO)
-    );
+  public static createInfernoSave = async (em: EntityManager<PostgreSqlDriver>, user: User) => {
+    const infernoSave = em.create(Save, getDefaultBaseData(user, BaseType.INFERNO));
 
-    const [{ baseid }] = await em
-      .getConnection()
-      .execute<{ baseid: string }>(NEXT_USER_BASEID);
+    const [result] = await em.execute<[{ baseid: string }]>(NEXT_USER_BASEID);
+    const baseid = result.baseid;
 
     infernoSave.type = BaseType.INFERNO;
     infernoSave.baseid = baseid;
@@ -584,6 +566,7 @@ export class Save {
 
     user.infernosave = infernoSave;
     await em.persistAndFlush(infernoSave);
+
     return infernoSave;
   };
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,14 +9,14 @@ import ormConfig from "./mikro-orm.config";
 import router from "./app.routes";
 
 import { createClient } from "redis";
-import { EntityManager, MikroORM, RequestContext } from "@mikro-orm/core";
+import { MikroORM, RequestContext } from "@mikro-orm/core";
+import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
 import { errorLog, logging } from "./utils/logger";
 import { ascii_node } from "./utils/ascii_art";
 import { ErrorInterceptor } from "./middleware/clientSafeError";
 import { processLanguagesFile } from "./middleware/processLanguageFile";
 import { logMissingAssets, morganLogging } from "./middleware/morganLogging";
 import { corsCacheControl } from "./middleware/corsCacheControlSetup";
-import { PostgreSqlDriver } from "@mikro-orm/postgresql";
 
 export const app = new Koa();
 app.proxy = true;
@@ -27,8 +27,8 @@ export const BASE_URL = process.env.BASE_URL;
 export const getApiVersion = () => "v1.4.2-beta";
 
 export const ORMContext = {} as {
-  orm: MikroORM;
-  em: EntityManager;
+  orm: MikroORM<PostgreSqlDriver>;
+  em: EntityManager<PostgreSqlDriver>;
 };
 
 export const redisClient = createClient({

--- a/server/src/services/maproom/v2/findFreeCell.ts
+++ b/server/src/services/maproom/v2/findFreeCell.ts
@@ -1,7 +1,7 @@
 import { MapRoom, Terrain } from "../../../enums/MapRoom";
 import { World } from "../../../models/world.model";
 import { WorldMapCell } from "../../../models/worldmapcell.model";
-import { EntityManager } from "@mikro-orm/core";
+import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
 import { logging } from "../../../utils/logger";
 import { generateNoise, getTerrainHeight } from "./generateMap";
 
@@ -18,11 +18,11 @@ interface Cell {
  * Finds a free cell in a given world that is not water and not occupied by another player.
  *
  * @param {World} world - The world in which to find a free cell.
- * @param {EntityManager} em - The entity manager for database operations.
+ * @param {EntityManager<PostgreSqlDriver>} em - The entity manager for database operations.
  * @returns {Promise<Cell>} - The coordinates and terrain height of the free cell.
  * @throws {Error} - If no free cell is found after several attempts.
  */
-export const findFreeCell = async (world: World, em: EntityManager) => {
+export const findFreeCell = async (world: World, em: EntityManager<PostgreSqlDriver>) => {
   let cell: Cell = { x: null, y: null, terrainHeight: null };
   let maxAttempts = 10;
 

--- a/server/src/services/maproom/v2/joinOrCreateWorld.ts
+++ b/server/src/services/maproom/v2/joinOrCreateWorld.ts
@@ -4,7 +4,7 @@ import { Save } from "../../../models/save.model";
 import { logging } from "../../../utils/logger";
 import { World } from "../../../models/world.model";
 import { MapRoom, MapRoomCell } from "../../../enums/MapRoom";
-import { EntityManager } from "@mikro-orm/core";
+import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
 import { ORMContext } from "../../../server";
 import { findFreeCell } from "./findFreeCell";
 
@@ -25,7 +25,7 @@ import { findFreeCell } from "./findFreeCell";
 export const joinOrCreateWorld = async (
   user: User,
   save: Save,
-  em: EntityManager = ORMContext.em,
+  em: EntityManager<PostgreSqlDriver> = ORMContext.em,
   relocate: Boolean = false
 ) => {
   let world: World | null = null;


### PR DESCRIPTION
## Fix EntityManager Type to Use PostgreSQL Driver

### Problem
The application was using the generic `EntityManager` from `@mikro-orm/core` instead of the PostgreSQL-specific one. This prevented access to important PostgreSQL methods like `.raw()`, `.execute()`, `.createQueryBuilder()`, and other SQL-specific features.

### Changes
- Updated `server.ts` to import and type `EntityManager` and `MikroORM` with `PostgreSqlDriver`
- Updated `save.model.ts` to use PostgreSQL `EntityManager` in static methods
- Refactored `.getConnection().execute()` calls to use `.execute()` directly on EntityManager
- Fixed TypeScript typing for database query results

### Technical Details
The core `EntityManager` is driver-agnostic and only provides ORM methods that work across all databases (MongoDB, MySQL, PostgreSQL, etc.). The PostgreSQL `EntityManager` extends this with SQL-specific capabilities:
- Raw SQL execution
- Query builder with PostgreSQL features
- Access to Knex instance
- PostgreSQL-specific optimizations

### Impact
No functional changes to application behavior. This is purely a TypeScript typing improvement that enables access to PostgreSQL-specific features we need for performance optimization and complex queries.