### PR TITLE
Map Room 2: Client Performance Optimizations

### DIFF
--- a/client/scripts/com/monsters/maproom_advanced/MapRoom.as
+++ b/client/scripts/com/monsters/maproom_advanced/MapRoom.as
@@ -1404,16 +1404,19 @@ package com.monsters.maproom_advanced
       
       public function Hide() : void
       {
-         if(_open && GLOBAL.mode != GLOBAL.e_BASE_MODE.ATTACK && GLOBAL.mode != GLOBAL.e_BASE_MODE.WMATTACK)
+         if(_open)
          {
             SOUNDS.Play("close");
-            if(_mc.parent)
+            if(_mc && _mc.parent)
             {
                _mc.parent.removeChild(_mc);
             }
             ClearCells();
-            _mc.Cleanup();
-            _mc = null;
+            if(_mc)
+            {
+               _mc.Cleanup();
+               _mc = null;
+            }
          }
          _open = false;
       }

--- a/client/scripts/com/monsters/maproom_advanced/MapRoomPopup.as
+++ b/client/scripts/com/monsters/maproom_advanced/MapRoomPopup.as
@@ -79,6 +79,10 @@ package com.monsters.maproom_advanced
 
       private var _lastBuffCount:Number = -1;
 
+      private var _onHomeClick:Function;
+
+      private var _onViewOnlyBookmarkClick:Function;
+
       public static var s_Instance:MapRoomPopup = null;
       
       public function MapRoomPopup()
@@ -160,11 +164,12 @@ package com.monsters.maproom_advanced
          if(!MapRoom._viewOnly)
          {
             this.bHome.SetupKey("btn_home");
-            this.bHome.addEventListener(MouseEvent.CLICK,function(param1:MouseEvent):void
+            this._onHomeClick = function(param1:MouseEvent):void
             {
                HideBookmarkMenu();
                MapRoom.JumpTo(GLOBAL._mapHome);
-            });
+            };
+            this.bHome.addEventListener(MouseEvent.CLICK, this._onHomeClick);
             this.bHome.buttonMode = true;
             this.bHome.x = mcFrame2.x + 20;
             this.bHome.y = mcFrame2.y + 200;
@@ -183,10 +188,11 @@ package com.monsters.maproom_advanced
          else
          {
             this.bBookmarks.SetupKey("btn_home");
-            this.bBookmarks.addEventListener(MouseEvent.CLICK,function(param1:MouseEvent):void
+            this._onViewOnlyBookmarkClick = function(param1:MouseEvent):void
             {
                MapRoom.JumpTo(MapRoom._inviteLocation);
-            });
+            };
+            this.bBookmarks.addEventListener(MouseEvent.CLICK, this._onViewOnlyBookmarkClick);
             this.bBookmarks.buttonMode = true;
             this.bBookmarks.Enabled = true;
             this.bBookmarks.x = mcFrame2.x + 20;
@@ -533,6 +539,8 @@ package com.monsters.maproom_advanced
       public function Cleanup() : void
       {
          var i:int = 0;
+         this.HideBookmarkMenu();
+
          this._bubble = null;
          if(this._popupInfoMine)
          {
@@ -624,21 +632,25 @@ package com.monsters.maproom_advanced
          this._lastBuffCount = -1;
          if(!MapRoom._viewOnly)
          {
-            this.bHome.removeEventListener(MouseEvent.CLICK,function(param1:MouseEvent):void
+            if(this._onHomeClick != null)
             {
-               HideBookmarkMenu();
-               MapRoom.JumpTo(GLOBAL._mapHome);
-            });
+               this.bHome.removeEventListener(MouseEvent.CLICK, this._onHomeClick);
+               this._onHomeClick = null;
+            }
             this.bJump.removeEventListener(MouseEvent.CLICK,this.JumpPopupShow);
             this.bBookmarks.removeEventListener(MouseEvent.CLICK,this.ShowBookmarkMenu);
          }
          else
          {
-            this.bBookmarks.removeEventListener(MouseEvent.CLICK,function(param1:MouseEvent):void
+            if(this._onViewOnlyBookmarkClick != null)
             {
-               MapRoom.JumpTo(MapRoom._inviteLocation);
-            });
+               this.bBookmarks.removeEventListener(MouseEvent.CLICK, this._onViewOnlyBookmarkClick);
+               this._onViewOnlyBookmarkClick = null;
+            }
          }
+
+         MapRoom.ClearCells();
+         s_Instance = null;
       }
       
       public function Setup() : void


### PR DESCRIPTION
## Summary

This PR significantly improves Map Room 2 client-side performance during panning and cell loading. The changes eliminate unnecessary object allocations, reduce iteration overhead, provide instant visual feedback for the player's home base, and fix critical memory leaks that caused progressive slowdown.

## Changes

### 1. Consolidate Cell Iteration Loops

**Problem:** The `Update()` function iterated over all cells (252 in fullscreen) three separate times per frame:
- Loop 1: Position updates, wrapping, data loading
- Loop 2: Glow alpha reset
- Loop 3: Collecting cells with flinger range

**Solution:** Merged all three loops into a single pass, reducing iterations from ~756 to ~252 per frame.

**Additional optimizations:**
- Pre-compute boundary constants outside the loop (avoids ~1,000 multiplications per frame)
- Reuse `Point` object in `ContainerMove()` instead of allocating 2 new Points per mouse move event

### 2. Cache DisplayBuffs State

**Problem:** `DisplayBuffs()` was called every frame during panning, performing full DOM teardown and rebuild of buff icons even though buffs rarely change.

**Solution:** Cache the powerup count and early-return if unchanged:
```actionscript
if (powerup == this._lastBuffCount) return;
this._lastBuffCount = powerup;
```

**Impact:** Eliminates unnecessary DOM manipulation, event listener removal/addition, and MovieClip allocations during panning.

### 3. Eliminate CellData Allocations in Range Highlighting

**Problem:** `GetCellsInRange()` allocated hundreds of `CellData` wrapper objects per frame:
- Range 10 = 330 objects per base
- With 3 bases visible = ~1,000 allocations per frame
- All immediately discarded, causing GC pressure

**Solution:** Created `ApplyRangeHighlighting()` that calculates hex positions and applies highlighting in a single pass without intermediate objects.

| Before | After |
|--------|-------|
| `GetCellsInRange()` returns `Vector.<CellData>` | Direct highlighting, no allocations |
| `ShowRange()` iterates and applies | Combined into one function |

**Note:** `GetCellsInRange()` is preserved for popup dialogs that need the data structure (one-time cost, not per-frame).

### 4. Instant Home Base Highlighting

**Problem:** Home base range highlighting was delayed ~1 second until zone data loaded from the server.

**Solution:** Use locally-available data to highlight immediately:
```actionscript
flingerRange = BUILDING5.getFlingerRange(GLOBAL._playerFlingerLevel.Get(), true);
this.ApplyRangeHighlighting(GLOBAL._mapHome.x, GLOBAL._mapHome.y, flingerRange);
```

**Impact:** Home base and its attack range are highlighted on the first frame, before server response.

### 5. Fix Memory Leaks Causing Progressive Slowdown

**Problem:** The game progressively slowed down after viewing/attacking bases due to multiple memory leaks:

1. **Anonymous event listeners never removed** - Using anonymous functions in `removeEventListener()` doesn't work; each creates a new function object that never matches the original
2. **Singleton not cleared** - `MapRoomPopup.s_Instance` was never nulled, keeping old instances in memory
3. **Zone cache never cleared on attack/view** - `MapRoom.Hide()` had a condition that skipped cleanup when in ATTACK mode
4. **Bookmark menu listeners not cleaned up**

**Solutions:**

**Fixed anonymous listeners:**
```actionscript
// Before - BROKEN: anonymous function never matches
this.bHome.removeEventListener(MouseEvent.CLICK, function(e):void { ... });

// After - Store reference, remove same reference
this._onHomeClick = function(e):void { ... };
this.bHome.addEventListener(MouseEvent.CLICK, this._onHomeClick);
// In Cleanup:
this.bHome.removeEventListener(MouseEvent.CLICK, this._onHomeClick);
```

**Clear singleton and zone cache:**
```actionscript
// At end of Cleanup()
MapRoom.ClearCells();
s_Instance = null;
```

**Always cleanup on Hide (MapRoom.as):**
```actionscript
// Before - Cleanup SKIPPED during attack!
if(_open && GLOBAL.mode != GLOBAL.e_BASE_MODE.ATTACK && GLOBAL.mode != GLOBAL.e_BASE_MODE.WMATTACK)

// After - Always cleanup
if(_open)
```

## Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| Cell iterations per frame | ~756 | ~252 |
| Point allocations per mouse move | 2 | 0 |
| CellData allocations per frame | ~1,000 | 0 |
| DisplayBuffs DOM operations per frame | ~10-20 | 0 (when unchanged) |
| Home base highlight delay | ~1 sec | Instant |
| Memory leaks on attack/view | Yes | Fixed |
