### PR TITLE
Fix Empire Destroyed Migration Memory Leaks and Security Issues

### DIFF
--- a/client/scripts/com/monsters/maproom_advanced/PopupLostMainBase.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupLostMainBase.as
@@ -72,7 +72,7 @@ package com.monsters.maproom_advanced
             }
             else
             {
-               GLOBAL.ErrorMessage("PopupLostMainBase.Relocate 1");
+               GLOBAL.ErrorMessage(param1.error);
                LOGGER.Log("err","PopupLostMainBase.Relocate non-zero error " + param1.error);
             }
          };

--- a/server/src/controllers/maproom/v2/migrateBase.ts
+++ b/server/src/controllers/maproom/v2/migrateBase.ts
@@ -1,11 +1,9 @@
-import z from "zod";
-
 import { KoaController } from "../../../utils/KoaController";
 import { User } from "../../../models/user.model";
 import { postgres } from "../../../server";
 import { WorldMapCell } from "../../../models/worldmapcell.model";
 import { Status } from "../../../enums/StatusCodes";
-import { BaseMode, BaseType } from "../../../enums/Base";
+import { BaseType } from "../../../enums/Base";
 import { getCurrentDateTime } from "../../../utils/getCurrentDateTime";
 import { errorLog } from "../../../utils/logger";
 import {
@@ -13,17 +11,11 @@ import {
   updateResources,
 } from "../../../services/base/updateResources";
 import { joinOrCreateWorld } from "../../../services/maproom/v2/joinOrCreateWorld";
+import { leaveWorld } from "../../../services/maproom/v2/leaveWorld";
 import { MapRoomCell } from "../../../enums/MapRoom";
-
-/**
- * Request schema for migrate base.
- */
-const MigrateBaseSchema = z.object({
-  type: z.nativeEnum(BaseType),
-  baseid: z.string(),
-  resources: z.string().transform((res) => JSON.parse(res)).optional(),
-  shiny: z.string().transform((shiny) => parseInt(shiny)).optional(),
-});
+import { relocateOutpostErr } from "../../../errors/errors";
+import { ClientSafeError } from "../../../middleware/clientSafeError";
+import { MigrateBaseSchema } from "../../../zod/MigrateBaseSchema";
 
 /**
  * Cooldown period for base migration.
@@ -46,9 +38,7 @@ const COOLDOWN_PERIOD = 24 * 60 * 60;
  */
 export const migrateBase: KoaController = async (ctx) => {
   try {
-    const { baseid, resources, shiny, type } = MigrateBaseSchema.parse(
-      ctx.request.body
-    );
+    const { baseid, resources, shiny, type } = MigrateBaseSchema.parse(ctx.request.body);
 
     const currentUser: User = ctx.authUser;
     await postgres.em.populate(currentUser, ["save"]);
@@ -67,9 +57,13 @@ export const migrateBase: KoaController = async (ctx) => {
       return;
     }
 
-    // Check if the user is relocating due to their empire being overrun.
-    if (type !== BaseType.OUTPOST && baseid === BaseMode.DEFAULT) {
+    // User is relocating due to their empire being overrun.
+    if (type === BaseType.RANDOM) {
+      if (userSave.outposts.length > 0) throw relocateOutpostErr();
+
+      await leaveWorld(currentUser, userSave);
       await joinOrCreateWorld(currentUser, userSave, postgres.em, true);
+
       ctx.status = Status.OK;
       ctx.body = { error: 0 };
       return;
@@ -142,6 +136,8 @@ export const migrateBase: KoaController = async (ctx) => {
       coords: [outpostX, outpostY],
     };
   } catch (error) {
+    if (error instanceof ClientSafeError) throw error;
+
     ctx.status = Status.BAD_REQUEST;
     ctx.body = { error: 1 };
     errorLog("Error migrating user base:", error);

--- a/server/src/errors/errors.ts
+++ b/server/src/errors/errors.ts
@@ -108,17 +108,25 @@ export const discordAgeErr = () =>
 
 export const permissionErr = () =>
   new ClientSafeError({
-    message:
-      "You do not have permission to complete this operation.",
+    message: "You do not have permission to complete this operation.",
     status: Status.FORBIDDEN,
     data: null,
     isClientFriendly: true,
   });
 
-  export const mailboxErr = () =>
-    new ClientSafeError({
-      message: "Mailbox failed with an error.",
-      status: Status.NOT_FOUND,
-      data: null,
-      isClientFriendly: true,
-    });
+export const mailboxErr = () =>
+  new ClientSafeError({
+    message: "Mailbox failed with an error.",
+    status: Status.NOT_FOUND,
+    data: null,
+    isClientFriendly: true,
+  });
+
+export const relocateOutpostErr = () =>
+  new ClientSafeError({
+    message:
+      "You cannot relocate while owning outposts in this world.",
+    status: Status.FORBIDDEN,
+    data: null,
+    isClientFriendly: true,
+  });

--- a/server/src/zod/MigrateBaseSchema.ts
+++ b/server/src/zod/MigrateBaseSchema.ts
@@ -1,0 +1,39 @@
+import z from "zod";
+import { BaseType } from "../enums/Base";
+
+/**
+ * Request schema for migrate base.
+ *
+ * @type {z.ZodObject}
+ */
+export const MigrateBaseSchema = z.object({
+  /**
+   * The baseMode type sent by the client.
+   * @type {string}
+   */
+  type: z.nativeEnum(BaseType),
+
+  /**
+   * The base ID of the base which is migration.
+   * @type {string}
+   */
+  baseid: z.string(),
+
+  /**
+   * The resources to be used for the migration, transformed from a JSON string to an object.
+   * @type {object | undefined}
+   */
+  resources: z
+    .string()
+    .transform((res) => JSON.parse(res))
+    .optional(),
+
+  /**
+   * The amount of shiny to be used for the migration, transformed from a string to a number.
+   * @type {number | undefined}
+   */
+  shiny: z
+    .string()
+    .transform((shiny) => parseInt(shiny))
+    .optional(),
+});


### PR DESCRIPTION
## Summary

Fixed critical issues in the "empire destroyed" migration flow where players can relocate their base for free when their empire is overrun.

## Issues Fixed

### 1. Memory Leak - Orphaned World Cells
**Problem:** When players used the free relocation feature, the old home cell was never cleaned up from the database, causing:
- Orphaned `WorldMapCell` records accumulating over time
- World player counts not decreasing correctly
- Database bloat from abandoned cells

**Solution:** Call `leaveWorld()` before `joinOrCreateWorld()` to properly clean up the old world position, delete orphaned cells, and decrement world player counts.

### 2. Security - No Server-Side Validation
**Problem:** The server trusted the client completely.
**Solution:** Added server-side validation to ensure `userSave.outposts.length === 0` before allowing free relocation.

### 3. Code Clarity - Assumption-Based Logic
**Problem:** The condition `if (type !== BaseType.OUTPOST && baseid === BaseMode.DEFAULT)` was making assumptions about what the client sends rather than checking explicitly.

**Solution:** Changed to `if (type === BaseType.RANDOM)` to directly match what the client sends (from `PopupLostMainBase.as`), making the code more explicit and maintainable.

### 4. Error Handling - Generic Error Messages
**Problem:** When validation failed, the controller's catch block would convert `ClientSafeError` instances into a generic `{ error: 1 }` response, preventing users from seeing the actual error message.

**Solution:** Re-throw `ClientSafeError` instances so the `ErrorInterceptor` middleware can properly format them with user-friendly messages.

## Files Changed

- `server/src/controllers/maproom/v2/migrateBase.ts`
  - Added `leaveWorld()` call before relocation
  - Added server-side validation for outpost count
  - Changed condition to check `BaseType.RANDOM` explicitly
  - Fixed error handling to preserve `ClientSafeError` messages

- `server/src/errors/errors.ts`
  - Added `relocateOutpostErr()` for validation failures
