### PR TITLE
Fix GLOBAL.Message rendering over AuthForm

### DIFF
--- a/client/scripts/LOGIN.as
+++ b/client/scripts/LOGIN.as
@@ -59,7 +59,7 @@ package
          else
          {
             authForm = new AuthForm();
-            GAME._instance.addChild(authForm);
+            GLOBAL._layerTop.addChild(authForm);
          }
       }
 

--- a/client/scripts/com/auth/AuthForm.as
+++ b/client/scripts/com/auth/AuthForm.as
@@ -12,18 +12,14 @@ package com.auth
     import flash.ui.Mouse;
     import flash.events.MouseEvent;
     import flash.text.TextFormat;
-    import flash.filters.DropShadowFilter;
     import flash.display.Bitmap;
     import flash.display.Loader;
     import flash.net.URLRequest;
     import flash.events.FocusEvent;
     import flash.text.TextFormatAlign;
-    import flash.system.LoaderContext;
     import flash.events.IOErrorEvent;
     import flash.utils.Timer;
     import flash.events.TimerEvent;
-    import flash.events.SecurityErrorEvent;
-    import flash.display.StageAlign;
 
     // TODO: This file needs a complete refactor. It is currently very messy and hard to read.
     public class AuthForm extends Sprite
@@ -103,8 +99,6 @@ package com.auth
 
         private var contentContainer:Sprite;
 
-        private var originalStageAlign:String;
-
         private const DESIGN_WIDTH:Number = 760;
         
         private const DESIGN_HEIGHT:Number = 670;
@@ -161,10 +155,6 @@ package com.auth
         {
             removeEventListener(Event.ADDED_TO_STAGE, formAddedToStageHandler);
 
-            // Store original alignment and set TOP_LEFT for AuthForm
-            originalStageAlign = stage.align;
-            stage.align = StageAlign.TOP_LEFT;
-
             drawBackground();
             centerContent();
             stage.addEventListener(Event.RESIZE, onStageResize);
@@ -188,20 +178,25 @@ package com.auth
         {
             drawBackground();
             centerContent();
+            GLOBAL.RefreshScreen();
+            GLOBAL.ResizeLayer(GLOBAL._layerTop);
         }
 
         private function drawBackground():void
         {
+            // slight hack but its only 2-lines of shit
+            var offsetX:Number = -(stage.stageWidth - DESIGN_WIDTH) / 2;
+            var offsetY:Number = -(stage.stageHeight - DESIGN_HEIGHT) / 2;
             background.graphics.clear();
             background.graphics.beginFill(BACKGROUND);
-            background.graphics.drawRect(0, 0, stage.stageWidth, stage.stageHeight);
+            background.graphics.drawRect(offsetX, offsetY, stage.stageWidth, stage.stageHeight);
             background.graphics.endFill();
         }
 
         private function centerContent():void
         {
-            contentContainer.x = (stage.stageWidth - DESIGN_WIDTH) / 2;
-            contentContainer.y = (stage.stageHeight - DESIGN_HEIGHT) / 2;
+            contentContainer.x = 0;
+            contentContainer.y = 0;
         }
 
         private function handleContentLoaded():void
@@ -754,10 +749,9 @@ package com.auth
                 }
                 else
                 {
-                    new URLLoaderApi().load(GLOBAL._apiURL + "bm/getnewmap", null, postAuthDetails, function(event:IOErrorEvent):void
-                        {
-                            GLOBAL.Message("We cannot connect you to the server at this time. Please try again later or check our server status.");
-                        });
+                    // Authentication call
+                    const authInfo:Array = [["email", emailValue], ["password", passwordValue]];
+                    LOGIN.AuthenticateUser(authInfo);
                 }
             }
             else
@@ -777,10 +771,6 @@ package com.auth
             }
         }
 
-        private function postAuthDetails(serverData:Object):void
-        {
-            LOGIN.OnGetNewMap(serverData, [["email", emailValue], ["password", passwordValue]]);
-        }
 
         private function registerNewUser(serverData:Object):void
         {
@@ -851,10 +841,8 @@ package com.auth
 
         public function disposeUI():void
         {
-            // Restore original stage alignment and remove listener
             if (stage)
             {
-                stage.align = originalStageAlign;
                 stage.removeEventListener(Event.RESIZE, onStageResize);
             }
 


### PR DESCRIPTION
### Problem

`GLOBAL.Message` popups were not appearing over the AuthForm login/register screen. When they did appear (after moving AuthForm to a shared layer), they were stuck in the top-left corner and did not reposition on window resize.

<br>

### Root Cause

AuthForm was setting `StageAlign.TOP_LEFT` which shifted the coordinate origin from the center of the 760x670 design area to the top-left of the viewport. This broke GLOBAL's entire positioning system:

- `_SCREENCENTER` remained at (380, 335) instead of the actual viewport center
- `_SCREEN.x/y` became incorrect negative offsets for TOP_LEFT alignment
- `BlockerAdd` positioned the dim overlay off-screen
- `POPUPSETTINGS.AlignToCenter` placed MESSAGE at the wrong coordinates

<br>

Additionally, `ResizeGame` only calls `RefreshScreen()` and `ResizeLayer(_layerTop)` when `GAME._firstLoadComplete` is true, which is false during auth, so MESSAGE and its blocker never repositioned on window resize.