### PR TITLE
[Android] force set URL to GET if request body is empty

### DIFF
--- a/client/scripts/URLLoaderApi.as
+++ b/client/scripts/URLLoaderApi.as
@@ -123,6 +123,10 @@ package
          }
          urlBuilder.data = urlVariables;
          urlBuilder.method = URLRequestMethod.POST;
+         if(currentIndex == 0)
+         {
+            urlBuilder.method = URLRequestMethod.GET;
+         }
          this._req = new URLLoader(urlBuilder);
          this._req.addEventListener(Event.COMPLETE, this.fireComplete);
          this._req.addEventListener(IOErrorEvent.IO_ERROR, this.loadError);


### PR DESCRIPTION
Issue: 
Android can't open the mailbox

Reason:
mailbox called the backend with POST instead of GET, somehow Android behavior doesn't follow how Desktop handle URL fallback automatically from POST to GET if the request body is empty. In Mailbox feature, there are two endpoints that is expected to be GET on server:
1. GET /api/:apiVersion/player/getmessagetargets
2. GET /api/:apiVersion/player/getmessagethreads

Solution:
handle URL fallback manually if the request body is empty based on available variable (currentIndex), force set it to GET

Proof on android:
<img width="1266" height="567" alt="Screen Shot 2025-11-30 at 12 47 29" src="https://github.com/user-attachments/assets/9b1ad880-11e0-437e-8f6a-8a73a5fec68b" />

