### PR TITLE
Add remember email toggle (email only, local storage, cleaner code)

### DIFF
--- a/client/scripts/com/auth/AuthForm.as
+++ b/client/scripts/com/auth/AuthForm.as
@@ -59,9 +59,9 @@ package com.auth
         private var usernameBorder:Sprite;
         private var emailBorder:Sprite;
         private var passwordBorder:Sprite;
-        private var baseEmailY:Number = NaN;
-        private var basePasswordY:Number = NaN;
-private var emailInput:TextField;
+        private var baseEmailY:Number;
+        private var basePasswordY:Number;
+        private var emailInput:TextField;
 
         private var passwordInput:TextField;
 
@@ -965,9 +965,7 @@ private var emailInput:TextField;
             var gap:Number = 20;
             var loginShift:Number = usernameH + gap;
 
-            // Safety: capture base positions if something recreated fields unexpectedly.
-            if (isNaN(baseEmailY) && emailInput) baseEmailY = emailInput.y;
-            if (isNaN(basePasswordY) && passwordInput) basePasswordY = passwordInput.y;
+            // baseEmailY/basePasswordY are captured in handleContentLoaded().
 
             if (isRegisterForm)
             {


### PR DESCRIPTION
_Edit: ignore first commits, the last one is the clean one_

Brief explanation: Adding this feature as discussed with React in the discord. The goal is to save time to those Android users that use the app a lot and have to manually log in with all the credentials. This would make them easy to log it without security concerns. The changes are made using basic core flash functions so it shoud work with AIR without problems

Original Changelog (commit v1 with messy comments and plaintext checkbox)

* Added “Remember email” option with local persistence (email only, no password).
* Implemented basic plaintext checkbox UI.
* Auto-prefill email field on launch when enabled.

Changelog (commit v2):

* Removed extra `RememberEmailStore` class and inlined storage logic into `AuthForm`.
* Replaced plaintext checkbox with a proper Sprite-based checkbox UI.
* Cleaned duplicated variables and simplified state handling (since v1).
* Simplified some comments.

Changelog (commit v3):
* Login UI resized
* Email checkbox improved
* Completely reworked file structure. Other minor improvements in the code and structure + fixes from last commit (Thank React for helping!)

**Changelog (commit v4 - Rework):**
* UI scaling fixed on smaller resolutions
* Other minor bugs fixed related to the switch between login and register
* Code cleaner with comments

**Changelog (commit v5):**
* Removed unnecessary scaling logic and messy code (not perfect but tested and working)
* v6 - Final Version: Cleaner code