### PR TITLE
Deobfuscate Variable Names in PATHING.as (+Documenting Pathfinding System)

### DIFF
--- a/client/scripts/com/monsters/monsters/MonsterBase.as
+++ b/client/scripts/com/monsters/monsters/MonsterBase.as
@@ -1172,29 +1172,25 @@ package com.monsters.monsters
          this._targetCreep = null;
       }
       
-      public function findTarget(param1:int = 0) : void
+      public function findTarget(targetGroup:int = 0) : void
       {
-         var _loc3_:Object = null;
-         var _loc4_:BFOUNDATION = null;
-         var _loc5_:BFOUNDATION = null;
-         var _loc6_:Point = null;
-         var _loc7_:Boolean = false;
-         var _loc8_:Point = null;
-         var _loc9_:Point = null;
-         var _loc10_:int = 0;
-         var _loc12_:* = undefined;
-         var _loc13_:Bunker = null;
-         var _loc14_:Boolean = false;
-         var _loc15_:int = 0;
-         var _loc16_:Point = null;
-         var _loc17_:int = 0;
-         var _loc18_:int = 0;
-         var _loc19_:int = 0;
-         var _loc20_:Number = NaN;
-         var _loc21_:Number = NaN;
-         var _loc22_:Point = null;
-         var _loc2_:int = getTimer();
-         var _loc11_:Array = [];
+         var building:BFOUNDATION = null;
+         var startPoint:Point = null;
+         var targetPoint:Point = null;
+         var distance:int = 0;
+         var bunker:* = undefined;
+         var huntBunker:Bunker = null;
+         var bunkerUsed:Boolean = false;
+         var idx:int = 0;
+         var burrowWaypoint:Point = null;
+         var randSide:int = 0;
+         var height:int = 0;
+         var width:int = 0;
+         var randAngle:Number = NaN;
+         var randRadius:Number = NaN;
+         var flyWaypoint:Point = null;
+         var startTime:int = getTimer();
+         var allTargets:Array = [];
          this._looking = true;
          if(this._behaviour == k_sBHVR_HUNT && (CREATURES._creatureCount > 0 || CREATURES._hasLivingGuardian))
          {
@@ -1208,61 +1204,61 @@ package com.monsters.monsters
                this._targetCenter = this._targetCreep._tmpPoint;
             }
          }
-         _loc8_ = PATHING.FromISO(this._tmpPoint);
-         if(param1 == 2)
+         startPoint = PATHING.FromISO(this._tmpPoint);
+         if(targetGroup == 2)
          {
-            for each(_loc4_ in BASE._buildingsWalls)
+            for each(building in BASE._buildingsWalls)
             {
-               if(!_loc4_._destroyed && _loc4_.health > 0)
+               if(!building._destroyed && building.health > 0)
                {
-                  _loc9_ = GRID.FromISO(_loc4_._mc.x,_loc4_._mc.y + _loc4_._middle);
-                  _loc10_ = GLOBAL.QuickDistance(_loc8_,_loc9_) - _loc4_._middle;
-                  _loc11_.push({
-                     "building":_loc4_,
-                     "distance":_loc10_
+                  targetPoint = GRID.FromISO(building._mc.x,building._mc.y + building._middle);
+                  distance = GLOBAL.QuickDistance(startPoint,targetPoint) - building._middle;
+                  allTargets.push({
+                     "building":building,
+                     "distance":distance
                   });
                }
             }
          }
-         else if(param1 == 3)
+         else if(targetGroup == 3)
          {
-            for each(_loc4_ in BASE._buildingsMain)
+            for each(building in BASE._buildingsMain)
             {
-               if(_loc4_.health > 0 && _loc4_ is ILootable && !_loc4_._looted)
+               if(building.health > 0 && building is ILootable && !building._looted)
                {
-                  _loc9_ = GRID.FromISO(_loc4_._mc.x,_loc4_._mc.y + _loc4_._middle);
-                  _loc10_ = GLOBAL.QuickDistance(_loc8_,_loc9_) - _loc4_._middle;
-                  _loc11_.push({
-                     "building":_loc4_,
-                     "distance":_loc10_
+                  targetPoint = GRID.FromISO(building._mc.x,building._mc.y + building._middle);
+                  distance = GLOBAL.QuickDistance(startPoint,targetPoint) - building._middle;
+                  allTargets.push({
+                     "building":building,
+                     "distance":distance
                   });
                }
             }
          }
-         else if(param1 == 4)
+         else if(targetGroup == 4)
          {
-            for each(_loc4_ in BASE._buildingsTowers)
+            for each(building in BASE._buildingsTowers)
             {
-               if(MONSTERBUNKER.isBunkerBuilding(_loc4_._type))
+               if(MONSTERBUNKER.isBunkerBuilding(building._type))
                {
-                  if((_loc12_ = _loc4_).health > 0 && (_loc12_._used > 0 || _loc12_._monstersDispatchedTotal > 0))
+                  if((bunker = building).health > 0 && (bunker._used > 0 || bunker._monstersDispatchedTotal > 0))
                   {
-                     _loc9_ = GRID.FromISO(_loc4_._mc.x,_loc4_._mc.y + _loc4_._middle);
-                     _loc10_ = GLOBAL.QuickDistance(_loc8_,_loc9_) - _loc4_._middle;
-                     _loc11_.push({
-                        "building":_loc4_,
-                        "distance":_loc10_,
+                     targetPoint = GRID.FromISO(building._mc.x,building._mc.y + building._middle);
+                     distance = GLOBAL.QuickDistance(startPoint,targetPoint) - building._middle;
+                     allTargets.push({
+                        "building":building,
+                        "distance":distance,
                         "expand":false
                      });
                   }
                }
-               else if(_loc4_._class != "trap" && _loc4_.health > 0 && !(_loc4_ as BTOWER).isJard)
+               else if(building._class != "trap" && building.health > 0 && !(building as BTOWER).isJard)
                {
-                  _loc9_ = GRID.FromISO(_loc4_._mc.x,_loc4_._mc.y + _loc4_._middle);
-                  _loc10_ = GLOBAL.QuickDistance(_loc8_,_loc9_) - _loc4_._middle;
-                  _loc11_.push({
-                     "building":_loc4_,
-                     "distance":_loc10_,
+                  targetPoint = GRID.FromISO(building._mc.x,building._mc.y + building._middle);
+                  distance = GLOBAL.QuickDistance(startPoint,targetPoint) - building._middle;
+                  allTargets.push({
+                     "building":building,
+                     "distance":distance,
                      "expand":false
                   });
                }
@@ -1270,110 +1266,110 @@ package com.monsters.monsters
          }
          else if(this._targetGroup == 6)
          {
-            for each(_loc13_ in BASE._buildingsBunkers)
+            for each(huntBunker in BASE._buildingsBunkers)
             {
-               if(_loc13_.health > 0)
+               if(huntBunker.health > 0)
                {
-                  _loc14_ = false;
-                  if(_loc13_._type == 22)
+                  bunkerUsed = false;
+                  if(huntBunker._type == 22)
                   {
-                     if(_loc13_._used > 0 || _loc13_._monstersDispatchedTotal > 0)
+                     if(huntBunker._used > 0 || huntBunker._monstersDispatchedTotal > 0)
                      {
-                        _loc14_ = true;
+                        bunkerUsed = true;
                      }
                   }
-                  if(_loc13_._type == 128)
+                  if(huntBunker._type == 128)
                   {
                      if(HOUSING._housingUsed.Get() > 0)
                      {
-                        _loc14_ = true;
+                        bunkerUsed = true;
                      }
                   }
-                  if(_loc14_)
+                  if(bunkerUsed)
                   {
-                     _loc9_ = GRID.FromISO(_loc13_._mc.x,_loc13_._mc.y + _loc13_._middle);
-                     _loc10_ = GLOBAL.QuickDistance(_loc8_,_loc9_) - _loc13_._middle;
-                     _loc11_.push({
-                        "building":_loc13_,
-                        "distance":_loc10_,
+                     targetPoint = GRID.FromISO(huntBunker._mc.x,huntBunker._mc.y + huntBunker._middle);
+                     distance = GLOBAL.QuickDistance(startPoint,targetPoint) - huntBunker._middle;
+                     allTargets.push({
+                        "building":huntBunker,
+                        "distance":distance,
                         "expand":false
                      });
                   }
                }
             }
          }
-         if(_loc11_.length == 0 || param1 == 1)
+         if(allTargets.length == 0 || targetGroup == 1)
          {
-            for each(_loc4_ in BASE._buildingsMain)
+            for each(building in BASE._buildingsMain)
             {
-               if(_loc4_._class != "decoration" && _loc4_._class != "immovable" && _loc4_.health > 0 && _loc4_._class != "enemy")
+               if(building._class != "decoration" && building._class != "immovable" && building.health > 0 && building._class != "enemy")
                {
                   if(this._targetGroup != 4)
                   {
                      this._targetGroup = 1;
                   }
-                  if(_loc4_._class == "tower" && !MONSTERBUNKER.isBunkerBuilding(_loc4_._type))
+                  if(building._class == "tower" && !MONSTERBUNKER.isBunkerBuilding(building._type))
                   {
-                     if((_loc4_ as BTOWER).isJard)
+                     if((building as BTOWER).isJard)
                      {
                         continue;
                      }
                   }
-                  _loc9_ = GRID.FromISO(_loc4_._mc.x,_loc4_._mc.y + _loc4_._middle);
-                  _loc10_ = GLOBAL.QuickDistance(_loc8_,_loc9_) - _loc4_._middle;
-                  _loc11_.push({
-                     "building":_loc4_,
-                     "distance":_loc10_,
+                  targetPoint = GRID.FromISO(building._mc.x,building._mc.y + building._middle);
+                  distance = GLOBAL.QuickDistance(startPoint,targetPoint) - building._middle;
+                  allTargets.push({
+                     "building":building,
+                     "distance":distance,
                      "expand":true
                   });
                }
             }
          }
-         if(_loc11_.length == 0 && !this._targetCreep)
+         if(allTargets.length == 0 && !this._targetCreep)
          {
             this.changeModeRetreat();
          }
          else
          {
-            _loc11_.sortOn("distance",Array.NUMERIC);
-            _loc15_ = 0;
+            allTargets.sortOn("distance",Array.NUMERIC);
+            idx = 0;
             if(this._movement == "burrow")
             {
                this._hasTarget = true;
                this._hasPath = true;
-               _loc16_ = GRID.FromISO(_loc11_[_loc15_].building._mc.x,_loc11_[_loc15_].building._mc.y);
-               _loc17_ = int(Math.random() * 4);
-               _loc18_ = int(_loc11_[_loc15_].building._footprint[0].height);
-               _loc19_ = int(_loc11_[_loc15_].building._footprint[0].width);
-               if(_loc17_ == 0)
+               burrowWaypoint = GRID.FromISO(allTargets[idx].building._mc.x,allTargets[idx].building._mc.y);
+               randSide = int(Math.random() * 4);
+               height = int(allTargets[idx].building._footprint[0].height);
+               width = int(allTargets[idx].building._footprint[0].width);
+               if(randSide == 0)
                {
-                  _loc16_.x += Math.random() * _loc18_;
-                  _loc16_.y += _loc19_;
+                  burrowWaypoint.x += Math.random() * height;
+                  burrowWaypoint.y += width;
                }
-               else if(_loc17_ == 1)
+               else if(randSide == 1)
                {
-                  _loc16_.x += _loc18_;
-                  _loc16_.y += _loc19_;
+                  burrowWaypoint.x += height;
+                  burrowWaypoint.y += width;
                }
-               else if(_loc17_ == 2)
+               else if(randSide == 2)
                {
-                  _loc16_.x += _loc18_ - Math.random() * _loc18_ / 2;
-                  _loc16_.y -= _loc19_ / 4;
+                  burrowWaypoint.x += height - Math.random() * height / 2;
+                  burrowWaypoint.y -= width / 4;
                }
-               else if(_loc17_ == 3)
+               else if(randSide == 3)
                {
-                  _loc16_.x -= _loc18_ / 4;
-                  _loc16_.y += _loc19_ - Math.random() * _loc19_ / 2;
+                  burrowWaypoint.x -= height / 4;
+                  burrowWaypoint.y += width - Math.random() * width / 2;
                }
-               this._waypoints = [GRID.ToISO(_loc16_.x,_loc16_.y,0)];
+               this._waypoints = [GRID.ToISO(burrowWaypoint.x,burrowWaypoint.y,0)];
                this._targetPosition = this._waypoints[0];
-               this._targetBuilding = _loc11_[_loc15_].building;
+               this._targetBuilding = allTargets[idx].building;
             }
             else if(this._movement == "fly" || this._movement == "fly_low")
             {
                this._hasTarget = true;
                this._hasPath = true;
-               this._targetBuilding = _loc11_[_loc15_].building;
+               this._targetBuilding = allTargets[idx].building;
                this._targetCenter = this._targetBuilding._position;
                if(this._creatureID == "IC5")
                {
@@ -1388,10 +1384,10 @@ package com.monsters.monsters
                      else
                      {
                         this._movement = "fly";
-                        _loc20_ = (_loc20_ = (_loc20_ = Math.atan2(this._tmpPoint.y - this._targetCenter.y,this._tmpPoint.x - this._targetCenter.x) * 57.2957795) + (Math.random() * 40 - 20)) / (180 / Math.PI);
-                        _loc21_ = 30 + Math.random() * 10;
-                        _loc22_ = new Point(this._targetCenter.x + Math.cos(_loc20_) * _loc21_,this._targetCenter.y + Math.sin(_loc20_) * _loc21_);
-                        this._waypoints = [_loc22_];
+                        randAngle = (randAngle = (randAngle = Math.atan2(this._tmpPoint.y - this._targetCenter.y,this._tmpPoint.x - this._targetCenter.x) * 57.2957795) + (Math.random() * 40 - 20)) / (180 / Math.PI);
+                        randRadius = 30 + Math.random() * 10;
+                        flyWaypoint = new Point(this._targetCenter.x + Math.cos(randAngle) * randRadius,this._targetCenter.y + Math.sin(randAngle) * randRadius);
+                        this._waypoints = [flyWaypoint];
                         this._targetPosition = this._waypoints[0];
                      }
                   }
@@ -1404,46 +1400,46 @@ package com.monsters.monsters
                }
                else
                {
-                  _loc20_ = (_loc20_ = (_loc20_ = Math.atan2(this._tmpPoint.y - this._targetCenter.y,this._tmpPoint.x - this._targetCenter.x) * 57.2957795) + (Math.random() * 40 - 20)) / (180 / Math.PI);
-                  _loc21_ = 120 + Math.random() * 10;
-                  _loc22_ = new Point(this._targetCenter.x + Math.cos(_loc20_) * _loc21_ * 1.7,this._targetCenter.y + Math.sin(_loc20_) * _loc21_);
-                  this._waypoints = [_loc22_];
+                  randAngle = (randAngle = (randAngle = Math.atan2(this._tmpPoint.y - this._targetCenter.y,this._tmpPoint.x - this._targetCenter.x) * 57.2957795) + (Math.random() * 40 - 20)) / (180 / Math.PI);
+                  randRadius = 120 + Math.random() * 10;
+                  flyWaypoint = new Point(this._targetCenter.x + Math.cos(randAngle) * randRadius * 1.7,this._targetCenter.y + Math.sin(randAngle) * randRadius);
+                  this._waypoints = [flyWaypoint];
                   this._targetPosition = this._waypoints[0];
                }
             }
             else if(GLOBAL._catchup)
             {
-               this.WaypointTo(new Point(_loc11_[0].building._mc.x,_loc11_[0].building._mc.y),_loc11_[0].building);
+               this.WaypointTo(new Point(allTargets[0].building._mc.x,allTargets[0].building._mc.y),allTargets[0].building);
             }
             else
             {
-               _loc15_ = 0;
-               while(_loc15_ < 2)
+               idx = 0;
+               while(idx < 2)
                {
-                  if(_loc11_.length > _loc15_)
+                  if(allTargets.length > idx)
                   {
-                     this.WaypointTo(new Point(_loc11_[_loc15_].building._mc.x,_loc11_[_loc15_].building._mc.y),_loc11_[_loc15_].building);
+                     this.WaypointTo(new Point(allTargets[idx].building._mc.x,allTargets[idx].building._mc.y),allTargets[idx].building);
                   }
-                  _loc15_++;
+                  idx++;
                }
             }
          }
       }
       
-      public function WaypointTo(param1:Point, param2:BFOUNDATION = null) : void
+      public function WaypointTo(targetPoint:Point, targetBuilding:BFOUNDATION = null) : void
       {
-         var _loc3_:Boolean = false;
+         var ignoreWalls:Boolean = false;
          if(this._behaviour === k_sBHVR_JUICE || this._behaviour === k_sBHVR_HOUSING || this._behaviour === k_sBHVR_PEN || this._behaviour === k_sBHVR_DEFEND || this._behaviour === k_sBHVR_FEED || this._movement === k_sBHVR_JUMP || this._behaviour === k_sBHVR_DECOY)
          {
-            _loc3_ = true;
+            ignoreWalls = true;
          }
-         if(param2)
+         if(targetBuilding)
          {
-            PATHING.GetPath(this._tmpPoint,new Rectangle(int(param1.x),int(param1.y),param2._footprint[0].width,param2._footprint[0].height),this.setWaypoints,_loc3_,param2);
+            PATHING.GetPath(this._tmpPoint,new Rectangle(int(targetPoint.x),int(targetPoint.y),targetBuilding._footprint[0].width,targetBuilding._footprint[0].height),this.setWaypoints,ignoreWalls,targetBuilding);
          }
          else
          {
-            PATHING.GetPath(this._tmpPoint,new Rectangle(int(param1.x),int(param1.y),10,10),this.setWaypoints,_loc3_);
+            PATHING.GetPath(this._tmpPoint,new Rectangle(int(targetPoint.x),int(targetPoint.y),10,10),this.setWaypoints,ignoreWalls);
          }
       }
       
@@ -1515,10 +1511,10 @@ package com.monsters.monsters
          this.m_juiceReady = true;
       }
       
-      public function setWaypoints(param1:Array, param2:BFOUNDATION = null, param3:Boolean = false) : void
+      public function setWaypoints(waypoints:Array, targetBuilding:BFOUNDATION = null, pathingWasCleared:Boolean = false) : void
       {
-         var _loc4_:Boolean = false;
-         if(param3)
+         var moveToTarget:Boolean = false;
+         if(pathingWasCleared)
          {
             switch(this._behaviour)
             {
@@ -1534,33 +1530,33 @@ package com.monsters.monsters
          }
          else
          {
-            _loc4_ = false;
-            if(param1.length < this._waypoints.length)
+            moveToTarget = false;
+            if(waypoints.length < this._waypoints.length)
             {
-               _loc4_ = true;
+               moveToTarget = true;
             }
-            if(_loc4_ && param2 && param2._class == "wall" && this._targetGroup != 2)
+            if(moveToTarget && targetBuilding && targetBuilding._class == "wall" && this._targetGroup != 2)
             {
-               _loc4_ = false;
+               moveToTarget = false;
             }
             if(!this._hasTarget)
             {
-               _loc4_ = true;
+               moveToTarget = true;
             }
             if(this._behaviour == k_sBHVR_DEFEND)
             {
-               _loc4_ = true;
+               moveToTarget = true;
             }
-            if(_loc4_)
+            if(moveToTarget)
             {
                this._hasTarget = true;
                this._atTarget = false;
                this._hasPath = true;
-               this._waypoints = param1;
+               this._waypoints = waypoints;
                this._targetPosition = this._waypoints[0];
-               if(param2)
+               if(targetBuilding)
                {
-                  this._targetBuilding = param2;
+                  this._targetBuilding = targetBuilding;
                }
             }
             this._looking = false;

--- a/client/scripts/com/monsters/pathing/PATHING.as
+++ b/client/scripts/com/monsters/pathing/PATHING.as
@@ -54,281 +54,281 @@ package com.monsters.pathing
 
       public static function Setup():void
       {
-         var _loc2_:PATHINGobject = null;
-         var _loc3_:int = 0;
-         var _loc4_:int = 0;
-         var _loc5_:int = 0;
-         var _loc1_:int = getTimer();
-         _loc4_ = 0;
-         while (_loc4_ < _gridWidth)
+         var gridSpace:PATHINGobject = null;
+         var gridKey:int = 0;
+         var widthIdx:int = 0;
+         var heightIdx:int = 0;
+         var startTime:int = getTimer();
+         widthIdx = 0;
+         while (widthIdx < _gridWidth)
          {
-            _loc5_ = 0;
-            while (_loc5_ < _gridHeight)
+            heightIdx = 0;
+            while (heightIdx < _gridHeight)
             {
-               _loc3_ = _loc4_ * 1000 + _loc5_;
-               _loc2_ = new PATHINGobject();
-               _loc2_.pointX = _loc4_;
-               _loc2_.pointY = _loc5_;
-               _loc2_.cost = 10;
-               _costs[_loc3_] = _loc2_;
-               _loc5_ += 1;
+               gridKey = widthIdx * 1000 + heightIdx;
+               gridSpace = new PATHINGobject();
+               gridSpace.pointX = widthIdx;
+               gridSpace.pointY = heightIdx;
+               gridSpace.cost = 10;
+               _costs[gridKey] = gridSpace;
+               heightIdx += 1;
             }
-            _loc4_ += 1;
+            widthIdx += 1;
          }
          _poolPathing = new Vector.<PATHINGobject>();
          _poolPathingB = new Vector.<PATHINGobject>();
          _poolPathingLength = 0;
       }
 
-      public static function Cost(param1:Point, param2:Rectangle, param3:int):Rectangle
+      public static function Cost(buildingPoint:Point, buildingRegion:Rectangle, regionCost:int):Rectangle
       {
-         var _loc4_:Point = null;
-         var _loc5_:Point = null;
-         var _loc6_:int = 0;
-         var _loc7_:int = 0;
-         var _loc8_:int = 0;
-         var _loc9_:Rectangle = null;
-         var _loc10_:int = 0;
-         _loc4_ = FromISO(param1);
-         _loc4_.x += param2.x;
-         _loc4_.y += param2.y;
-         _loc5_ = GlobalLocal(_loc4_);
-         _loc9_ = new Rectangle(_loc5_.x, _loc5_.y, param2.width * 0.1, param2.height * 0.1);
-         _loc7_ = _loc9_.x;
-         while (_loc7_ < _loc9_.x + _loc9_.width)
+         var convertPoint:Point = null;
+         var gridPoint:Point = null;
+         var gridKey:int = 0;
+         var xIdx:int = 0;
+         var yIdx:int = 0;
+         var gridRegion:Rectangle = null;
+         var cost:int = 0;
+         convertPoint = FromISO(buildingPoint);
+         convertPoint.x += buildingRegion.x;
+         convertPoint.y += buildingRegion.y;
+         gridPoint = GlobalLocal(convertPoint);
+         gridRegion = new Rectangle(gridPoint.x, gridPoint.y, buildingRegion.width * 0.1, buildingRegion.height * 0.1);
+         xIdx = gridRegion.x;
+         while (xIdx < gridRegion.x + gridRegion.width)
          {
-            _loc8_ = _loc9_.y;
-            while (_loc8_ < _loc9_.y + _loc9_.height)
+            yIdx = gridRegion.y;
+            while (yIdx < gridRegion.y + gridRegion.height)
             {
-               _loc6_ = _loc7_ * 1000 + _loc8_;
-               if (_costs[_loc6_])
+               gridKey = xIdx * 1000 + yIdx;
+               if (_costs[gridKey])
                {
-                  _loc10_ = int(_costs[_loc6_].cost);
-                  _costs[_loc6_].cost += param3;
-                  if (_costs[_loc6_].cost < 2)
+                  cost = int(_costs[gridKey].cost);
+                  _costs[gridKey].cost += regionCost;
+                  if (_costs[gridKey].cost < 2)
                   {
-                     _costs[_loc6_].cost = 2;
+                     _costs[gridKey].cost = 2;
                   }
                }
-               _loc8_ += 1;
+               yIdx += 1;
             }
-            _loc7_ += 1;
+            xIdx += 1;
          }
-         return _loc9_;
+         return gridRegion;
       }
 
-      public static function RegisterBuilding(param1:Rectangle, param2:BFOUNDATION, param3:Boolean):void
+      public static function RegisterBuilding(region:Rectangle, building:BFOUNDATION, register:Boolean):void
       {
-         var _loc4_:Point = null;
-         var _loc5_:int = 0;
-         var _loc6_:int = 0;
-         var _loc7_:int = 0;
-         _loc4_ = GlobalLocal(FromISO(new Point(param1.x, param1.y)));
-         param1.width *= 0.1;
-         param1.height *= 0.1;
-         _loc6_ = _loc4_.x;
-         while (_loc6_ < _loc4_.x + param1.width)
+         var gridEndPoint:Point = null;
+         var gridKey:int = 0;
+         var xIdx:int = 0;
+         var yIdx:int = 0;
+         gridEndPoint = GlobalLocal(FromISO(new Point(region.x, region.y)));
+         region.width *= 0.1;
+         region.height *= 0.1;
+         xIdx = gridEndPoint.x;
+         while (xIdx < gridEndPoint.x + region.width)
          {
-            _loc7_ = _loc4_.y;
-            while (_loc7_ < _loc4_.y + param1.height)
+            yIdx = gridEndPoint.y;
+            while (yIdx < gridEndPoint.y + region.height)
             {
-               _loc5_ = _loc6_ * 1000 + _loc7_;
-               if (_costs[_loc5_])
+               gridKey = xIdx * 1000 + yIdx;
+               if (_costs[gridKey])
                {
-                  if (param3)
+                  if (register)
                   {
-                     _costs[_loc5_].building = param2;
+                     _costs[gridKey].building = building;
                   }
                   else
                   {
-                     delete _costs[_loc5_].building;
+                     delete _costs[gridKey].building;
                   }
                }
-               _loc7_ += 1;
+               yIdx += 1;
             }
-            _loc6_ += 1;
+            xIdx += 1;
          }
       }
 
       public static function Tick():void
       {
-         var _loc5_:Point = null;
-         var _loc6_:int = 0;
-         var _loc7_:int = 0;
-         var _loc8_:BFOUNDATION = null;
-         var _loc9_:Array = null;
-         var _loc10_:Vector.<Object> = null;
-         var _loc1_:int = getTimer();
-         var _loc2_:int = 0;
-         var _loc3_:int = 0;
-         var _loc4_:int = 0;
+         var buildingPoint:Point = null;
+         var widthIdx:int = 0;
+         var heightIdx:int = 0;
+         var building:BFOUNDATION = null;
+         var regionCostArray:Array = null;
+         var allBuildings:Vector.<Object> = null;
+         var startTime:int = getTimer();
+         var elapsedTime:int = 0;
+         var elapsedTime2:int = 0;
+         var elapsedTime3:int = 0;
          if (_resetRequested)
          {
             _resetRequested = false;
-            _loc5_ = new Point(0, 0);
+            buildingPoint = new Point(0, 0);
             Clear();
-            _loc6_ = 0;
-            while (_loc6_ < _gridWidth)
+            widthIdx = 0;
+            while (widthIdx < _gridWidth)
             {
-               _loc7_ = 0;
-               while (_loc7_ < _gridHeight)
+               heightIdx = 0;
+               while (heightIdx < _gridHeight)
                {
-                  _costs[_loc6_ * 1000 + _loc7_].cost = 10;
-                  _loc7_ += 1;
+                  _costs[widthIdx * 1000 + heightIdx].cost = 10;
+                  heightIdx += 1;
                }
-               _loc6_ += 1;
+               widthIdx += 1;
             }
-            _loc2_ = getTimer() - _loc1_;
-            _loc10_ = InstanceManager.getInstancesByClass(BFOUNDATION);
-            for each (_loc8_ in _loc10_)
+            elapsedTime = getTimer() - startTime;
+            allBuildings = InstanceManager.getInstancesByClass(BFOUNDATION);
+            for each (building in allBuildings)
             {
-               if (Boolean(_loc8_._gridCost) && (_loc8_.health > 0 || _loc8_ is BMUSHROOM))
+               if (Boolean(building._gridCost) && (building.health > 0 || building is BMUSHROOM))
                {
-                  for each (_loc9_ in _loc8_._gridCost)
+                  for each (regionCostArray in building._gridCost)
                   {
-                     _loc5_.x = _loc8_.x;
-                     _loc5_.y = _loc8_.y;
-                     PATHING.Cost(_loc5_, _loc9_[0], _loc9_[1]);
+                     buildingPoint.x = building.x;
+                     buildingPoint.y = building.y;
+                     PATHING.Cost(buildingPoint, regionCostArray[0], regionCostArray[1]);
                   }
                }
             }
-            _loc3_ = getTimer() - _loc1_;
-            _loc4_ = getTimer() - _loc1_;
+            elapsedTime2 = getTimer() - startTime;
+            elapsedTime3 = getTimer() - startTime;
          }
          ProcessFlood();
       }
 
-      public static function GetPath(param1:Point, param2:Rectangle, param3:Function = null, param4:Boolean = false, param5:BFOUNDATION = null):Array
+      public static function GetPath(startPoint:Point, targetRect:Rectangle, callback:Function = null, ignoreWalls:Boolean = false, targetBuilding:BFOUNDATION = null):Array
       {
-         var _loc6_:Point = null;
-         var _loc7_:Rectangle = null;
-         var _loc8_:Point = null;
-         var _loc9_:Point = null;
-         var _loc10_:Point = null;
-         _loc9_ = param1;
-         _loc10_ = new Point(param2.x, param2.y);
-         param1.x = int(param1.x);
-         param1.y = int(param1.y);
-         param2.x = int(param2.x);
-         param2.y = int(param2.y);
-         _loc6_ = FromISO(param1);
-         _loc8_ = FromISO(new Point(param2.x, param2.y));
-         _loc7_ = param2;
-         _loc7_.x = _loc8_.x;
-         _loc7_.y = _loc8_.y;
-         _loc6_ = GlobalLocal(_loc6_);
-         _loc8_ = GlobalLocal(new Point(_loc7_.x, _loc7_.y));
-         _loc7_.x = int(_loc8_.x);
-         _loc7_.y = int(_loc8_.y);
-         _loc7_.width *= 0.1;
-         _loc7_.height *= 0.1;
-         GetPathB(_loc6_, _loc7_, _loc9_, _loc10_, param3, param4, param5);
+         var gridStart:Point = null;
+         var gridTargetRect:Rectangle = null;
+         var gridTargetPoint:Point = null;
+         var originalStart:Point = null;
+         var originalTarget:Point = null;
+         originalStart = startPoint;
+         originalTarget = new Point(targetRect.x, targetRect.y);
+         startPoint.x = int(startPoint.x);
+         startPoint.y = int(startPoint.y);
+         targetRect.x = int(targetRect.x);
+         targetRect.y = int(targetRect.y);
+         gridStart = FromISO(startPoint);
+         gridTargetPoint = FromISO(new Point(targetRect.x, targetRect.y));
+         gridTargetRect = targetRect;
+         gridTargetRect.x = gridTargetPoint.x;
+         gridTargetRect.y = gridTargetPoint.y;
+         gridStart = GlobalLocal(gridStart);
+         gridTargetPoint = GlobalLocal(new Point(gridTargetRect.x, gridTargetRect.y));
+         gridTargetRect.x = int(gridTargetPoint.x);
+         gridTargetRect.y = int(gridTargetPoint.y);
+         gridTargetRect.width *= 0.1;
+         gridTargetRect.height *= 0.1;
+         GetPathB(gridStart, gridTargetRect, originalStart, originalTarget, callback, ignoreWalls, targetBuilding);
          return [];
       }
 
-      public static function GetPathB(param1:Point, param2:Rectangle, param3:Point, param4:Point, param5:Function = null, param6:Boolean = false, param7:BFOUNDATION = null):void
+      public static function GetPathB(gridStart:Point, gridTargetRect:Rectangle, originalStart:Point, originalTarget:Point, callback:Function = null, ignoreWalls:Boolean = false, targetBuilding:BFOUNDATION = null):void
       {
-         var _loc8_:int = 0;
-         var _loc9_:int = 0;
-         var _loc10_:Number = NaN;
-         var _loc11_:Number = NaN;
-         var _loc12_:Number = NaN;
-         var _loc13_:int = 0;
-         var _loc14_:Object = null;
-         var _loc15_:Object = null;
-         var _loc16_:Object = null;
-         var _loc17_:int = 0;
-         var _loc18_:PATHINGfloodobject = null;
-         var _loc23_:int = 0;
-         var _loc24_:PATHINGobject = null;
-         var _loc25_:PATHINGobject = null;
-         var _loc26_:PATHINGobject = null;
+         var gridKeyTarget:int = 0;
+         var gridKeyStart:int = 0;
+         var angle:Number = NaN;
+         var moveX:Number = NaN;
+         var moveY:Number = NaN;
+         var attempts:int = 0;
+         var edgeArr:Object = null;
+         var floodFillArr:Object = null;
+         var startArr:Object = null;
+         var widthIdx:int = 0;
+         var newFlood:PATHINGfloodobject = null;
+         var heightIdx:int = 0;
+         var initEdgeSpace:PATHINGobject = null;
+         var initFillSpace:PATHINGobject = null;
+         var initStartSpace:PATHINGobject = null;
          RenderCosts();
-         param1.x = int(param1.x);
-         param1.y = int(param1.y);
-         param2.x = int(param2.x);
-         param2.y = int(param2.y);
-         _loc9_ = param1.x * 1000 + param1.y;
-         _loc8_ = param2.x * 1000 + param2.y;
-         if (!_costs[_loc9_] && !_costs[_loc8_])
+         gridStart.x = int(gridStart.x);
+         gridStart.y = int(gridStart.y);
+         gridTargetRect.x = int(gridTargetRect.x);
+         gridTargetRect.y = int(gridTargetRect.y);
+         gridKeyStart = gridStart.x * 1000 + gridStart.y;
+         gridKeyTarget = gridTargetRect.x * 1000 + gridTargetRect.y;
+         if (!_costs[gridKeyStart] && !_costs[gridKeyTarget])
          {
-            param5([param3, param4], param7);
-            RenderPath([param3, param4]);
+            callback([originalStart, originalTarget], targetBuilding);
+            RenderPath([originalStart, originalTarget]);
             return;
          }
-         if (!_costs[_loc9_])
+         if (!_costs[gridKeyStart])
          {
-            _loc10_ = 90 - Math.atan2(param2.y - param1.y, param2.x - param1.x) * 57.2957795;
-            _loc11_ = Math.sin(_loc10_ * 0.0174532925) * 5;
-            _loc12_ = Math.cos(_loc10_ * 0.0174532925) * 5;
-            _loc13_ = 0;
-            while (!_costs[_loc9_] && _loc13_ < 2000)
+            angle = 90 - Math.atan2(gridTargetRect.y - gridStart.y, gridTargetRect.x - gridStart.x) * 57.2957795;
+            moveX = Math.sin(angle * 0.0174532925) * 5;
+            moveY = Math.cos(angle * 0.0174532925) * 5;
+            attempts = 0;
+            while (!_costs[gridKeyStart] && attempts < 2000)
             {
-               _loc13_ += 1;
-               param1.x += _loc11_;
-               param1.y += _loc12_;
-               _loc9_ = int(param1.x) * 1000 + int(param1.y);
+               attempts += 1;
+               gridStart.x += moveX;
+               gridStart.y += moveY;
+               gridKeyStart = int(gridStart.x) * 1000 + int(gridStart.y);
             }
-            param1.x = int(param1.x);
-            param1.y = int(param1.y);
+            gridStart.x = int(gridStart.x);
+            gridStart.y = int(gridStart.y);
          }
-         if (!_costs[_loc8_])
+         if (!_costs[gridKeyTarget])
          {
-            param5([param3, param4], param7);
-            RenderPath([param3, param4]);
+            callback([originalStart, originalTarget], targetBuilding);
+            RenderPath([originalStart, originalTarget]);
             return;
          }
-         if (param6)
+         if (ignoreWalls)
          {
-            _loc8_ += 1000000;
+            gridKeyTarget += 1000000;
          }
-         if (!_floods[_loc8_])
+         if (!_floods[gridKeyTarget])
          {
-            _loc14_ = {};
-            _loc15_ = {};
-            _loc16_ = {};
-            _loc17_ = 0;
-            while (_loc17_ < param2.width)
+            edgeArr = {};
+            floodFillArr = {};
+            startArr = {};
+            widthIdx = 0;
+            while (widthIdx < gridTargetRect.width)
             {
-               _loc23_ = 0;
-               while (_loc23_ < param2.height)
+               heightIdx = 0;
+               while (heightIdx < gridTargetRect.height)
                {
-                  _loc24_ = new PATHINGobject();
-                  _loc24_.pointX = param2.x + _loc17_;
-                  _loc24_.pointY = param2.y + _loc23_;
-                  _loc24_.depth = 0;
-                  _loc14_[param2.x + _loc17_ * 1000 + param2.y + _loc23_] = _loc24_;
-                  _loc25_ = new PATHINGobject();
-                  _loc25_.pointX = param2.x + _loc17_;
-                  _loc25_.pointY = param2.y + _loc23_;
-                  _loc25_.depth = 0;
-                  _loc15_[param2.x + _loc17_ * 1000 + param2.y + _loc23_] = _loc25_;
-                  _loc26_ = new PATHINGobject();
-                  _loc26_.pointX = param2.x + _loc17_;
-                  _loc26_.pointY = param2.y + _loc23_;
-                  _loc26_.depth = 0;
-                  _loc16_[param2.x + _loc17_ * 1000 + param2.y + _loc23_] = _loc26_;
-                  _loc23_ += 1;
+                  initEdgeSpace = new PATHINGobject();
+                  initEdgeSpace.pointX = gridTargetRect.x + widthIdx;
+                  initEdgeSpace.pointY = gridTargetRect.y + heightIdx;
+                  initEdgeSpace.depth = 0;
+                  edgeArr[gridTargetRect.x + widthIdx * 1000 + gridTargetRect.y + heightIdx] = initEdgeSpace;
+                  initFillSpace = new PATHINGobject();
+                  initFillSpace.pointX = gridTargetRect.x + widthIdx;
+                  initFillSpace.pointY = gridTargetRect.y + heightIdx;
+                  initFillSpace.depth = 0;
+                  floodFillArr[gridTargetRect.x + widthIdx * 1000 + gridTargetRect.y + heightIdx] = initFillSpace;
+                  initStartSpace = new PATHINGobject();
+                  initStartSpace.pointX = gridTargetRect.x + widthIdx;
+                  initStartSpace.pointY = gridTargetRect.y + heightIdx;
+                  initStartSpace.depth = 0;
+                  startArr[gridTargetRect.x + widthIdx * 1000 + gridTargetRect.y + heightIdx] = initStartSpace;
+                  heightIdx += 1;
                }
-               _loc17_ += 1;
+               widthIdx += 1;
             }
-            _loc18_ = new PATHINGfloodobject();
-            _loc18_.flood = _loc15_;
-            _loc18_.edge = _loc14_;
-            _loc18_.start = _loc16_;
-            _loc18_.ignoreWalls = param6;
-            _floods[_loc8_] = _loc18_;
+            newFlood = new PATHINGfloodobject();
+            newFlood.flood = floodFillArr;
+            newFlood.edge = edgeArr;
+            newFlood.start = startArr;
+            newFlood.ignoreWalls = ignoreWalls;
+            _floods[gridKeyTarget] = newFlood;
          }
-         if (!_floods[_loc8_].startpoints[_loc9_])
+         if (!_floods[gridKeyTarget].startpoints[gridKeyStart])
          {
-            _floods[_loc8_].startpoints[_loc9_] = {
-                  "startID": _loc9_,
+            _floods[gridKeyTarget].startpoints[gridKeyStart] = {
+                  "startID": gridKeyStart,
                   "callbackfunctions": [],
-                  "startPoint": param1
+                  "startPoint": gridStart
                };
          }
-         _floods[_loc8_].startpoints[_loc9_].callbackfunctions.push([param5, param6, param7, param4]);
-         _floods[_loc8_].pending += 1;
+         _floods[gridKeyTarget].startpoints[gridKeyStart].callbackfunctions.push([callback, ignoreWalls, targetBuilding, originalTarget]);
+         _floods[gridKeyTarget].pending += 1;
       }
 
       /**
@@ -422,45 +422,45 @@ package com.monsters.pathing
                      {
                         currentX = currentEdgePoint.pointX;
                         currentY = currentEdgePoint.pointY;
-                        neighborY = currentX - 1;
+                        neighborX = currentX - 1;
 
                         // Check all neighboring points
-                        while (neighborY < currentX + 2)
+                        while (neighborX < currentX + 2)
                         {
-                           neighborKey = currentY - 1;
-                           while (neighborKey < currentY + 2)
+                           neighborY = currentY - 1;
+                           while (neighborY < currentY + 2)
                            {
                               // Skip the current point itself
-                              if (!(neighborY == currentX && neighborKey == currentY))
+                              if (!(neighborX == currentX && neighborY == currentY))
                               {
-                                 neighborX = neighborY * 1000 + neighborKey;
+                                 neighborKey = neighborX * 1000 + neighborY;
 
                                  // Check if the neighbor is already part of the flood
-                                 if (!currentFloodObject.flood[neighborX])
+                                 if (!currentFloodObject.flood[neighborKey])
                                  {
 
                                     // If the neighbor hasn't been added yet, evaluate it
-                                    if (!newEdge[neighborX])
+                                    if (!newEdge[neighborKey])
                                     {
-                                       if (_costs[neighborX])
+                                       if (_costs[neighborKey])
                                        {
                                           expandedPointsCount += 1;
                                           newFloodPoint = new PATHINGobject();
-                                          newFloodPoint.pointX = neighborY;
-                                          newFloodPoint.pointY = neighborKey;
+                                          newFloodPoint.pointX = neighborX;
+                                          newFloodPoint.pointY = neighborY;
 
                                           // Calculate movement cost
-                                          movementCost = int(_costs[neighborX].cost);
+                                          movementCost = int(_costs[neighborKey].cost);
                                           if (currentFloodObject.ignoreWalls)
                                           {
-                                             if (_costs[neighborX].building)
+                                             if (_costs[neighborKey].building)
                                              {
                                                 movementCost = 20;
                                              }
                                           }
 
                                           // Increase cost for diagonal movement
-                                          if (neighborY != currentEdgePoint.pointX && neighborKey != currentEdgePoint.pointY)
+                                          if (neighborX != currentEdgePoint.pointX && neighborY != currentEdgePoint.pointY)
                                           {
                                              movementCost *= 1.5;
                                           }
@@ -473,17 +473,17 @@ package com.monsters.pathing
                                           }
 
                                           // Add the new point to the flood and edge
-                                          newEdge[neighborX] = newFloodPoint;
-                                          currentFloodObject.flood[neighborX] = newFloodPoint;
+                                          newEdge[neighborKey] = newFloodPoint;
+                                          currentFloodObject.flood[neighborKey] = newFloodPoint;
                                           currentFloodObject.edgeLength += 1;
                                           pointsAddedCount += 1;
                                        }
                                     }
                                  }
                               }
-                              neighborKey += 1;
+                              neighborY += 1;
                            }
-                           neighborY += 1;
+                           neighborX += 1;
                         }
                      }
                      else
@@ -507,181 +507,181 @@ package com.monsters.pathing
          }
       }
 
-      private static function CheckStartReached(param1:PATHINGfloodobject):int
+      private static function CheckStartReached(floodFill:PATHINGfloodobject):int
       {
-         var _loc3_:Object = null;
-         var _loc4_:Array = null;
-         var _loc2_:int = 0;
-         for each (_loc3_ in param1.startpoints)
+         var pathingStart:Object = null;
+         var callback:Array = null;
+         var found:int = 0;
+         for each (pathingStart in floodFill.startpoints)
          {
-            if (Boolean(_loc3_) && Boolean(param1.flood[_loc3_.startID]))
+            if (Boolean(pathingStart) && Boolean(floodFill.flood[pathingStart.startID]))
             {
-               for each (_loc4_ in _loc3_.callbackfunctions)
+               for each (callback in pathingStart.callbackfunctions)
                {
-                  Path(param1.flood, _loc3_.startID, _loc4_[0], _loc4_[1], _loc4_[2], _loc4_[3]);
-                  --param1.pending;
-                  _loc2_ += 1;
+                  Path(floodFill.flood, pathingStart.startID, callback[0], callback[1], callback[2], callback[3]);
+                  --floodFill.pending;
+                  found += 1;
                }
-               _loc3_.callbackfunctions = [];
-               delete param1.startpoints[_loc3_.startID];
+               pathingStart.callbackfunctions = [];
+               delete floodFill.startpoints[pathingStart.startID];
             }
          }
-         return _loc2_;
+         return found;
       }
 
-      public static function Path(param1:Object, param2:int, param3:Function, param4:Boolean = false, param5:BFOUNDATION = null, param6:Point = null):void
+      public static function Path(floodFill:Object, startId:int, callback:Function, ignoreWalls:Boolean = false, targetBuilding:BFOUNDATION = null, originalTarget:Point = null):void
       {
-         var _loc8_:int = 0;
-         var _loc9_:int = 0;
-         var _loc12_:int = 0;
-         var _loc13_:Point = null;
-         var _loc14_:int = 0;
-         var _loc15_:int = 0;
-         var _loc16_:int = 0;
-         var _loc17_:Boolean = false;
-         var _loc18_:BFOUNDATION = null;
-         var _loc19_:Boolean = false;
-         var _loc20_:int = 0;
-         var _loc21_:int = 0;
-         var _loc22_:int = 0;
-         var _loc23_:int = 0;
-         var _loc24_:Array = null;
-         var _loc25_:int = 0;
-         var _loc26_:int = 0;
-         var _loc27_:Point = null;
-         var _loc28_:int = 0;
-         var _loc7_:int = getTimer();
-         var _loc10_:Array = [];
-         var _loc11_:int = 0;
-         if (param1[param2])
+         var startX:int = 0;
+         var startY:int = 0;
+         var gridKey:int = 0;
+         var gridPoint:Point = null;
+         var currentDepth:int = 0;
+         var currentX:int = 0;
+         var currentY:int = 0;
+         var foundLowerDepth:Boolean = false;
+         var wall:BFOUNDATION = null;
+         var buildPath:Boolean = false;
+         var offsetX:int = 0;
+         var offsetY:int = 0;
+         var repeat:int = 0;
+         var nearbyOffsetX:int = 0;
+         var nearbyGridSpaces:Array = null;
+         var nearbyOffsetY:int = 0;
+         var nearbyGridKey:int = 0;
+         var nearbyPoint:Point = null;
+         var randIdx:int = 0;
+         var startTime:int = getTimer();
+         var path:Array = [];
+         var numWaypoints:int = 0;
+         if (floodFill[startId])
          {
-            _loc8_ = int(param1[param2].pointX);
-            _loc9_ = int(param1[param2].pointY);
-            _loc14_ = int(param1[param2].depth);
-            _loc10_[_loc11_] = ToISO(LocalGlobal(new Point(_loc8_, _loc9_)), 0);
-            _loc11_ += 1;
-            _loc19_ = true;
+            startX = int(floodFill[startId].pointX);
+            startY = int(floodFill[startId].pointY);
+            currentDepth = int(floodFill[startId].depth);
+            path[numWaypoints] = ToISO(LocalGlobal(new Point(startX, startY)), 0);
+            numWaypoints += 1;
+            buildPath = true;
          }
-         _loc13_ = new Point(0, 0);
-         while (_loc19_)
+         gridPoint = new Point(0, 0);
+         while (buildPath)
          {
-            _loc19_ = false;
-            _loc20_ = -1;
-            while (_loc20_ < 2)
+            buildPath = false;
+            offsetX = -1;
+            while (offsetX < 2)
             {
-               _loc21_ = -1;
-               while (_loc21_ < 2)
+               offsetY = -1;
+               while (offsetY < 2)
                {
-                  if (!(_loc20_ == 0 && _loc21_ == 0))
+                  if (!(offsetX == 0 && offsetY == 0))
                   {
-                     _loc13_.x = _loc8_ + _loc20_;
-                     _loc13_.y = _loc9_ + _loc21_;
-                     _loc12_ = _loc13_.x * 1000 + _loc13_.y;
-                     if (param1[_loc12_] && param1[_loc12_].depth < _loc14_ && param1[_loc12_].depth > 0)
+                     gridPoint.x = startX + offsetX;
+                     gridPoint.y = startY + offsetY;
+                     gridKey = gridPoint.x * 1000 + gridPoint.y;
+                     if (floodFill[gridKey] && floodFill[gridKey].depth < currentDepth && floodFill[gridKey].depth > 0)
                      {
-                        _loc15_ = _loc13_.x;
-                        _loc16_ = _loc13_.y;
-                        _loc17_ = true;
-                        _loc14_ = int(param1[_loc12_].depth);
-                        _loc19_ = true;
-                        if (!param4 && _loc11_ > 1)
+                        currentX = gridPoint.x;
+                        currentY = gridPoint.y;
+                        foundLowerDepth = true;
+                        currentDepth = int(floodFill[gridKey].depth);
+                        buildPath = true;
+                        if (!ignoreWalls && numWaypoints > 1)
                         {
-                           if (_costs[_loc12_])
+                           if (_costs[gridKey])
                            {
-                              _loc18_ = _costs[_loc12_].building;
-                              if (_loc18_)
+                              wall = _costs[gridKey].building;
+                              if (wall)
                               {
-                                 if (_loc18_.health > 0)
+                                 if (wall.health > 0)
                                  {
-                                    _loc22_ = (_loc18_._lvl.Get() ^ 2) + 1;
-                                    _loc23_ = 0;
-                                    while (_loc23_ < _loc22_)
+                                    repeat = (wall._lvl.Get() ^ 2) + 1;
+                                    nearbyOffsetX = 0;
+                                    while (nearbyOffsetX < repeat)
                                     {
-                                       _loc10_.push(_loc10_[_loc10_.length - 1]);
-                                       _loc23_++;
+                                       path.push(path[path.length - 1]);
+                                       nearbyOffsetX++;
                                     }
-                                    param3(_loc10_, _loc18_);
-                                    RenderPath(_loc10_);
+                                    callback(path, wall);
+                                    RenderPath(path);
                                     return;
                                  }
                               }
                            }
                         }
-                        if (!param4 && _loc14_ < 20)
+                        if (!ignoreWalls && currentDepth < 20)
                         {
                            if (Math.random() < 0.6)
                            {
-                              _loc24_ = new Array();
-                              _loc23_ = -3;
-                              while (_loc23_ < 4)
+                              nearbyGridSpaces = new Array();
+                              nearbyOffsetX = -3;
+                              while (nearbyOffsetX < 4)
                               {
-                                 _loc25_ = -3;
-                                 while (_loc25_ < 4)
+                                 nearbyOffsetY = -3;
+                                 while (nearbyOffsetY < 4)
                                  {
-                                    if (Boolean(_loc23_) && Boolean(_loc25_))
+                                    if (Boolean(nearbyOffsetX) && Boolean(nearbyOffsetY))
                                     {
-                                       _loc26_ = (_loc15_ + _loc23_) * 1000 + _loc16_ + _loc25_;
-                                       if (param1[_loc26_])
+                                       nearbyGridKey = (currentX + nearbyOffsetX) * 1000 + currentY + nearbyOffsetY;
+                                       if (floodFill[nearbyGridKey])
                                        {
-                                          if (param1[_loc26_].depth < 20 && param1[_loc26_].depth > 0)
+                                          if (floodFill[nearbyGridKey].depth < 20 && floodFill[nearbyGridKey].depth > 0)
                                           {
-                                             _loc27_ = new Point(_loc15_ + _loc23_, _loc16_ + _loc25_);
-                                             _loc24_.push(_loc27_);
+                                             nearbyPoint = new Point(currentX + nearbyOffsetX, currentY + nearbyOffsetY);
+                                             nearbyGridSpaces.push(nearbyPoint);
                                           }
                                        }
                                     }
-                                    _loc25_++;
+                                    nearbyOffsetY++;
                                  }
-                                 _loc23_++;
+                                 nearbyOffsetX++;
                               }
-                              if (_loc24_.length > 0)
+                              if (nearbyGridSpaces.length > 0)
                               {
-                                 _loc28_ = int(Math.random() * _loc24_.length);
-                                 _loc15_ = int(_loc24_[_loc28_].x);
-                                 _loc16_ = int(_loc24_[_loc28_].y);
+                                 randIdx = int(Math.random() * nearbyGridSpaces.length);
+                                 currentX = int(nearbyGridSpaces[randIdx].x);
+                                 currentY = int(nearbyGridSpaces[randIdx].y);
                               }
                            }
                         }
                      }
                   }
-                  _loc21_ += 1;
+                  offsetY += 1;
                }
-               _loc20_ += 1;
+               offsetX += 1;
             }
-            if (_loc17_)
+            if (foundLowerDepth)
             {
-               _loc8_ = _loc15_;
-               _loc9_ = _loc16_;
-               _loc10_[_loc11_] = ToISO(LocalGlobal(Jiggle(_loc15_, _loc16_)), 0);
-               _loc11_ += 1;
+               startX = currentX;
+               startY = currentY;
+               path[numWaypoints] = ToISO(LocalGlobal(Jiggle(currentX, currentY)), 0);
+               numWaypoints += 1;
             }
          }
-         if (param6)
+         if (originalTarget)
          {
-            _loc13_ = GlobalLocal(FromISO(param6));
-            if (!param5 || !_costs[_loc13_.x * 1000 + _loc13_.y])
+            gridPoint = GlobalLocal(FromISO(originalTarget));
+            if (!targetBuilding || !_costs[gridPoint.x * 1000 + gridPoint.y])
             {
-               _loc10_[_loc11_] = param6;
+               path[numWaypoints] = originalTarget;
             }
          }
          RenderFlood();
-         RenderPath(_loc10_);
-         param3(_loc10_, param5);
+         RenderPath(path);
+         callback(path, targetBuilding);
       }
 
-      private static function Jiggle(param1:int, param2:int):Point
+      private static function Jiggle(x:int, y:int):Point
       {
-         return new Point(param1 + (Math.random() - 0.5) * 0.4, param2 + (Math.random() - 0.5) * 0.4);
+         return new Point(x + (Math.random() - 0.5) * 0.4, y + (Math.random() - 0.5) * 0.4);
       }
 
-      public static function GetBuildingFromISO(param1:Point):BFOUNDATION
+      public static function GetBuildingFromISO(isoPoint:Point):BFOUNDATION
       {
-         var _loc2_:Point = FromISO(param1);
-         var _loc3_:Point = GlobalLocal(_loc2_);
-         var _loc4_:int = 1000 * int(_loc3_.x) + int(_loc3_.y);
-         if (_costs[_loc4_])
+         var cartPoint:Point = FromISO(isoPoint);
+         var gridPoint:Point = GlobalLocal(cartPoint);
+         var gridKey:int = 1000 * int(gridPoint.x) + int(gridPoint.y);
+         if (_costs[gridKey])
          {
-            return _costs[_loc4_].building;
+            return _costs[gridKey].building;
          }
          return null;
       }
@@ -757,54 +757,54 @@ package com.monsters.pathing
 
       public static function Cleanup():void
       {
-         var _loc1_:* = undefined;
-         for each (_loc1_ in _costs)
+         var gridSpace:* = undefined;
+         for each (gridSpace in _costs)
          {
-            delete _costs[_loc1_];
+            delete _costs[gridSpace];
          }
          _costs = {};
          _floods = {};
       }
 
-      public static function LineOfSight(param1:int, param2:int, param3:int, param4:int, param5:BFOUNDATION = null, param6:Boolean = false):Boolean
+      public static function LineOfSight(startX:int, startY:int, targetX:int, targetY:int, targetBuilding:BFOUNDATION = null, includeAllBuildings:Boolean = false):Boolean
       {
-         var _loc7_:int = 0;
-         var _loc8_:int = 0;
-         var _loc9_:BFOUNDATION = null;
-         var _loc16_:int = 0;
-         var _loc18_:int = 0;
-         var _loc10_:Point = GlobalLocal(FromISO(new Point(param1, param2)));
-         var _loc11_:Point = GlobalLocal(FromISO(new Point(param3, param4)));
-         param1 = _loc10_.x;
-         param2 = _loc10_.y;
-         param3 = _loc11_.x;
-         param4 = _loc11_.y;
-         var _loc12_:Number = param3 - param1;
-         var _loc13_:Number = param4 - param2;
-         var _loc14_:Number = Math.atan2(_loc13_, _loc12_) * c180PI;
-         var _loc15_:Number = Math.sqrt(_loc12_ * _loc12_ + _loc13_ * _loc13_);
-         _loc7_ = 0;
-         while (_loc7_ < _loc15_)
+         var currentDistance:int = 0;
+         var gridKey:int = 0;
+         var wall:BFOUNDATION = null;
+         var gridX:int = 0;
+         var gridY:int = 0;
+         var gridStart:Point = GlobalLocal(FromISO(new Point(startX, startY)));
+         var gridTarget:Point = GlobalLocal(FromISO(new Point(targetX, targetY)));
+         startX = gridStart.x;
+         startY = gridStart.y;
+         targetX = gridTarget.x;
+         targetY = gridTarget.y;
+         var difX:Number = targetX - startX;
+         var difY:Number = targetY - startY;
+         var angle:Number = Math.atan2(difY, difX) * c180PI;
+         var totalDistance:Number = Math.sqrt(difX * difX + difY * difY);
+         currentDistance = 0;
+         while (currentDistance < totalDistance)
          {
-            _loc16_ = param1 + Math.cos(_loc14_ * cPI180) * _loc7_;
-            _loc18_ = param2 + Math.sin(_loc14_ * cPI180) * _loc7_;
-            _loc8_ = _loc16_ * 1000 + _loc18_;
-            if (!_costs[_loc8_])
+            gridX = startX + Math.cos(angle * cPI180) * currentDistance;
+            gridY = startY + Math.sin(angle * cPI180) * currentDistance;
+            gridKey = gridX * 1000 + gridY;
+            if (!_costs[gridKey])
             {
                return true;
             }
-            _loc9_ = _costs[_loc8_].building;
-            if (Boolean(_loc9_) && _loc9_.health > 0)
+            wall = _costs[gridKey].building;
+            if (Boolean(wall) && wall.health > 0)
             {
-               if (!(Boolean(param5) && _loc9_ == param5))
+               if (!(Boolean(targetBuilding) && wall == targetBuilding))
                {
-                  if (_loc9_._type == 17 || param6)
+                  if (wall._type == 17 || includeAllBuildings)
                   {
                      return false;
                   }
                }
             }
-            _loc7_++;
+            currentDistance++;
          }
          return true;
       }
@@ -878,38 +878,38 @@ package com.monsters.pathing
          return _loc4_;
       }
 
-      private static function GlobalLocal(param1:Point):Point
+      private static function GlobalLocal(toGridPoint:Point):Point
       {
-         param1.x *= 0.1;
-         param1.y *= 0.1;
-         param1.x += _gridWidth >> 1;
-         param1.y += _gridHeight >> 1;
-         param1.x = int(param1.x);
-         param1.y = int(param1.y);
-         return param1;
+         toGridPoint.x *= 0.1;
+         toGridPoint.y *= 0.1;
+         toGridPoint.x += _gridWidth >> 1;
+         toGridPoint.y += _gridHeight >> 1;
+         toGridPoint.x = int(toGridPoint.x);
+         toGridPoint.y = int(toGridPoint.y);
+         return toGridPoint;
       }
 
-      public static function LocalGlobal(param1:Point):Point
+      public static function LocalGlobal(toCartPoint:Point):Point
       {
-         param1.x -= _gridWidth >> 1;
-         param1.y -= _gridHeight >> 1;
-         param1.x *= 10;
-         param1.y *= 10;
-         return param1;
+         toCartPoint.x -= _gridWidth >> 1;
+         toCartPoint.y -= _gridHeight >> 1;
+         toCartPoint.x *= 10;
+         toCartPoint.y *= 10;
+         return toCartPoint;
       }
 
-      public static function ToISO(param1:Point, param2:int):Point
+      public static function ToISO(cartPoint:Point, offset:int):Point
       {
-         var _loc3_:int = (param1.x + param1.y) * 0.5 - param2;
-         var _loc5_:int = param1.x - param1.y;
-         return new Point(_loc5_, _loc3_);
+         var isoY:int = (cartPoint.x + cartPoint.y) * 0.5 - offset;
+         var isoX:int = cartPoint.x - cartPoint.y;
+         return new Point(isoX, isoY);
       }
 
-      public static function FromISO(param1:Point):Point
+      public static function FromISO(isoPoint:Point):Point
       {
-         var _loc2_:int = param1.y - param1.x * 0.5;
-         var _loc3_:int = param1.x * 0.5 + param1.y;
-         return new Point(_loc3_, _loc2_);
+         var cartY:int = isoPoint.y - isoPoint.x * 0.5;
+         var cartX:int = isoPoint.x * 0.5 + isoPoint.y;
+         return new Point(cartX, cartY);
       }
 
       public static function PlotRandom(param1:MouseEvent):void


### PR DESCRIPTION
This pull request contains Deobfuscated variable names for the following functions in the client:
- All used functions in PATHING.as
- The `findTarget`, `WayPointTo`, and `setWaypoints` functions in MonsterBase.as

The structure and functionality of the code remains the same. The only code that is changed is the removal of 4 entirely unused variables in `findTarget` that were never written to nor read.
I intend to change the structure of these functions in a future PR with the intent to solve an issue causing the game to freeze during high-volume attacks. As requested, this change is a separate PR to make the future PR's diff easier to read.

All changes are client side. Let me know if you spot any errors, need clarification, or you would want something named differently.

# Pathfinding System Functionality:
Rather than listing out all the name changes and individual reasons why the names were chosen, I will take this opportunity to document how the Pathfinding system in the game works, and hopefully that will provide enough context as to why the names were chosen.

## `_costs` Grid
The game uses a grid-based system to give directions on where monsters should move, and to determine how costly it is to move to particular locations.

**Setting up the Grid.** Once PATHING's `Setup` function is called, it initializes a 164x132 grid where each grid space is a `PATHINGobject` that stores its x/y coordinates, its cost, and whether or not a wall is in that space.
- This 164x132 grid is held in the `_costs` object.
- `_costs` is a 1d array storing a 2d grid, so each grid space is given a key based on their (x,y) coordinates. This key is equal to (x*1000 + y).
- Each grid space is given a "cost" value of 10 by default.

> **Notable flaw:**
> The 164x132 grid size is not large enough for a base that has all of its yard expansion upgrades. Players with these large yards can place buildings outside of the grid's bounds.
> Monsters ignore all walls and simply move straight to their target if it is out of bounds.

**Setup Costs.** To give each grid space their proper cost, PATHING grabs every building in the base and calls `Cost` using that building. How costly it is to move through a building is determined by that building object's `_gridCost` array.
A building's `_gridCost` array is a 2d array that is meant to contain one or more "regions" in or around the building. For example, the Twig Snapper has two regions: one "outer" region that contains its entire 7x7 area that has a cost of 10, and an "inner" region that takes up a 5x5 area in the building's center which has a cost of 200. Most buildings have an "outer" region with a lower cost and an "inner" region with a very high cost. This is so monsters will path around a building's edges rather than go straight through them.

**Visual Walkthrough.** To visualize what values `_costs` is storing, imagine a section of a base that appears like this: with two sniper towers, a silo, and some wooden and stone blocks. Each one of these grid spaces will be given a cost.
Each space by default has a cost of 10, so a 10 will be placed onto each grid space to denote its cost.

<img width="962" height="961" alt="GridCosts1" src="https://github.com/user-attachments/assets/72cde66b-406a-4c18-a751-37aa0d72cd19" />

The costs of the Sniper Tower and the Silo will be added next. Both of these buildings have an "outer" region with a cost of 10, and an "inner" region with a cost of 200.

The cost value of a grid space is always added to, not overwritten. Because the "inner" and "outer regions of the Sniper and Silo overlap, their "inner" region will actually have a cost of 210, which is also added to the default cost of 10.
Now the `_costs` Grid looks as follows:

<img width="1010" height="1007" alt="GridCosts2" src="https://github.com/user-attachments/assets/09bacd04-4fba-4684-b892-fcaa1fdc3373" />

Now the cost of the wood and stone blocks need to be added. Blocks also have two regions:
- Their inner region has a base cost of 100, increasing by 100 per level of the block. In this case, the wooden block's cost is 100, and the stone block's cost is 200. *This region covers the block's entire 2x2 area*.
- A block's outer region has a cost of 20, and is not affected by the block's level. This outer region *extends 1 space beyond the block's in-game area*. This makes any grid space within 1 space of a block is more expensive to move through. This also makes grid spaces near multiple blocks even more expensive.
Once the costs for the blocks are added, the `_costs` grid is essentially complete:

<img width="1018" height="1016" alt="GridCosts3" src="https://github.com/user-attachments/assets/0b34fcba-e81c-4b78-8ea3-831e164f207f" />

**Walls.** The only thing that's left is to insert which grid spaces have a wall. Every time a block is loaded or placed/moved, it calls `PATHING.RegisterBuilding` and gives the block's region as the parameters. This function is responsible for giving the grid spaces their "has a wall" state.
Despite the function name `RegisterBuilding` implying it's used for many kinds of buildings, it is only ever used with walls/blocks.

**Resetting the Grid.** Each game tick, PATHING checks whether the grid's "cost" values need to be reset. This is true whenever the `ResetCosts` function is called. `ResetCosts` is called whenever loading a base, when a wild monster attack begins, and *whenever a building is destroyed during an attack*.

## Converting Building Coordinates to Grid Coordinates
PATHING has functions to convert coordinates between their isometric, Cartesian, and `_costs` grid values.
- `FromISO` and `ToISO` convert isometric coordinates to Cartesian coordinates and vice versa.
- `GlobalLocal` and `LocalGlobal` convert cartesian coordinates to `_costs` grid coordinates and vice versa.
- `_costs` grid coordinates are always integers.

To convert from Cartesian coordinates to the Grid's coordinate system:
- Divide the Cartesian coordinates X and Y values by 10.
- Add half the grid's width to X, and half the grid's height to Y.
- Convert the X and Y values to an integer.

> **Notable flaw:**
> Building locations are placed in increments of 5 in the game. But, whether you place a building at Cartesian coordinates (x125, y85), or at (x120, y80)... the building will still be placed on the same `_costs` grid space because the coordinates are divided by 10 then turned into an integer.
> In other words, the pathfinding grid's resolution is *coarser* than it is for building placement.

## Pathfinding Tasks
**Task Types.** PATHING contains all of its current "Pathfinding Tasks" in its `_floods` object. There are two kinds of tasks, which I will call a *Flood Task* and a *Path Task*.
- *Flood Tasks* are represented as `PATHINGfloodobject`s in the code. There is a *Flood Task* stored in `_floods` for every target coordinate that a monster is trying to get to. The `PATHINGfloodobject` is used to store the progress of the Flood Fill algorithm the pathfinding system uses to find the path.
- *Path Tasks* do not have any special named object that represents them. There is a *Path Task* stored in the *Flood Task* for every starting coordinate that a monster is in. In the code, the `PATHINGfloodobject` stores all of these *Path Tasks* in its `startpoints` object.

For example, say there are 5 monsters:
- One monster is trying to get to the grid coordinates (x20,y30), and is starting from grid coordinates (x5,y5).
- The other four monsters are trying to get to grid coordinates (x44,y70). Two are starting from grid coordinates (x5,y8), one is starting from (x5,y5), and the last one is starting from (x6,y8).

In this case, there will be two *Flood Tasks* stored in `_floods`, one with the key "20030" for coordinates (x20,y30), and the other with the key "44070" for (44,y77).
- The *Flood Task* for coordinates (x20,y30) will only have 1 *Path Task* since there is only one monster moving to these coordinates. The task has key "5005".
- The *Flood Task* for coordinates (x44,y70) will have 3 *Path Tasks* since there are 3 starting locations across the 4 monsters. The tasks have the keys "5008", "5005", and "6008".

> all objects in `_floods` in this case:
> `_floods[20030].startpoint[5005]`
> `_floods[44070].startpoint[5005]`, `_floods[44070].startpoints[5008]`, `_floods[44070].startpoint[6008]`

**Callback Functions.** Each *Path Task* is given a list of callback functions to call when the *Path Task* is finished or the `_costs` grid is reset. In this case, the callback function is always the monster's `setWaypoints` function. This is so that if multiple monsters are moving to the same target, from the same starting location, all of the monsters get the path at once.
If the callback function is called due to the `_costs` grid being reset, the monster stays where they are and calls their `findTarget` function again. In practical terms, this means whenever a building is destroyed in an attack, each monster that was waiting for a path has to restart the pathfinding process from the beginning.

> Notable flaw:
> When adding a monster's callback function to a *Path Task*, the code **does not check for duplicates**.

**Choosing a Target.** Attacking monsters choose their initial target via their `findTarget` function. Monsters typically find the two closest buildings to target (closest literally on the screen, nothing pathfinding related is used to determine what's closest). The only exception is monsters that prefer targeting other monsters, which simply just move straight to their target monster.

## Finding the Path
**Completing a Flood Task.** When a *Flood Task* is initialized, it takes every grid space the target area encompasses and adds it all to a "fill" array and an "edge" array.
- The "fill" array contains every grid space that the task has checked (includes edge spaces).
- The "edge" array contains every grid space that is at the edge of the fill area. It is practically like the "outline" of the fill area.
- Each grid space in the arrays have a "depth" that represents the *total* cost to move to that space.

**The Flood-Fill Algorithm** is used to determine the path monsters should take to get to their target. What this algorithm does is essentially:
- For every "edge" grid space with the current lowest depth (aka lowest total cost):
	- For each adjacent grid space that has not been checked already:
		- Add the adjacent grid space to the "fill" array and the "edge" array.
		- Give the adjacent grid space a depth equal to the current edge space's depth, plus the adjacent grid space's cost in `_costs` (Multiplied by 1.5x if diagonal).
	- Remove self from the edge array

The *Flood Task*'s algorithm continues until it reaches the starting location for every single *Path Task* it has.

**Visual Walkthrough.** To visualize the Flood Fill algorithm, assume a monster wants to navigate to a Sniper Tower, and sends a *Flood Task* for PATHING to complete. First the algorithm initializes each "fill" and "edge" space with every grid space the sniper tower encompasses. Each one of these spaces is initialized with a depth of 0.

> The cost values in these images differ from the final image in the `_costs` Grid section. The values in that section are the correct ones. When I was making the images for this section, I forgot to add 20 to the "inner region" of the silo, and sniper tower, and forgot to add 30 to the "inner region" of the walls. This mistake does not change the resulting path, however.

<img width="1280" height="977" alt="Flood0" src="https://github.com/user-attachments/assets/13496f79-3061-43d4-b5b4-9fe096a5cbd3" />

> Technically, every starting grid space counts as an edge. However, since the inner region doesn't have any adjacent grid spaces that aren't already contained in the "fill" space, I have not marked them as edges.

I'll handle just a single edge first. Say the top-right edge space is handled. Each adjacent grid space around this one will get added as an edge. Each one of these spaces will have a depth equal to the depth of the current space (which is 0), plus the cost of that adjacent space. When traveling diagonally, the adjacent space's cost is multiplied by 1.5x.

<img width="1245" height="947" alt="Flood0_1" src="https://github.com/user-attachments/assets/7e200755-1b44-4d42-8ea2-61f0a54bc44a" />

Every edge space needs to handled. I will be calculating this from top-to-bottom, left-to-right. Each edge space gets their adjacent spaces added as edges with their respective depth

<img width="1299" height="986" alt="Flood1" src="https://github.com/user-attachments/assets/f492f91e-732d-4939-8211-cb1be2fe5517" />

> **Notable flaw:**
> Notice how many spaces have a depth that is higher than expected. This is because the algorithm will not add an edge space for any space that has already been checked. When a diagonal adjacent space is added, it gets added with the 1.5x cost, even if there is another edge space that is both adjacent and not diagonal to it. 
> Because I calculated this from top-to-bottom, left-to-right, only the corner edges were able to calculate depths without a 1.5x cost multiplier.

Next, we need to keep track of the edge space with the lowest depth. In this case, the lowest depth of any edge space is 15. 
This means the algorithm will always process the least expensive paths first.
Here's the next iteration:

<img width="1293" height="989" alt="Flood2" src="https://github.com/user-attachments/assets/4b4011ec-af8d-4474-977e-17cc1a93e4e8" />

Now the edge space with the lowest depth is 25. Those edges are calculated next:

<img width="1293" height="984" alt="Flood3" src="https://github.com/user-attachments/assets/174741ac-a41e-40e4-971c-3dfc12f10b17" />

I'll calculate the next two iterations, the depths 30 and 35 edges.

<img width="1289" height="983" alt="Flood5" src="https://github.com/user-attachments/assets/858af357-2251-4d8e-8e5c-45f8c5213485" />

Then edges for depths 40, 45, and 50...

<img width="1221" height="928" alt="Flood8" src="https://github.com/user-attachments/assets/f79011d9-4829-4352-8490-527a2e419e5a" />

The algorithm continues expanding the fill area until, eventually, it reaches the monster's starting location:

<img width="1281" height="978" alt="FloodEnd" src="https://github.com/user-attachments/assets/36d6fc76-1a54-4204-9e4b-0d9359038d03" />

If there were multiple starting locations that must be found, then the algorithm would continue until all of them are found.

*Starting Out-of-Bounds.* When the monster's starting position is out-of-bounds of the `_costs` grid, the starting point is nudged forward towards the monster's target until the start point is within the grid's bounds again.

> **Notable flaw:**
> When the monster's start point is nudged back in bounds, the start point can be placed directly into a wall. When this happens, the monster has no valid paths that don't go through the wall. So, if a wall happens to be on the edge of the `_costs` grid, a monster can sometimes target the block directly despite seemingly not needing to.

**Completing a Path Task.** Once the Flood Fill algorithm reaches a starting point, the shortest path to the monster's target must be recreated. The process for doing this is fairly straightforward:
- Starting from the monster's starting space...
- Check each adjacent space for the one with the lowest depth
	- repeat until a space with depth 0 is reached.
	
In the end, the final path appears as follows:

<img width="1243" height="947" alt="Path" src="https://github.com/user-attachments/assets/d04ef4c4-08de-4dd1-9805-6252c6572453" />

**If a Path Encounters a Wall,** then the wall becomes the monster's new target and the path to the wall is given to the monster.

**If a Monster Ignores Walls,** then any grid space containing a wall is treated as having a grid cost of "20" during the "flood fill" algorithm step. *Flood Tasks* that ignore walls are separated from the ones that don't ignore walls, even if the target locations are the same.

**Random Movement.** When a monster is very close to its target, it has a 60% for it to move to a random grid space within 3 spaces, as long as that random grid space does not have a higher depth. This makes it so monsters spread out across their target if they can.

## Line of Sight Checks
While PATHING does not do any Line of Sight checks in its Pathfinding algorithm, it does contain the function for doing such checks. In order to check if a monster has a Line of Sight to their target: it first finds the direction towards the target, then starts advancing towards the target in a straight line starting from the monster's position. The space is checked for a wall each time it advances. If it sees a wall, then the check naturally fails.

There is a parameter in the Line of Sight function that enables/disables the ability for monsters to see through other buildings that aren't Blocks. Since Blocks are the only buildings that are ever registered to the grid, this parameter goes unused. Currently, monsters can perfectly see through every other building in the yard.

Here is a visualization of the Line of Sight check. Two monsters are making a Line of Sight check to a sniper tower. The northern monster's check fails due to a block in the way, while the eastern monster's check passes even with another sniper tower in the way.

<img width="1315" height="927" alt="LineOfSight" src="https://github.com/user-attachments/assets/894d4f46-4a30-4320-a238-f042b12025d2" />
