### PR TITLE
Refactor: Convert damage protection system from boolean to timestamp-based

### DIFF
--- a/server/src/controllers/maproom/inferno/getNeighbours.ts
+++ b/server/src/controllers/maproom/inferno/getNeighbours.ts
@@ -211,7 +211,9 @@ const updateNeighbourData = async (cachedNeighbours: NeighbourData[]) => {
 
       // TODO: Add the rest of the cases here for attack permissions
       // e.g. level too low, starting protection, etc
-      if (currentSave.protected === 1) {
+      const currentTime = getCurrentDateTime();
+      const isProtected = currentSave.protected > 0 && currentSave.protected > currentTime;
+      if (isProtected) {
         neighbour.attackpermitted = AttackPermission.DAMAGE_PROTECTION;
       } else {
         neighbour.attackpermitted = AttackPermission.ATTACKABLE;

--- a/server/src/controllers/maproom/v2/cells/userCell.ts
+++ b/server/src/controllers/maproom/v2/cells/userCell.ts
@@ -48,6 +48,9 @@ export const userCell = async (ctx: Context, cell: WorldMapCell) => {
 
     await damageProtection(cellSave);
 
+    const currentTime = getCurrentDateTime();
+    const isProtected = cellSave.protected > 0 && cellSave.protected > currentTime;
+
     return {
       uid: cellOwner.userid,
       b: cell.base_type,
@@ -63,7 +66,7 @@ export const userCell = async (ctx: Context, cell: WorldMapCell) => {
       n: cellOwner.username,
       fr: 0,
       on: online,
-      p: cellSave.protected,
+      p: isProtected ? 1 : 0, // Convert timestamp to boolean for client
       r: cellSave.resources,
       m: cellSave.monsters || {},
       l: baseLevel,

--- a/server/src/controllers/maproom/v2/takeoverCell.ts
+++ b/server/src/controllers/maproom/v2/takeoverCell.ts
@@ -88,14 +88,15 @@ export const takeoverCell: KoaController = async (ctx) => {
     }
 
     // Update save
+    const currentTime = getCurrentDateTime();
+    const twelveHours = 12 * 60 * 60;
+
     cellSave.saveuserid = currentUser.userid;
     cellSave.userid = userSave.userid;
     cellSave.homebaseid = userSave.homebaseid;
     cellSave.name = userSave.name;
-    cellSave.createtime = getCurrentDateTime();
-    cellSave.outpostProtectionTime = getCurrentDateTime();
-
-    cellSave.protected = 1;
+    cellSave.createtime = currentTime;
+    cellSave.protected = currentTime + twelveHours;
     cellSave.attacks = [];
     cellSave.resources = {};
     cellSave.tutorialstage = 205;

--- a/server/src/data/getDefaultBaseData.ts
+++ b/server/src/data/getDefaultBaseData.ts
@@ -20,13 +20,17 @@ export const getDefaultBaseData = (user: User, baseType: BaseType) => {
   if (baseType === BaseType.INFERNO && devConfig.infernoSandbox)
     return infernoSandbox(user);
 
+  const currentTime = getCurrentDateTime();
+  const sevenDays = 7 * 24 * 60 * 60;
+
   return {
     saveuserid: user.userid,
     userid: user.userid,
     cellid: -1,
     name: user.username,
     credits: devConfig.shiny || 1000,
-    createtime: getCurrentDateTime(),
+    createtime: currentTime,
+    protected: currentTime + sevenDays,
 
     // Pre-populated Objects
     resources: {

--- a/server/src/database/migrations/DeleteProtectionCols.ts
+++ b/server/src/database/migrations/DeleteProtectionCols.ts
@@ -1,0 +1,19 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * Remove redundant damage protection tracking columns.
+ * The system now uses only the 'protected' timestamp field instead of
+ * separate tracking columns (mainProtectionTime, outpostProtectionTime,
+ * initialProtectionOver, initialOutpostProtectionOver).
+ */
+export class DeleteProtectionCols extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "bym"."save"
+      DROP COLUMN IF EXISTS "main_protection_time",
+      DROP COLUMN IF EXISTS "outpost_protection_time",
+      DROP COLUMN IF EXISTS "initial_protection_over",
+      DROP COLUMN IF EXISTS "initial_outpost_protection_over";
+    `);
+  }
+}

--- a/server/src/models/save.model.ts
+++ b/server/src/models/save.model.ts
@@ -66,19 +66,6 @@ export class Save {
   @Property({ default: 0 })
   wmid!: number;
 
-  // Damage Protection
-  @Property({ nullable: true })
-  mainProtectionTime: number | null;
-
-  @Property({ nullable: true })
-  outpostProtectionTime: number | null;
-
-  @Property({ default: false })
-  initialProtectionOver!: boolean;
-
-  @Property({ default: false })
-  initialOutpostProtectionOver!: boolean;
-
   // Primatives
   @Index()
   @FrontendKey


### PR DESCRIPTION
### Summary
Refactored the damage protection system to use Unix timestamps instead of boolean values (1/0). This enables the Flash client to display countdown timers showing exactly when protection expires, while maintaining backward compatibility with existing client expectations.

### Key Changes

**Protection Logic**
- Changed `protected` field from boolean (1/0) to Unix timestamp
- Protection is active when `protected > 0 && protected > currentTime`
- Protection expires when `protected <= currentTime`
- Attacking (BaseMode.ATTACK) immediately sets `protected = 0`

**Removed Redundant Columns**
- Dropped `mainProtectionTime`, `outpostProtectionTime`, `initialProtectionOver`, `initialOutpostProtectionOver`
- System now uses only the `protected` timestamp field for all tracking

**Files Modified**
- `damageProtection.ts` - Simplified protection logic, removed helper functions, added auto-cleanup for expired timestamps
- `getDefaultBaseData.ts` - Sets 7-day protection timestamp for new accounts
- `takeoverCell.ts` - Sets 12-hour protection timestamp for outpost takeovers
- `userCell.ts` - Converts timestamp to boolean (1/0) for map cell display
- `getNeighbours.ts` - Uses timestamp check for inferno protection validation
- `molochTribes.ts` - Sets NPC tribes to max timestamp (always protected)
- `save.model.ts` - Removed redundant column definitions
- Created migration to drop unused database columns

**Client Compatibility**
- Map cells receive boolean (1/0) for backwards compatibility
- Base load endpoint sends raw timestamp for countdown timer display
- No client-side changes required

### Protection Rules (Unchanged)
All existing protection rules remain functional:
- New accounts: 7 days protection
- Outpost takeover: 12 hours protection
- Main yard: 4 attacks in 1 hour grants 1 hour protection
- Main yard: 50%+ damage grants 36 hours protection
- Outpost: 25%+ damage grants 8 hours protection
- Inferno: 50%+ damage grants 36 hours protection

### Database Migration
Run `npm run migration:up` to apply schema changes (drops 4 unused columns from `save` table).
