### PR TITLE
Bugfix: Laser Tower Damage Text Offset

### DIFF
--- a/client/scripts/ATTACK.as
+++ b/client/scripts/ATTACK.as
@@ -910,44 +910,39 @@ package
       {
       }
       
-      public static function damage(param1:Number, param2:IAttackable = null, param3:Number = 0) : void
+      public static function damage(amount:int, damagedTarget:IAttackable = null, amountModified:Number = 0) : void
       {
-         var _loc8_:String = null;
          if(getTimer() - m_lastAttackTime > 400)
          {
             m_recentlyAttacked = new Dictionary();
             m_lastAttackTime = getTimer();
          }
-         var _loc4_:uint = ParticleText.TYPE_DAMAGE;
-         if(param1 < 0)
+         var particleType:uint = (amount < 0) ? ParticleText.TYPE_HEAL : ParticleText.TYPE_DAMAGE;
+         var particleSpawn:Point = new Point(damagedTarget.x,damagedTarget.y);
+         if(damagedTarget is MonsterBase)
          {
-            _loc4_ = ParticleText.TYPE_HEAL;
+            particleSpawn.y -= MonsterBase(damagedTarget)._altitude;
          }
-         var _loc5_:Point = new Point(param2.x,param2.y);
-         if(param2 is MonsterBase)
-         {
-            _loc5_.y -= MonsterBase(param2)._altitude;
-         }
-         var _loc6_:int = int(m_recentlyAttacked[param2]);
-         m_recentlyAttacked[param2] = _loc6_ + 1;
-         if(_loc6_ > 2)
+         var recentAttacks:int = int(m_recentlyAttacked[damagedTarget]);
+         m_recentlyAttacked[damagedTarget] = recentAttacks + 1;
+         if(recentAttacks > 2)
          {
             return;
          }
-         if(_loc6_ == 1)
+         if(recentAttacks == 1)
          {
-            _loc5_.x += 10 * param1.toString().length;
+            particleSpawn.x += 10 * amount.toString().length;
          }
-         else if(_loc6_ == 2)
+         else if(recentAttacks == 2)
          {
-            _loc5_.x -= 10 * param1.toString().length;
+            particleSpawn.x -= 10 * amount.toString().length;
          }
-         var _loc7_:ParticleDamageItem = ParticleText.Create(_loc5_,param1,_loc4_);
-         if(param3 != 0 && Boolean(_loc7_))
+         var damageParticle:ParticleDamageItem = ParticleText.Create(particleSpawn,amount,particleType);
+         if(amountModified != 0 && Boolean(damageParticle))
          {
-            _loc8_ = param3 < 0 ? "-" : "+";
-            _loc7_._mc.tLootA.htmlText += "(" + _loc8_ + Math.abs(Math.round(param3)) + ")";
-            _loc7_._mc.tLootB.htmlText += "(" + _loc8_ + Math.abs(Math.round(param3)) + ")";
+            var modifier:String = amountModified < 0 ? "-" : "+";
+            damageParticle._mc.tLootA.htmlText += "(" + modifier + Math.abs(Math.round(amountModified)) + ")";
+            damageParticle._mc.tLootB.htmlText += "(" + modifier + Math.abs(Math.round(amountModified)) + ")";
          }
       }
       

--- a/client/scripts/com/monsters/monsters/MonsterBase.as
+++ b/client/scripts/com/monsters/monsters/MonsterBase.as
@@ -1179,7 +1179,7 @@ package com.monsters.monsters
          var closestBuilding:Object = null;
          var secondClosestBuilding:Object = null;
          this._looking = true;
-         var checkTarget:Function = function(building)
+         var checkTarget:Function = function(building:BFOUNDATION) : void
          {
             var targetPoint:Point = GRID.FromISO(building._mc.x,building._mc.y + building._middle);
             var distance:Number = GLOBAL.QuickDistance(startPoint,targetPoint) - building._middle;


### PR DESCRIPTION
This pull request is intended to do the following:
- Resolve an issue where damage text particles caused by the Laser Tower have a very high x-offset.
- Fix a compiler warning left by PR #212

All changes are client side.

# Changes:
## Refactored `ATTACK.damage` Function:
**ATTACK.as:**
- Renamed variables.
- Moved `_loc8_`/`modifier` variable declaration to relevant scope.
- Turned `_loc4_`/`particleType` assignment into ternary operator for compactness.

## Laser Tower Damage Text Fix:
**ATTACK.as:** Modified `damage` function's `param1`/`amount` parameter to be an int instead of a Number.

**Context:**
- The function converts the `param1`/`amount` parameter to a string, then uses the string's length to determine how much of an x-offset the damage text should have.
- Since the parameter was a Number, many decimal places contributed to a very long string, thus a large x-offset.
- In almost all cases, the parameter is converted to an int before being passed to `damage` (so no decimals). The laser tower does not convert it to an int before passing it.
- The function that creates the damage text particle (`ParticleText.Create`) already uses an int parameter for the actual text shown, so its safe to assume the `damage` function is also expecting an int.

> **Current Version:**
> *Tesla tower included to show other towers are unaffected by the changes.*

<img width="426" height="160" alt="DamageNoChanges" src="https://github.com/user-attachments/assets/ee1ac4e7-b31d-4407-8bc0-1cc88a257b64" />
</br>
<img width="353" height="125" alt="DamageTesla" src="https://github.com/user-attachments/assets/638ad2e7-ed1c-4756-888d-99ffbad659a0" />

> **With Code Changes:**

<img width="446" height="167" alt="DamageWithChanges" src="https://github.com/user-attachments/assets/24db4ef4-3b87-4fae-8169-31d87d3feab3" />

<img width="357" height="156" alt="DamageTeslaChanges" src="https://github.com/user-attachments/assets/f1f9324d-7a6a-4e56-b40e-c787ba423b30" />

## findTarget Compiler Warning Fix:
**MonsterBase.as:** Edited the `checkTarget` local function to add a type declaration to the building parameter, and a return type declaration.
- Functionality unchanged.

> Removes the following warnings:
> `parameter 'building' for function '' has no type declaration.`
> `return value for function '' has no type declaration.`