### PR TITLE
Flinger Level Cap & Map Room Range Highlighting

### DIFF
--- a/client/scripts/GLOBAL.as
+++ b/client/scripts/GLOBAL.as
@@ -704,16 +704,9 @@ package
             "r4":new SecNum(0),
             "time":new SecNum(97200),
             "re":[[14,1,4],[11,1,1]]
-         },{
-            "r1":new SecNum(1247840),
-            "r2":new SecNum(1247840),
-            "r3":new SecNum(623920),
-            "r4":new SecNum(0),
-            "time":new SecNum(97200),
-            "re":[[14,1,4],[11,1,1]]
          }];
-         _buildingProps[4].hp = [4000,8000,16000,28000,28000];
-         _buildingProps[4].capacity = [500,1000,1750,2250,3000,4000,4000];
+         _buildingProps[4].hp = [4000,8000,16000,28000];
+         _buildingProps[4].capacity = [500,1000,1750,2250,3000,4000];
       }
 
       public static function SetBuildingProps():void

--- a/client/scripts/com/monsters/maproom_advanced/MapRoomPopup.as
+++ b/client/scripts/com/monsters/maproom_advanced/MapRoomPopup.as
@@ -1104,9 +1104,12 @@ package com.monsters.maproom_advanced
          }
       }
 
-      /*
+      /**
        * Applies range highlighting directly without allocating intermediate objects.
        * This is an optimized version that combines GetCellsInRange + highlighting into one pass.
+       *
+       * Cells within base flinger range get full highlight (alpha 0.5).
+       * Cells in bonus range from Alliance Declare War powerup get dimmer highlight (alpha 0.35).
        */
       private function ApplyRangeHighlighting(startOffsetX:int, startOffsetY:int, range:int):void
       {
@@ -1114,6 +1117,12 @@ package com.monsters.maproom_advanced
          var distance:int;
          var currentOffsetX:int;
          var currentOffsetY:int;
+         var baseRange:int = range;
+
+         if (POWERUPS.CheckPowers(POWERUPS.ALLIANCE_DECLAREWAR, "NORMAL"))
+         {
+            baseRange = range - 2;
+         }
 
          var startAxialQ:int = startOffsetX;
          var startAxialR:int = startOffsetY - (startOffsetX - (startOffsetX & 1)) / 2;
@@ -1134,7 +1143,7 @@ package com.monsters.maproom_advanced
 
                if (cell && !cell._water) {
                   if (!cell._over) {
-                     cell.mc.mcGlow.alpha = distance <= 10 ? 0.5 : Math.max(cell.mc.mcGlow.alpha, 0.35);
+                     cell.mc.mcGlow.alpha = distance <= baseRange ? 0.5 : Math.max(cell.mc.mcGlow.alpha, 0.35);
                   }
                   cell._inRange = true;
                }


### PR DESCRIPTION
## Summary
Implements proper flinger level restrictions based on Map Room version and fixes range highlighting behavior for the Alliance Declare War powerup.

## Changes

### Flinger Level Cap by Map Room Version
- **MapRoom2**: Flinger max level is **4** (range 10 cells)
- **MapRoom3**: Flinger max level is **5** (range 12 cells)

This mirrors the existing pattern used for Housing (max level 6 in MR2, level 10 in MR3).

#### Files Modified:
- `GLOBAL.as` - Updated `changeNotMaproom3SpecificBuildings()` to limit flinger costs array to 4 entries when not in MapRoom3

### Range Highlighting Fix
Fixed the "dimmer" highlight cells behavior in the Map Room:
- **Base flinger range**: Full highlight (alpha 0.5)
- **Bonus range from Alliance Declare War powerup (+2)**: Dimmer highlight (alpha 0.35)

Previously, the dimmer cells would always show for ranges beyond 10, regardless of whether the powerup was active. Now they only appear when the powerup provides bonus range.

#### Files Modified:
- `MapRoomPopup.as` - Updated `ApplyRangeHighlighting()` to dynamically calculate base range vs powerup bonus range

### Code Cleanup
Removed redundant flinger level capping code that was superseded by the building props approach:
- `MapRoomPopup.as` - Removed manual flinger level and outpost range capping
- `BASE.as` - Removed custom flinger check from `CanUpgrade()` (no longer needed)
- `BUILDINGOPTIONSPOPUP.as` - Removed custom flinger check and unused import

## Technical Details

### How Flinger Level Restriction Works
The game uses `changeNotMaproom3SpecificBuildings()` to modify building properties when NOT in MapRoom3. By setting `_buildingProps[4].costs` to only 4 entries (instead of 5), the flinger naturally shows "Fully Upgraded" at level 4 in MapRoom2.

When the player upgrades to MapRoom3, `SetBuildingProps()` is called again and uses the full `YARD_PROPS` which includes level 5 costs.

### Flinger Range Formula
```
Main Yard: range = 2 + (2 × level)
  - Level 4: range 10
  - Level 5: range 12

Outpost: range = level
  - Level 4: range 4
  - Level 5: range 5
```

### Alliance Declare War Powerup
Adds +2 to flinger range when active. The highlighting now properly distinguishes between base range and bonus range visually.
