### PR TITLE
Implements base loading (view/attack) for MR3 wild monster structures

### DIFF
--- a/client/scripts/BASE.as
+++ b/client/scripts/BASE.as
@@ -658,6 +658,7 @@ package
          }
          requestData.push(["baseid", _baseID]);
          requestData.push(["type", _loc7_]);
+         requestData.push(["mapversion", MapRoomManager.instance.mapRoomVersion]);
          if (MapRoomManager.instance.viewOnly && (GLOBAL.mode == GLOBAL.e_BASE_MODE.VIEW || GLOBAL.mode == GLOBAL.e_BASE_MODE.WMVIEW))
          {
             requestData.push(["worldid", MapRoomManager.instance.worldID]);
@@ -1764,16 +1765,30 @@ package
             _buildingData = null;
          }
 
-         // Always ensure that the main yard has a town hall
+         // Client guards to ensure the main building on each yard is always the correct type
          if (isMainYard && _buildingData.hasOwnProperty("0") && _buildingData["0"].t !== 14)
          {
             _buildingData["0"].t = 14;
          }
 
-         // Always ensure that the outpost has an outpost building
-         if (isOutpost && _buildingData.hasOwnProperty("0") && _buildingData["0"].t !== 112)
+         if (isOutpostMapRoom2Only && _buildingData.hasOwnProperty("0") && _buildingData["0"].t !== 112)
          {
             _buildingData["0"].t = 112;
+         }
+
+         if (isOutpostStronghold && _buildingData.hasOwnProperty("0") && _buildingData["0"].t !== GuardTower.k_TYPE)
+         {
+            _buildingData["0"].t = GuardTower.k_TYPE;
+         }
+
+         if (isOutpostResource && _buildingData.hasOwnProperty("0") && _buildingData["0"].t !== ResourceOutpost.k_TYPE)
+         {
+            _buildingData["0"].t = ResourceOutpost.k_TYPE;
+         }
+
+         if (isOutpostFortification && _buildingData.hasOwnProperty("0") && _buildingData["0"].t !== OutpostDefender.k_TYPE)
+         {
+            _buildingData["0"].t = OutpostDefender.k_TYPE;
          }
 
          var buildingTypeCounts:Dictionary = new Dictionary();
@@ -4310,13 +4325,14 @@ package
                tmpMode = GLOBAL.e_BASE_MODE.IVIEW;
          }
          _paging = true;
+         var mapVersion:int = MapRoomManager.instance.mapRoomVersion;
          if (isInfernoMainYardOrOutpost || isEventBaseId(_baseID) && GLOBAL.mode == "wmattack")
          {
-            new URLLoaderApi().load(GLOBAL._infBaseURL + "updatesaved", [["baseid", BASE._loadedBaseID], ["version", GLOBAL._version.Get()], ["lastupdate", UPDATES._lastUpdateID], ["type", tmpMode]], handleLoadSuccessful, handleLoadError);
+            new URLLoaderApi().load(GLOBAL._infBaseURL + "updatesaved", [["baseid", BASE._loadedBaseID], ["version", GLOBAL._version.Get()], ["lastupdate", UPDATES._lastUpdateID], ["type", tmpMode], ["mapversion", mapVersion]], handleLoadSuccessful, handleLoadError);
          }
          else
          {
-            new URLLoaderApi().load(GLOBAL._baseURL + "updatesaved", [["baseid", BASE._loadedBaseID], ["version", GLOBAL._version.Get()], ["lastupdate", UPDATES._lastUpdateID], ["type", tmpMode]], handleLoadSuccessful, handleLoadError);
+            new URLLoaderApi().load(GLOBAL._baseURL + "updatesaved", [["baseid", BASE._loadedBaseID], ["version", GLOBAL._version.Get()], ["lastupdate", UPDATES._lastUpdateID], ["type", tmpMode], ["mapversion", mapVersion]], handleLoadSuccessful, handleLoadError);
          }
       }
 

--- a/server/src/config/MapRoom3Config.ts
+++ b/server/src/config/MapRoom3Config.ts
@@ -1,4 +1,7 @@
 import { EnumYardType } from "../enums/EnumYardType.js";
+import { strongholds } from "../data/tribes/v3/strongholds.js";
+import { resources } from "../data/tribes/v3/resources.js";
+import { defenders } from "../data/tribes/v3/defenders.js";
 
 /**
  * The seed for cell generation. Changing this will produce a different cell layout.
@@ -80,6 +83,13 @@ export const STRUCTURE_LEVELS: Record<number, number[]> = {
 export const STRUCTURE_RANGE: Record<number, Record<number, number>> = {
   [EnumYardType.STRONGHOLD]: { 30: 10, 40: 15, 50: 20 },
   [EnumYardType.RESOURCE]: { 10: 2, 20: 3, 30: 4, 40: 5, 50: 6 },
+};
+
+/** Save data templates per structure type and level. */
+export const STRUCTURE_SAVES: Record<number, Record<number, Record<string, any>>> = {
+  [EnumYardType.STRONGHOLD]: strongholds,
+  [EnumYardType.RESOURCE]: resources,
+  [EnumYardType.FORTIFICATION]: defenders,
 };
 
 /** Defender levels per parent structure type and level. */

--- a/server/src/controllers/base/load/baseLoad.ts
+++ b/server/src/controllers/base/load/baseLoad.ts
@@ -35,7 +35,7 @@ export const baseLoad: KoaController = async (ctx) => {
   await postgres.em.populate(user, ["save", "infernosave"]);
 
   try {
-    const { baseid, type, attackData } = BaseLoadSchema.parse(ctx.request.body);
+    const { baseid, type, mapversion, attackData } = BaseLoadSchema.parse(ctx.request.body);
 
     let baseSave: Save = null;
 
@@ -46,14 +46,14 @@ export const baseLoad: KoaController = async (ctx) => {
 
       case BaseMode.VIEW:
       case BaseMode.IVIEW:
-        baseSave = await baseModeView(baseid);
+        baseSave = await baseModeView(baseid, mapversion);
         break;
 
       case BaseMode.ATTACK:
         if (!ctx.meetsDiscordAgeCheck) throw discordAgeErr();
 
         await validateAttack(user, attackData);
-        baseSave = await baseModeAttack(user, baseid);
+        baseSave = await baseModeAttack(user, baseid, mapversion);
         break;
 
       case BaseMode.IDESCENT:

--- a/server/src/controllers/base/load/modes/baseModeView.ts
+++ b/server/src/controllers/base/load/modes/baseModeView.ts
@@ -1,6 +1,7 @@
+import type { MapRoomVersion } from "../../../../enums/MapRoom.js";
 import { Save } from "../../../../models/save.model.js";
 import { postgres } from "../../../../server.js";
-import { wildMonsterSave } from "../../../../services/maproom/v2/wildMonsters.js";
+import { tribeSaveHandler } from "../../../../services/maproom/tribeSaveHandler.js";
 import { getCurrentDateTime } from "../../../../utils/getCurrentDateTime.js";
 
 /**
@@ -13,21 +14,21 @@ const WILD_MONSTER_EXPIRATION = 43200;
  * Handles viewing the base mode for a given base ID.
  * If the save is outdated for a wild monster, it removes the old save and creates a new one.
  *
- * @param {User} user - The authenticated user object.
  * @param {string} baseid - The base identifier for the requested save.
+ * @param {MapRoomVersion} mapversion - The version of the map to determine the save handling logic.
  * @returns {Promise<Loaded<Save, never>>} The save object or null if no valid save is found.
  */
-export const baseModeView = async (baseid: string) => {
+export const baseModeView = async (baseid: string, mapversion: MapRoomVersion) => {
   let save = await postgres.em.findOne(Save, { baseid });
 
-  if (!save) save = wildMonsterSave(baseid);
+  if (!save) save = tribeSaveHandler(baseid, mapversion);
 
   if (save && save.wmid !== 0) {
     const currentTimestamp = getCurrentDateTime();
 
     if (currentTimestamp - save.savetime > WILD_MONSTER_EXPIRATION) {
       await postgres.em.removeAndFlush(save);
-      save = wildMonsterSave(baseid);
+      save = tribeSaveHandler(baseid, mapversion);
     }
   }
 

--- a/server/src/controllers/base/save/updateSaved.ts
+++ b/server/src/controllers/base/save/updateSaved.ts
@@ -21,6 +21,7 @@ const UpdateSavedSchema = z.object({
   version: z.string(),
   lastupdate: z.string(),
   baseid: z.string(),
+  mapversion: z.coerce.number(),
 });
 
 /**
@@ -37,7 +38,7 @@ export const updateSaved: KoaController = async (ctx) => {
   const userSave = user.save;
   
   try {
-    const { baseid, type } = UpdateSavedSchema.parse(ctx.request.body);
+    const { baseid, type, mapversion } = UpdateSavedSchema.parse(ctx.request.body);
 
     let baseSave: Save = null;
 
@@ -52,7 +53,7 @@ export const updateSaved: KoaController = async (ctx) => {
         break;
 
       default:
-        baseSave = await baseModeView(baseid);
+        baseSave = await baseModeView(baseid, mapversion);
         break;
     }
 

--- a/server/src/controllers/maproom/v3/cells/tribeOutpostCell.ts
+++ b/server/src/controllers/maproom/v3/cells/tribeOutpostCell.ts
@@ -4,13 +4,14 @@ import { Tribes } from "../../../../enums/Tribes.js";
 import { WorldMapCell } from "../../../../models/worldmapcell.model.js";
 import { generateBaseId } from "../../../../utils/generateBaseId.js";
 import type { CellData } from "../../../../types/CellData.js";
+import { MapRoomVersion } from "../../../../enums/MapRoom.js";
 
 export const tribeOutpostCell = async (cell: WorldMapCell, worldId: string): Promise<CellData> => {
   const [cellX, cellY] = [cell.x, cell.y];
 
   const tribeIndex = (cellX + cellY) % Tribes.length;
   
-  const baseid = generateBaseId(worldId, cellX, cellY);
+  const baseid = generateBaseId(worldId, cellX, cellY, MapRoomVersion.V3);
 
   return {
     uid: 0,

--- a/server/src/controllers/maproom/v3/cells/wildMonsterCell.ts
+++ b/server/src/controllers/maproom/v3/cells/wildMonsterCell.ts
@@ -6,6 +6,7 @@ import { WorldMapCell } from "../../../../models/worldmapcell.model.js";
 import { generateBaseId } from "../../../../utils/generateBaseId.js";
 import { calculateStructureLevel } from "../../../../services/maproom/v3/calculateStructureLevel.js";
 import type { CellData } from "../../../../types/CellData.js";
+import { MapRoomVersion } from "../../../../enums/MapRoom.js";
 
 /**
  * Formats a wild monster cell (stronghold, resource outpost, or defender) for Map Room 3.
@@ -25,7 +26,7 @@ export const wildMonsterCell = async (cell: WorldMapCell, worldId: string): Prom
   const tribeId = cell.base_type === EnumYardType.STRONGHOLD ? tribeIndex + 4 : tribeIndex;
 
   const level = calculateStructureLevel(cellX, cellY, cell.base_type);
-  const baseid = generateBaseId(worldId, cellX, cellY);
+  const baseid = generateBaseId(worldId, cellX, cellY, MapRoomVersion.V3);
 
   // 60% no clover (altitude 5-31), 40% on clovers (altitude 32-49)
   const altitude = 5 + (cellX * 73 + cellY * 31) % 45;

--- a/server/src/controllers/maproom/v3/getCells.ts
+++ b/server/src/controllers/maproom/v3/getCells.ts
@@ -35,11 +35,16 @@ export const getMapRoomCells: KoaController = async (ctx) => {
       return;
     }
 
-    // Convert the IDs the client sends to coordinates
-    const requestedCoords: Coord[] = cellids.map((id) => ({
-      x: id % MapRoom3.WIDTH,
-      y: Math.floor(id / MapRoom3.WIDTH),
-    }));
+    // Note: the client uses 1-based cell IDs (MapRoom3.as: CalculateCellId: y * width + x + 1)
+    // so that cellId 0 can serve as a "no cell" sentinel for uninitialized AS3 ints.
+    // Subtract 1 here to convert back to 0-based grid coordinates.
+    const requestedCoords: Coord[] = cellids.map((id) => {
+      const zeroBasedId = id - 1;
+      return {
+        x: zeroBasedId % MapRoom3.WIDTH,
+        y: Math.floor(zeroBasedId / MapRoom3.WIDTH),
+      };
+    });
 
     const generateCells = getGeneratedCells();
 

--- a/server/src/data/tribes/v3/defenders.ts
+++ b/server/src/data/tribes/v3/defenders.ts
@@ -47,7 +47,7 @@ export const defenders: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 140, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -150,7 +150,7 @@ export const defenders: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 140, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -253,7 +253,7 @@ export const defenders: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 140, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -356,7 +356,7 @@ export const defenders: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 140, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -459,7 +459,7 @@ export const defenders: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 140, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -562,7 +562,7 @@ export const defenders: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 140, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -665,7 +665,7 @@ export const defenders: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 140, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -768,7 +768,7 @@ export const defenders: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 140, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -871,7 +871,7 @@ export const defenders: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 140, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -974,7 +974,7 @@ export const defenders: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 140, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},

--- a/server/src/data/tribes/v3/resources.ts
+++ b/server/src/data/tribes/v3/resources.ts
@@ -47,7 +47,7 @@ export const resources: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 139, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -150,7 +150,7 @@ export const resources: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 139, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -253,7 +253,7 @@ export const resources: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 139, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -356,7 +356,7 @@ export const resources: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 139, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -459,7 +459,7 @@ export const resources: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 139, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},

--- a/server/src/data/tribes/v3/strongholds.ts
+++ b/server/src/data/tribes/v3/strongholds.ts
@@ -47,7 +47,7 @@ export const strongholds: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 138, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -150,7 +150,7 @@ export const strongholds: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 138, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},
@@ -253,7 +253,7 @@ export const strongholds: Record<number, Record<string, any>> = {
     attackid: 0,
     purchasecomplete: 0,
     buildingdata: {
-      "0": { X: -70, Y: 0, t: 14, id: 0 },
+      "0": { X: -70, Y: 0, t: 138, id: 0 },
     },
     buildingkeydata: {},
     researchdata: {},

--- a/server/src/services/maproom/tribeSaveHandler.ts
+++ b/server/src/services/maproom/tribeSaveHandler.ts
@@ -1,0 +1,17 @@
+import { MapRoomVersion } from "../../enums/MapRoom.js";
+import { tribeSaveV2 } from "./v2/tribeSaveV2.js";
+import { tribeSaveV3 } from "./v3/tribeSaveV3.js";
+
+/**
+ * Generates a wild monster Save for the given baseid.
+ * Routes to the correct version handler based on the client's map version.
+ *
+ * @param {string} baseid - The base ID
+ * @param {MapRoomVersion} mapversion - The map room version from the client
+ * @returns {Save | null} A new Save entity for the wild monster, or null
+ */
+export const tribeSaveHandler = (baseid: string, mapversion: MapRoomVersion) => {
+  if (mapversion === MapRoomVersion.V3) return tribeSaveV3(baseid);
+
+  return tribeSaveV2(baseid);
+};

--- a/server/src/services/maproom/v2/tribeSaveV2.ts
+++ b/server/src/services/maproom/v2/tribeSaveV2.ts
@@ -8,7 +8,7 @@ import { kozu } from "../../../data/tribes/v2/kozu.js";
 import { legionnaire } from "../../../data/tribes/v2/legionnaire.js";
 
 /**
- * Generates a save for a wild monster based on the given base ID.
+ * Generates a save for a wild monster on Map Room 2 based on the given base ID.
  *
  * The base ID is used to calculate the cell coordinates (`cellX`, `cellY`)
  * and derive a tribe index from the combined coordinates. Based on the tribe index,
@@ -17,7 +17,7 @@ import { legionnaire } from "../../../data/tribes/v2/legionnaire.js";
  * @param {string} baseid - The base ID as a string, which will be converted to an integer.
  * @returns {Save} - A new `Save` object for the wild monster, with tribe-specific data.
  */
-export const wildMonsterSave = (baseid: string) => {
+export const tribeSaveV2 = (baseid: string) => {
   const cellX = parseInt(baseid.slice(-6, -3));
   const cellY = parseInt(baseid.slice(-3));
 

--- a/server/src/services/maproom/v3/tribeSaveV3.ts
+++ b/server/src/services/maproom/v3/tribeSaveV3.ts
@@ -1,0 +1,40 @@
+import { Save } from "../../../models/save.model.js";
+import { postgres } from "../../../server.js";
+import { EnumYardType } from "../../../enums/EnumYardType.js";
+import { STRUCTURE_SAVES } from "../../../config/MapRoom3Config.js";
+import { getGeneratedCells } from "./generateCells.js";
+import { calculateStructureLevel } from "./calculateStructureLevel.js";
+
+/**
+ * Generates a Save for an MR3 wild monster structure based on baseid.
+ *
+ * Extracts coordinates from the baseid, looks up the structure type from
+ * the generated cell cache, and returns the matching data file entry.
+ * Returns null if the cell type has no associated save data.
+ *
+ * @param {string} baseid - The base ID (15 digits: [3][worldHash:8][X:3][Y:3])
+ * @returns {Save | null} A new Save entity for the wild monster structure, or null
+ */
+export const tribeSaveV3 = (baseid: string): Save | null => {
+  const cellX = parseInt(baseid.slice(-6, -3));
+  const cellY = parseInt(baseid.slice(-3));
+
+  const genCell = getGeneratedCells().get(`${cellX},${cellY}`);
+  const structureType = genCell?.type;
+
+  const tribeSave = STRUCTURE_SAVES[structureType];
+  
+  if (!tribeSave) return null;
+
+  // Defenders use pre-computed levels from generation, others are derived from coordinates
+  const isFortification = structureType === EnumYardType.FORTIFICATION;
+
+  const level = isFortification ? genCell.level : calculateStructureLevel(cellX, cellY, structureType);
+
+  return postgres.em.create(Save, {
+    ...tribeSave[level],
+    baseid,
+    level,
+    wmid: structureType,
+  });
+};

--- a/server/src/utils/generateBaseId.ts
+++ b/server/src/utils/generateBaseId.ts
@@ -21,20 +21,25 @@ const worldIdTo24Bit = (worldId: string): number => {
 /**
  * Generates a deterministic base ID that is safe for use with ActionScript
  * (double-precision numbers), based on worldId and cell coordinates.
- * The worldHash is constrained to 8 digits
+ * The worldHash is constrained to 8 digits.
  *
- * The format is:
- * [worldHash: 8 digits][X: 3 digits][Y: 3 digits] => 14 digits max.
+ * MR2 format: [worldHash: 8][X: 3][Y: 3] => 14 digits
+ * MR3 format: [3][worldHash: 8][X: 3][Y: 3] => 15 digits
+ *
+ * Coordinates are always the last 6 digits regardless of version.
+ * Max safe integer for AS3 doubles is 2^53-1 (16 digits), so 15 is safe.
  *
  * @param {string} worldId - The UUID of the world.
  * @param {number} x - The X coordinate of the cell (max 3 digits, 0–999).
  * @param {number} y - The Y coordinate of the cell (max 3 digits, 0–999).
- * @returns {string} A 14-digit deterministic base ID.
+ * @param {number} version - Map room version prefix (omitted for MR2, 3 for MR3).
+ * @returns {string} A deterministic base ID.
  */
-export const generateBaseId = (worldId: string, x: number, y: number) => {
-const worldHash = (worldIdTo24Bit(worldId) % 90000000) + 10000000;
+export const generateBaseId = (worldId: string, x: number, y: number, version?: number) => {
+  const worldHash = (worldIdTo24Bit(worldId) % 90000000) + 10000000;
+  const prefix = version ? `${version}` : "";
 
-  return `${worldHash}${x.toString().padStart(3, "0")}${y
+  return `${prefix}${worldHash}${x.toString().padStart(3, "0")}${y
     .toString()
     .padStart(3, "0")}`;
 };

--- a/server/src/zod/BaseLoadSchema.ts
+++ b/server/src/zod/BaseLoadSchema.ts
@@ -21,6 +21,12 @@ export const BaseLoadSchema = z.object({
   baseid: z.string(),
 
   /**
+   * The map room version the client is currently in (1, 2, or 3).
+   * @type {number}
+   */
+  mapversion: z.coerce.number(),
+
+  /**
    * The attack payload, transformed from a JSON string to an AttackPayload object.
    * @type {AttackData | undefined}
    */


### PR DESCRIPTION
## Summary

Implements base loading (view/attack) for MR3 wild monster structures (strongholds, resources, defenders) and fixes a critical cellid offset bug that caused all MR3 cell interactions to target the wrong cell.

<br>

## Changes

### Bug Fix: 1-based cellid offset
The client's `MapRoom3.CalculateCellId()` uses 1-based IDs (`y * width + x + 1`) so that cellid 0 can serve as a "no cell" sentinel for uninitialized AS3 ints. The server was decoding these as 0-based, causing every cell coordinate to be off by +1 in the X axis — clicking any cell would load the structure to the right of it. Fixed by subtracting 1 before decoding in `getCells.ts`.

### MR3 base load pipeline
- **`tribeSaveV3.ts`** (new) — Generates a Save for MR3 wild monster structures. Extracts coordinates from baseid, looks up the structure type from the generated cell cache, and returns the matching save template from the data files. Returns null for cell types without data (e.g., tribe outposts).
- **`tribeSaveHandler.ts`** (new) — Routes between `tribeSaveV2` (MR2) and `tribeSaveV3` (MR3) based on the client's `mapversion` field.
- **`tribeSaveV2.ts`** (renamed from `wildMonsters.ts`) — Renamed for consistency with the v2/v3 naming convention.

### Correct building types per structure
Updated server data files to send the correct core building type for each MR3 structure, and updated `BASE.Build()` on the client to force the correct building class:
- Strongholds: `t: 138` (GuardTower)
- Resources: `t: 139` (ResourceOutpost)
- Defenders: `t: 140` (OutpostDefender)
- MR2 outposts: `t: 112` (original outpost building)

### Explicit map version from client
Replaced the `baseid.startsWith("3")` convention for detecting MR3 with an explicit `mapversion` field sent by the client. The client now sends `mapversion` (1, 2, or 3) using `MapRoomManager.instance.mapRoomVersion` in both `base/load` and `base/updatesaved` requests. The server requires this as a non-optional field via the Zod schemas.

### Null save handling
- `tribeSaveV3` returns null for cell types without save data (tribe outposts, terrain, etc.) instead of creating an invalid Save that crashes the client.
- `baseLoad` returns `{ error: 1 }` when baseSave is null.
- `baseModeAttack` throws a descriptive error when save is null.

### Config cleanup
Moved `STRUCTURE_SAVES` lookup map to `MapRoom3Config.ts` alongside `STRUCTURE_LEVELS`, `STRUCTURE_RANGE`, and `DEFENDER_LEVELS` for consistency.
