### PR TITLE
Bug Fix: Ending damage protection now updates outpost HP back to full

### DIFF
--- a/server/src/services/maproom/v2/damageProtection.ts
+++ b/server/src/services/maproom/v2/damageProtection.ts
@@ -78,6 +78,7 @@ export const damageProtection = async (save: Save, mode?: BaseMode) => {
           // Clear expired protection timestamp
           if (protection > 0 && protection <= currentTime) {
             protection = 0;
+            save.damage = 0; 
             persist = true;
           }
 


### PR DESCRIPTION
The damage protection changes forgot to update outpost damage state after damage protection expired. This change fixes it so it should properly update to full HP when expiring. 