### PR TITLE
refactor: removed renderer_friend namespace

### DIFF
--- a/client/scripts/com/monsters/rendering/RasterData.as
+++ b/client/scripts/com/monsters/rendering/RasterData.as
@@ -7,83 +7,81 @@ package com.monsters.rendering
    import flash.filters.BitmapFilter;
    import flash.geom.Point;
    import flash.geom.Rectangle;
-   
-   use namespace renderer_friend;
-   
+      
    public class RasterData
    {
       
-      renderer_friend static const s_rasterData:Vector.<RasterData> = new Vector.<RasterData>();
+      internal static const s_rasterData:Vector.<RasterData> = new Vector.<RasterData>();
       
-      renderer_friend static const s_visibleData:Vector.<RasterData> = new Vector.<RasterData>();
+      internal static const s_visibleData:Vector.<RasterData> = new Vector.<RasterData>();
       
-      renderer_friend static const s_unsortedData:Vector.<RasterData> = new Vector.<RasterData>();
+      internal static const s_unsortedData:Vector.<RasterData> = new Vector.<RasterData>();
       
-      renderer_friend static const s_debugData:Vector.<RasterData> = new Vector.<RasterData>();
+      internal static const s_debugData:Vector.<RasterData> = new Vector.<RasterData>();
       
-      renderer_friend static var s_needsSort:Boolean;
+      internal static var s_needsSort:Boolean;
       
       private static var s_id:uint;
        
       
-      renderer_friend const _id:uint = s_id++;
+      internal const _id:uint = s_id++;
       
-      renderer_friend var _data:IBitmapDrawable;
+      internal var _data:IBitmapDrawable;
       
-      renderer_friend var _pt:Point;
+      internal var _pt:Point;
       
-      renderer_friend var _depth:Number;
+      internal var _depth:Number;
       
-      renderer_friend var _rect:Rectangle;
+      internal var _rect:Rectangle;
       
-      renderer_friend var _blendMode:String;
+      internal var _blendMode:String;
       
-      renderer_friend var _filter:BitmapFilter;
+      internal var _filter:BitmapFilter;
       
-      renderer_friend var _scaleX:int;
+      internal var _scaleX:int;
       
-      renderer_friend var _scaleY:int;
+      internal var _scaleY:int;
       
-      renderer_friend var _alpha:uint;
+      internal var _alpha:uint;
       
-      renderer_friend var _visible:Boolean;
+      internal var _visible:Boolean;
       
-      renderer_friend var _unSorted:Boolean;
+      internal var _unSorted:Boolean;
       
-      renderer_friend var _cleared:Boolean;
+      internal var _cleared:Boolean;
       
-      public function RasterData(param1:IBitmapDrawable, param2:Point, param3:Number, param4:String = null, param5:Boolean = false)
+      public function RasterData(data:IBitmapDrawable, pt:Point, depth:Number, blendMode:String = null, unSorted:Boolean = false)
       {
          super();
-         this.data = param1;
-         this.renderer_friend::_pt = param2;
-         this.renderer_friend::_depth = param3;
-         this.renderer_friend::_blendMode = param4;
-         this.renderer_friend::_scaleX = this.renderer_friend::_scaleY = 100;
-         this.renderer_friend::_alpha = 4278190080;
-         this.renderer_friend::_visible = true;
-         this.renderer_friend::_unSorted = param5;
-         renderer_friend::s_needsSort = this.renderer_friend::_unSorted ? renderer_friend::s_needsSort : true;
-         if(this.renderer_friend::_unSorted)
+         this.data = data;
+         this._pt = pt;
+         this._depth = depth;
+         this._blendMode = blendMode;
+         this._scaleX = this._scaleY = 100;
+         this._alpha = 4278190080;
+         this._visible = true;
+         this._unSorted = unSorted;
+         s_needsSort = this._unSorted ? s_needsSort : true;
+         if(this._unSorted)
          {
-            renderer_friend::s_rasterData[renderer_friend::s_rasterData.length] = this;
-            renderer_friend::s_unsortedData[renderer_friend::s_unsortedData.length] = this;
+            s_rasterData[s_rasterData.length] = this;
+            s_unsortedData[s_unsortedData.length] = this;
          }
          else
          {
-            renderer_friend::s_rasterData[renderer_friend::s_rasterData.length] = this;
-            renderer_friend::s_visibleData[renderer_friend::s_visibleData.length] = this;
+            s_rasterData[s_rasterData.length] = this;
+            s_visibleData[s_visibleData.length] = this;
          }
       }
       
       public static function get rasterData() : Vector.<RasterData>
       {
-         return renderer_friend::s_rasterData;
+         return s_rasterData;
       }
       
       public static function get visibleData() : Vector.<RasterData>
       {
-         return renderer_friend::s_visibleData;
+         return s_visibleData;
       }
       
       public static function get totalMemory() : uint
@@ -91,9 +89,9 @@ package com.monsters.rendering
          var _loc1_:uint = 0;
          var _loc2_:RasterData = null;
          var _loc3_:BitmapData = null;
-         for each(_loc2_ in renderer_friend::s_rasterData)
+         for each(_loc2_ in s_rasterData)
          {
-            _loc3_ = _loc2_.renderer_friend::_data as BitmapData;
+            _loc3_ = _loc2_._data as BitmapData;
             if(_loc3_)
             {
                _loc1_ += _loc3_.getPixels(_loc3_.rect).length;
@@ -102,186 +100,186 @@ package com.monsters.rendering
          return _loc1_;
       }
       
-      renderer_friend static function showDebug() : void
+      internal static function showDebug() : void
       {
          var _loc1_:RasterData = null;
          var _loc2_:BitmapData = null;
          var _loc3_:Shape = null;
-         for each(_loc1_ in renderer_friend::s_rasterData)
+         for each(_loc1_ in s_rasterData)
          {
-            _loc2_ = _loc1_.renderer_friend::_data as BitmapData;
+            _loc2_ = _loc1_._data as BitmapData;
             if(_loc2_)
             {
                _loc3_ = new Shape();
                _loc3_.graphics.lineStyle(1,16711680);
                _loc3_.graphics.beginFill(10027008,0.4);
                _loc3_.graphics.drawRect(0,0,_loc2_.width,_loc2_.height);
-               renderer_friend::s_debugData[renderer_friend::s_debugData.length] = new RasterData(_loc3_,_loc1_.renderer_friend::_pt,_loc1_.renderer_friend::_depth);
+               s_debugData[s_debugData.length] = new RasterData(_loc3_,_loc1_._pt,_loc1_._depth);
             }
          }
       }
       
-      renderer_friend static function hideDebug() : void
+      internal static function hideDebug() : void
       {
          var _loc1_:RasterData = null;
-         for each(_loc1_ in renderer_friend::s_debugData)
+         for each(_loc1_ in s_debugData)
          {
             _loc1_.clear(true);
          }
-         renderer_friend::s_debugData.length = 0;
+         s_debugData.length = 0;
       }
       
       public static function clear(param1:Boolean = false) : void
       {
          var _loc2_:RasterData = null;
-         for each(_loc2_ in renderer_friend::s_rasterData)
+         for each(_loc2_ in s_rasterData)
          {
             _loc2_.clear(param1);
          }
-         renderer_friend::s_unsortedData.length = renderer_friend::s_visibleData.length = renderer_friend::s_rasterData.length = renderer_friend::s_debugData.length = 0;
+         s_unsortedData.length = s_visibleData.length = s_rasterData.length = s_debugData.length = 0;
       }
       
       public function get id() : uint
       {
-         return this.renderer_friend::_id;
+         return this._id;
       }
       
       public function get data() : IBitmapDrawable
       {
-         return this.renderer_friend::_data;
+         return this._data;
       }
       
-      public function set data(param1:IBitmapDrawable) : void
+      public function set data(newData:IBitmapDrawable) : void
       {
-         this.renderer_friend::_data = param1;
+         this._data = newData;
          switch(true)
          {
-            case this.renderer_friend::_data is BitmapData:
-               this.renderer_friend::_rect = (this.renderer_friend::_data as BitmapData).rect;
+            case this._data is BitmapData:
+               this._rect = (this._data as BitmapData).rect;
                break;
-            case this.renderer_friend::_data is MovieClip:
-               this.renderer_friend::_rect = (this.renderer_friend::_data as MovieClip).getRect(this.renderer_friend::_data as MovieClip);
+            case this._data is MovieClip:
+               this._rect = (this._data as MovieClip).getRect(this._data as MovieClip);
                break;
             default:
-               this.renderer_friend::_rect = new Rectangle();
+               this._rect = new Rectangle();
          }
       }
       
-      public function set pt(param1:Point) : void
+      public function set pt(newPt:Point) : void
       {
-         this.renderer_friend::_pt = param1;
+         this._pt = newPt;
       }
       
       public function get rect() : Rectangle
       {
-         return this.renderer_friend::_rect;
+         return this._rect;
       }
       
       public function get depth() : Number
       {
-         return this.renderer_friend::_depth;
+         return this._depth;
       }
       
-      public function set depth(param1:Number) : void
+      public function set depth(newDepth:Number) : void
       {
-         if(this.renderer_friend::_depth !== param1)
+         if(this._depth !== newDepth)
          {
-            renderer_friend::s_needsSort = true;
-            this.renderer_friend::_depth = param1;
+            s_needsSort = true;
+            this._depth = newDepth;
          }
       }
       
-      public function set blendMode(param1:String) : void
+      public function set blendMode(newBlendMode:String) : void
       {
-         this.renderer_friend::_blendMode = param1;
+         this._blendMode = newBlendMode;
       }
       
-      public function set filter(param1:BitmapFilter) : void
+      public function set filter(newFilter:BitmapFilter) : void
       {
-         this.renderer_friend::_filter = param1;
+         this._filter = newFilter;
       }
       
-      public function set scaleX(param1:Number) : void
+      public function set scaleX(newScaleX:Number) : void
       {
-         this.renderer_friend::_scaleX = param1 * 100 >> 0;
+         this._scaleX = newScaleX * 100 >> 0;
       }
       
-      public function set scaleY(param1:Number) : void
+      public function set scaleY(newScaleY:Number) : void
       {
-         this.renderer_friend::_scaleY = param1 * 100 >> 0;
+         this._scaleY = newScaleY * 100 >> 0;
       }
       
-      public function set alpha(param1:Number) : void
+      public function set alpha(newAlpha:Number) : void
       {
-         this.renderer_friend::_alpha = Math.ceil(param1 * 255) << 24;
+         this._alpha = Math.ceil(newAlpha * 255) << 24;
       }
       
       public function get visible() : Boolean
       {
-         return this.renderer_friend::_visible;
+         return this._visible;
       }
       
-      public function set visible(param1:Boolean) : void
+      public function set visible(newVisible:Boolean) : void
       {
-         if(!this.renderer_friend::_visible && param1)
+         if(!this._visible && newVisible)
          {
-            if(this.renderer_friend::_unSorted)
+            if(this._unSorted)
             {
-               renderer_friend::s_unsortedData[renderer_friend::s_unsortedData.length] = this;
+               s_unsortedData[s_unsortedData.length] = this;
             }
             else
             {
-               renderer_friend::s_visibleData[renderer_friend::s_visibleData.length] = this;
+               s_visibleData[s_visibleData.length] = this;
             }
-            renderer_friend::s_needsSort = true;
+            s_needsSort = true;
          }
-         else if(this.renderer_friend::_visible && !param1)
+         else if(this._visible && !newVisible)
          {
-            if(this.renderer_friend::_unSorted)
+            if(this._unSorted)
             {
-               renderer_friend::s_unsortedData.splice(renderer_friend::s_unsortedData.indexOf(this),1);
+               s_unsortedData.splice(s_unsortedData.indexOf(this),1);
             }
             else
             {
-               renderer_friend::s_visibleData.splice(renderer_friend::s_visibleData.indexOf(this),1);
+               s_visibleData.splice(s_visibleData.indexOf(this),1);
             }
-            renderer_friend::s_needsSort = true;
+            s_needsSort = true;
          }
-         this.renderer_friend::_visible = param1;
+         this._visible = newVisible;
       }
       
       public function clone() : RasterData
       {
-         return new RasterData(this.renderer_friend::_data,this.renderer_friend::_pt,this.renderer_friend::_depth);
+         return new RasterData(this._data,this._pt,this._depth);
       }
       
-      public function clear(param1:Boolean = false) : void
+      public function clear(dispose:Boolean = false) : void
       {
-         if(this.renderer_friend::_cleared)
+         if(this._cleared)
          {
             return;
          }
-         renderer_friend::s_rasterData.splice(renderer_friend::s_rasterData.indexOf(this),1);
-         if(this.renderer_friend::_visible)
+         s_rasterData.splice(s_rasterData.indexOf(this),1);
+         if(this._visible)
          {
-            if(this.renderer_friend::_unSorted)
+            if(this._unSorted)
             {
-               renderer_friend::s_unsortedData.splice(renderer_friend::s_unsortedData.indexOf(this),1);
+               s_unsortedData.splice(s_unsortedData.indexOf(this),1);
             }
             else
             {
-               renderer_friend::s_visibleData.splice(renderer_friend::s_visibleData.indexOf(this),1);
+               s_visibleData.splice(s_visibleData.indexOf(this),1);
             }
          }
-         if(param1 && this.renderer_friend::_data is BitmapData)
+         if(dispose && this._data is BitmapData)
          {
-            (this.renderer_friend::_data as BitmapData).dispose();
+            (this._data as BitmapData).dispose();
          }
-         this.renderer_friend::_data = null;
-         this.renderer_friend::_pt = null;
-         this.renderer_friend::_rect = null;
-         this.renderer_friend::_blendMode = null;
-         this.renderer_friend::_cleared = true;
+         this._data = null;
+         this._pt = null;
+         this._rect = null;
+         this._blendMode = null;
+         this._cleared = true;
       }
    }
 }

--- a/client/scripts/com/monsters/rendering/RasterData.as
+++ b/client/scripts/com/monsters/rendering/RasterData.as
@@ -7,83 +7,81 @@ package com.monsters.rendering
    import flash.filters.BitmapFilter;
    import flash.geom.Point;
    import flash.geom.Rectangle;
-   
-   use namespace renderer_friend;
-   
+      
    public class RasterData
    {
       
-      renderer_friend static const s_rasterData:Vector.<RasterData> = new Vector.<RasterData>();
+      internal static const s_rasterData:Vector.<RasterData> = new Vector.<RasterData>();
       
-      renderer_friend static const s_visibleData:Vector.<RasterData> = new Vector.<RasterData>();
+      internal static const s_visibleData:Vector.<RasterData> = new Vector.<RasterData>();
       
-      renderer_friend static const s_unsortedData:Vector.<RasterData> = new Vector.<RasterData>();
+      internal static const s_unsortedData:Vector.<RasterData> = new Vector.<RasterData>();
       
-      renderer_friend static const s_debugData:Vector.<RasterData> = new Vector.<RasterData>();
+      internal static const s_debugData:Vector.<RasterData> = new Vector.<RasterData>();
       
-      renderer_friend static var s_needsSort:Boolean;
+      internal static var s_needsSort:Boolean;
       
       private static var s_id:uint;
        
       
-      renderer_friend const _id:uint = s_id++;
+      internal const _id:uint = s_id++;
       
-      renderer_friend var _data:IBitmapDrawable;
+      internal var _data:IBitmapDrawable;
       
-      renderer_friend var _pt:Point;
+      internal var _pt:Point;
       
-      renderer_friend var _depth:Number;
+      internal var _depth:Number;
       
-      renderer_friend var _rect:Rectangle;
+      internal var _rect:Rectangle;
       
-      renderer_friend var _blendMode:String;
+      internal var _blendMode:String;
       
-      renderer_friend var _filter:BitmapFilter;
+      internal var _filter:BitmapFilter;
       
-      renderer_friend var _scaleX:int;
+      internal var _scaleX:int;
       
-      renderer_friend var _scaleY:int;
+      internal var _scaleY:int;
       
-      renderer_friend var _alpha:uint;
+      internal var _alpha:uint;
       
-      renderer_friend var _visible:Boolean;
+      internal var _visible:Boolean;
       
-      renderer_friend var _unSorted:Boolean;
+      internal var _unSorted:Boolean;
       
-      renderer_friend var _cleared:Boolean;
+      internal var _cleared:Boolean;
       
-      public function RasterData(param1:IBitmapDrawable, param2:Point, param3:Number, param4:String = null, param5:Boolean = false)
+      public function RasterData(data:IBitmapDrawable, pt:Point, depth:Number, blendMode:String = null, unSorted:Boolean = false)
       {
          super();
-         this.data = param1;
-         this.renderer_friend::_pt = param2;
-         this.renderer_friend::_depth = param3;
-         this.renderer_friend::_blendMode = param4;
-         this.renderer_friend::_scaleX = this.renderer_friend::_scaleY = 100;
-         this.renderer_friend::_alpha = 4278190080;
-         this.renderer_friend::_visible = true;
-         this.renderer_friend::_unSorted = param5;
-         renderer_friend::s_needsSort = this.renderer_friend::_unSorted ? renderer_friend::s_needsSort : true;
-         if(this.renderer_friend::_unSorted)
+         this.data = data;
+         this._pt = pt;
+         this._depth = depth;
+         this._blendMode = blendMode;
+         this._scaleX = this._scaleY = 100;
+         this._alpha = 4278190080;
+         this._visible = true;
+         this._unSorted = unSorted;
+         s_needsSort = this._unSorted ? s_needsSort : true;
+         if(this._unSorted)
          {
-            renderer_friend::s_rasterData[renderer_friend::s_rasterData.length] = this;
-            renderer_friend::s_unsortedData[renderer_friend::s_unsortedData.length] = this;
+            s_rasterData[s_rasterData.length] = this;
+            s_unsortedData[s_unsortedData.length] = this;
          }
          else
          {
-            renderer_friend::s_rasterData[renderer_friend::s_rasterData.length] = this;
-            renderer_friend::s_visibleData[renderer_friend::s_visibleData.length] = this;
+            s_rasterData[s_rasterData.length] = this;
+            s_visibleData[s_visibleData.length] = this;
          }
       }
       
       public static function get rasterData() : Vector.<RasterData>
       {
-         return renderer_friend::s_rasterData;
+         return s_rasterData;
       }
       
       public static function get visibleData() : Vector.<RasterData>
       {
-         return renderer_friend::s_visibleData;
+         return s_visibleData;
       }
       
       public static function get totalMemory() : uint
@@ -91,9 +89,9 @@ package com.monsters.rendering
          var _loc1_:uint = 0;
          var _loc2_:RasterData = null;
          var _loc3_:BitmapData = null;
-         for each(_loc2_ in renderer_friend::s_rasterData)
+         for each(_loc2_ in s_rasterData)
          {
-            _loc3_ = _loc2_.renderer_friend::_data as BitmapData;
+            _loc3_ = _loc2_._data as BitmapData;
             if(_loc3_)
             {
                _loc1_ += _loc3_.getPixels(_loc3_.rect).length;
@@ -102,215 +100,215 @@ package com.monsters.rendering
          return _loc1_;
       }
       
-      renderer_friend static function showDebug() : void
+      internal static function showDebug() : void
       {
          var _loc1_:RasterData = null;
          var _loc2_:BitmapData = null;
          var _loc3_:Shape = null;
-         for each(_loc1_ in renderer_friend::s_rasterData)
+         for each(_loc1_ in s_rasterData)
          {
-            _loc2_ = _loc1_.renderer_friend::_data as BitmapData;
+            _loc2_ = _loc1_._data as BitmapData;
             if(_loc2_)
             {
                _loc3_ = new Shape();
                _loc3_.graphics.lineStyle(1,16711680);
                _loc3_.graphics.beginFill(10027008,0.4);
                _loc3_.graphics.drawRect(0,0,_loc2_.width,_loc2_.height);
-               renderer_friend::s_debugData[renderer_friend::s_debugData.length] = new RasterData(_loc3_,_loc1_.renderer_friend::_pt,_loc1_.renderer_friend::_depth);
+               s_debugData[s_debugData.length] = new RasterData(_loc3_,_loc1_._pt,_loc1_._depth);
             }
          }
       }
       
-      renderer_friend static function hideDebug() : void
+      internal static function hideDebug() : void
       {
          var _loc1_:RasterData = null;
-         for each(_loc1_ in renderer_friend::s_debugData)
+         for each(_loc1_ in s_debugData)
          {
             _loc1_.clear(true);
          }
-         renderer_friend::s_debugData.length = 0;
+         s_debugData.length = 0;
       }
       
       public static function clear(param1:Boolean = false) : void
       {
          var _loc2_:RasterData = null;
-         for each(_loc2_ in renderer_friend::s_rasterData)
+         for each(_loc2_ in s_rasterData)
          {
             _loc2_.clear(param1);
          }
-         renderer_friend::s_unsortedData.length = renderer_friend::s_visibleData.length = renderer_friend::s_rasterData.length = renderer_friend::s_debugData.length = 0;
+         s_unsortedData.length = s_visibleData.length = s_rasterData.length = s_debugData.length = 0;
       }
       
       public function get id() : uint
       {
-         return this.renderer_friend::_id;
+         return this._id;
       }
       
       public function get data() : IBitmapDrawable
       {
-         return this.renderer_friend::_data;
+         return this._data;
       }
       
-      public function set data(param1:IBitmapDrawable) : void
+      public function set data(newData:IBitmapDrawable) : void
       {
-         this.renderer_friend::_data = param1;
+         this._data = newData;
          switch(true)
          {
-            case this.renderer_friend::_data is BitmapData:
-               this.renderer_friend::_rect = (this.renderer_friend::_data as BitmapData).rect;
+            case this._data is BitmapData:
+               this._rect = (this._data as BitmapData).rect;
                break;
-            case this.renderer_friend::_data is MovieClip:
-               this.renderer_friend::_rect = (this.renderer_friend::_data as MovieClip).getRect(this.renderer_friend::_data as MovieClip);
+            case this._data is MovieClip:
+               this._rect = (this._data as MovieClip).getRect(this._data as MovieClip);
                break;
             default:
-               this.renderer_friend::_rect = new Rectangle();
+               this._rect = new Rectangle();
          }
       }
       
-      public function set pt(param1:Point) : void
+      public function set pt(newPt:Point) : void
       {
-         this.renderer_friend::_pt = param1;
+         this._pt = newPt;
       }
       
       public function get rect() : Rectangle
       {
-         return this.renderer_friend::_rect;
+         return this._rect;
       }
       
       public function get depth() : Number
       {
-         return this.renderer_friend::_depth;
+         return this._depth;
       }
       
-      public function set depth(param1:Number) : void
+      public function set depth(newDepth:Number) : void
       {
-         if(this.renderer_friend::_depth !== param1)
+         if(this._depth !== newDepth)
          {
-            renderer_friend::s_needsSort = true;
-            this.renderer_friend::_depth = param1;
+            s_needsSort = true;
+            this._depth = newDepth;
          }
       }
       
-      public function set blendMode(param1:String) : void
+      public function set blendMode(newBlendMode:String) : void
       {
-         this.renderer_friend::_blendMode = param1;
+         this._blendMode = newBlendMode;
       }
       
-      public function set filter(param1:BitmapFilter) : void
+      public function set filter(newFilter:BitmapFilter) : void
       {
-         this.renderer_friend::_filter = param1;
+         this._filter = newFilter;
       }
       
-      public function set scaleX(param1:Number) : void
+      public function set scaleX(newScaleX:Number) : void
       {
-         this.renderer_friend::_scaleX = param1 * 100 >> 0;
+         this._scaleX = newScaleX * 100 >> 0;
       }
       
-      public function set scaleY(param1:Number) : void
+      public function set scaleY(newScaleY:Number) : void
       {
-         this.renderer_friend::_scaleY = param1 * 100 >> 0;
+         this._scaleY = newScaleY * 100 >> 0;
       }
       
-      public function set alpha(param1:Number) : void
+      public function set alpha(newAlpha:Number) : void
       {
-         this.renderer_friend::_alpha = Math.ceil(param1 * 255) << 24;
+         this._alpha = Math.ceil(newAlpha * 255) << 24;
       }
       
       public function get visible() : Boolean
       {
-         return this.renderer_friend::_visible;
+         return this._visible;
       }
       
-      public function set visible(param1:Boolean) : void
+      public function set visible(newVisible:Boolean) : void
       {
-         if (this.renderer_friend::_cleared) return;
+         if (this._cleared) return;
 
          var idx:int = 0;
-         
-         if(!this.renderer_friend::_visible && param1)
+
+         if(!this._visible && newVisible)
          {
-            if(this.renderer_friend::_unSorted)
+            if(this._unSorted)
             {
-               renderer_friend::s_unsortedData[renderer_friend::s_unsortedData.length] = this;
+               s_unsortedData[s_unsortedData.length] = this;
             }
             else
             {
-               renderer_friend::s_visibleData[renderer_friend::s_visibleData.length] = this;
+               s_visibleData[s_visibleData.length] = this;
             }
-            renderer_friend::s_needsSort = true;
+            s_needsSort = true;
          }
-         else if(this.renderer_friend::_visible && !param1)
+         else if(this._visible && !newVisible)
          {
-            if(this.renderer_friend::_unSorted)
+            if(this._unSorted)
             {
-               idx = renderer_friend::s_unsortedData.indexOf(this);
+               idx = s_unsortedData.indexOf(this);
 
                if(idx >= 0)
                {
-                  renderer_friend::s_unsortedData.splice(idx,1);
+                  s_unsortedData.splice(idx,1);
                }
             }
             else
             {
-               idx = renderer_friend::s_visibleData.indexOf(this);
+               idx = s_visibleData.indexOf(this);
 
                if(idx >= 0)
                {
-                  renderer_friend::s_visibleData.splice(idx,1);
+                  s_visibleData.splice(idx,1);
                }
             }
-            renderer_friend::s_needsSort = true;
+            s_needsSort = true;
          }
-         this.renderer_friend::_visible = param1;
+         this._visible = newVisible;
       }
       
       public function clone() : RasterData
       {
-         return new RasterData(this.renderer_friend::_data,this.renderer_friend::_pt,this.renderer_friend::_depth);
+         return new RasterData(this._data,this._pt,this._depth);
       }
       
-      public function clear(param1:Boolean = false) : void
+      public function clear(dispose:Boolean = false) : void
       {
-         if(this.renderer_friend::_cleared)
+         if(this._cleared)
          {
             return;
          }
-         var idx:int = renderer_friend::s_rasterData.indexOf(this);
+         var idx:int = s_rasterData.indexOf(this);
 
          if(idx >= 0)
          {
-            renderer_friend::s_rasterData.splice(idx,1);
+            s_rasterData.splice(idx,1);
          }
-         if(this.renderer_friend::_visible)
+         if(this._visible)
          {
-            if(this.renderer_friend::_unSorted)
+            if(this._unSorted)
             {
-               idx = renderer_friend::s_unsortedData.indexOf(this);
+               idx = s_unsortedData.indexOf(this);
 
                if(idx >= 0)
                {
-                  renderer_friend::s_unsortedData.splice(idx,1);
+                  s_unsortedData.splice(idx,1);
                }
             }
             else
             {
-               idx = renderer_friend::s_visibleData.indexOf(this);
+               idx = s_visibleData.indexOf(this);
 
                if(idx >= 0)
                {
-                  renderer_friend::s_visibleData.splice(idx,1);
+                  s_visibleData.splice(idx,1);
                }
             }
          }
-         if(param1 && this.renderer_friend::_data is BitmapData)
+         if(dispose && this._data is BitmapData)
          {
-            (this.renderer_friend::_data as BitmapData).dispose();
+            (this._data as BitmapData).dispose();
          }
-         this.renderer_friend::_data = null;
-         this.renderer_friend::_pt = null;
-         this.renderer_friend::_rect = null;
-         this.renderer_friend::_blendMode = null;
-         this.renderer_friend::_cleared = true;
+         this._data = null;
+         this._pt = null;
+         this._rect = null;
+         this._blendMode = null;
+         this._cleared = true;
       }
    }
 }

--- a/client/scripts/com/monsters/rendering/RasterData.as
+++ b/client/scripts/com/monsters/rendering/RasterData.as
@@ -121,21 +121,32 @@ package com.monsters.rendering
       
       internal static function hideDebug() : void
       {
-         var _loc1_:RasterData = null;
-         for each(_loc1_ in s_debugData)
+         var rasterData:RasterData = null;
+         while(s_debugData.length > 0)
          {
-            _loc1_.clear(true);
+            rasterData = s_debugData.pop();
+            rasterData.clear(true);
          }
-         s_debugData.length = 0;
       }
       
-      public static function clear(param1:Boolean = false) : void
+      public static function clear(dispose:Boolean = false) : void
       {
-         var _loc2_:RasterData = null;
-         for each(_loc2_ in s_rasterData)
+         var rasterData:RasterData = null;
+
+         while(s_rasterData.length > 0)
          {
-            _loc2_.clear(param1);
+            rasterData = s_rasterData.pop();
+            rasterData.clear(dispose, false);
          }
+
+         // A correct drain leaves these empty. Anything left means the registries
+         // desynced and truncating alone won't neutralise it, since the stale entry 
+         // is still _cleared == false and can re-add itself via set visible.
+         if(s_visibleData.length > 0 || s_unsortedData.length > 0)
+         {
+            LOGGER.Log("error","RasterData.clear() registry desync: visible=" + s_visibleData.length + " unsorted=" + s_unsortedData.length + " | both should be 0.");
+         }
+
          s_unsortedData.length = s_visibleData.length = s_rasterData.length = s_debugData.length = 0;
       }
       
@@ -267,13 +278,14 @@ package com.monsters.rendering
          return new RasterData(this._data,this._pt,this._depth);
       }
       
-      public function clear(dispose:Boolean = false) : void
+      public function clear(dispose:Boolean = false, shouldSpliceFromCollection:Boolean = true) : void
       {
          if(this._cleared)
          {
             return;
          }
-         var idx:int = s_rasterData.indexOf(this);
+         // shouldSpliceFromCollection is used to avoid splicing the same RasterData multiple times when clear() is called from RasterData.clear() static method
+         var idx:int = shouldSpliceFromCollection ? s_rasterData.indexOf(this) : -1;
 
          if(idx >= 0)
          {

--- a/client/scripts/com/monsters/rendering/Renderer.as
+++ b/client/scripts/com/monsters/rendering/Renderer.as
@@ -7,19 +7,17 @@ package com.monsters.rendering
    import flash.geom.Point;
    import flash.geom.Rectangle;
    
-   use namespace renderer_friend;
-   
    public class Renderer
    {
       
-      renderer_friend static var _debug:Boolean;
+      internal static var _debug:Boolean;
       
       private static var _debugShape:Shape;
        
       
-      renderer_friend var _canvas:BitmapData;
+      internal var _canvas:BitmapData;
       
-      renderer_friend var _viewRect:Rectangle;
+      internal var _viewRect:Rectangle;
       
       private const _matrix:Matrix = new Matrix();
       
@@ -34,47 +32,47 @@ package com.monsters.rendering
       public function Renderer(param1:BitmapData, param2:Rectangle)
       {
          super();
-         this.renderer_friend::_canvas = param1;
-         this.renderer_friend::_viewRect = param2;
+         this._canvas = param1;
+         this._viewRect = param2;
       }
       
       public static function get debug() : Boolean
       {
-         return renderer_friend::_debug;
+         return _debug;
       }
       
       public static function set debug(param1:Boolean) : void
       {
-         renderer_friend::_debug = param1;
-         if(renderer_friend::_debug)
+         _debug = param1;
+         if(_debug)
          {
             _debugShape = _debugShape || new Shape();
-            RasterData.renderer_friend::showDebug();
+            RasterData.showDebug();
          }
          else
          {
             _debugShape = null;
-            RasterData.renderer_friend::hideDebug();
+            RasterData.hideDebug();
          }
       }
       
       public function set canvas(param1:BitmapData) : void
       {
-         this.renderer_friend::_canvas = param1;
+         this._canvas = param1;
       }
       
       public function render() : void
       {
-         var _loc1_:Vector.<RasterData> = RasterData.renderer_friend::s_visibleData;
+         var _loc1_:Vector.<RasterData> = RasterData.s_visibleData;
          this._curCopyIndex = this._curDrawIndex = 0;
-         if(RasterData.renderer_friend::s_needsSort)
+         if(RasterData.s_needsSort)
          {
             _loc1_.sort(this.sortRasterData);
-            RasterData.renderer_friend::s_needsSort = false;
+            RasterData.s_needsSort = false;
          }
-         this.renderer_friend::_canvas.lock();
-         this.rasterize(RasterData.renderer_friend::s_unsortedData.concat(_loc1_));
-         this.renderer_friend::_canvas.unlock();
+         this._canvas.lock();
+         this.rasterize(RasterData.s_unsortedData.concat(_loc1_));
+         this._canvas.unlock();
       }
       
       private function cull(param1:Vector.<RasterData>) : void
@@ -84,9 +82,9 @@ package com.monsters.rendering
          var _loc2_:Vector.<RasterData> = param1;
          for each(_loc3_ in _loc2_)
          {
-            (_loc4_ = _loc3_.renderer_friend::_rect).x = _loc3_.renderer_friend::_pt.x;
-            _loc4_.y = _loc3_.renderer_friend::_pt.y;
-            if(this.renderer_friend::_viewRect.intersects(_loc4_))
+            (_loc4_ = _loc3_._rect).x = _loc3_._pt.x;
+            _loc4_.y = _loc3_._pt.y;
+            if(this._viewRect.intersects(_loc4_))
             {
                _loc2_[_loc2_.length] = _loc3_;
             }
@@ -95,7 +93,7 @@ package com.monsters.rendering
       
       private function sortRasterData(param1:RasterData, param2:RasterData) : Number
       {
-         return param1.renderer_friend::_depth - param2.renderer_friend::_depth;
+         return param1._depth - param2._depth;
       }
       
       private function rasterize(param1:Vector.<RasterData>) : void
@@ -109,16 +107,16 @@ package com.monsters.rendering
          var _loc3_:int = int(_loc2_.length);
          while(_loc7_ < _loc3_)
          {
-            _loc5_ = (_loc4_ = _loc2_[_loc7_]).renderer_friend::_data as BitmapData;
-            this._pt.x = _loc4_.renderer_friend::_pt.x;
-            this._pt.y = _loc4_.renderer_friend::_pt.y;
-            if(_loc5_ && !_loc4_.renderer_friend::_blendMode && !_loc4_.renderer_friend::_filter && (_loc4_.renderer_friend::_scaleX & _loc4_.renderer_friend::_scaleY) === 100)
+            _loc5_ = (_loc4_ = _loc2_[_loc7_])._data as BitmapData;
+            this._pt.x = _loc4_._pt.x;
+            this._pt.y = _loc4_._pt.y;
+            if(_loc5_ && !_loc4_._blendMode && !_loc4_._filter && (_loc4_._scaleX & _loc4_._scaleY) === 100)
             {
-               if(_loc4_.renderer_friend::_alpha !== 4278190080)
+               if(_loc4_._alpha !== 4278190080)
                {
-                  _loc6_ = new BitmapData(_loc5_.width,_loc5_.height,true,_loc4_.renderer_friend::_alpha);
+                  _loc6_ = new BitmapData(_loc5_.width,_loc5_.height,true,_loc4_._alpha);
                }
-               this.renderer_friend::_canvas.copyPixels(_loc5_,_loc5_.rect,this._pt,_loc6_);
+               this._canvas.copyPixels(_loc5_,_loc5_.rect,this._pt,_loc6_);
                if(_loc6_)
                {
                   _loc6_.dispose();
@@ -127,16 +125,16 @@ package com.monsters.rendering
             }
             else
             {
-               this._matrix.createBox(_loc4_.renderer_friend::_scaleX * 0.01,_loc4_.renderer_friend::_scaleY * 0.01,0,this._pt.x,this._pt.y);
-               if(Boolean(_loc4_.renderer_friend::_filter) && Boolean(_loc5_))
+               this._matrix.createBox(_loc4_._scaleX * 0.01,_loc4_._scaleY * 0.01,0,this._pt.x,this._pt.y);
+               if(Boolean(_loc4_._filter) && Boolean(_loc5_))
                {
                   this._bm.bitmapData = _loc5_;
-                  this._bm.filters = [_loc4_.renderer_friend::_filter];
-                  this.renderer_friend::_canvas.draw(this._bm,this._matrix,null,_loc4_.renderer_friend::_blendMode);
+                  this._bm.filters = [_loc4_._filter];
+                  this._canvas.draw(this._bm,this._matrix,null,_loc4_._blendMode);
                }
                else
                {
-                  this.renderer_friend::_canvas.draw(_loc4_.renderer_friend::_data,this._matrix,null,_loc4_.renderer_friend::_blendMode);
+                  this._canvas.draw(_loc4_._data,this._matrix,null,_loc4_._blendMode);
                }
             }
             _loc7_++;

--- a/client/scripts/com/monsters/rendering/Renderer.as
+++ b/client/scripts/com/monsters/rendering/Renderer.as
@@ -71,8 +71,14 @@ package com.monsters.rendering
             RasterData.s_needsSort = false;
          }
          this._canvas.lock();
-         this.rasterize(RasterData.s_unsortedData.concat(_loc1_));
-         this._canvas.unlock();
+         try {
+            this.rasterize(RasterData.s_unsortedData.concat(_loc1_));
+         } catch(e:Error) {
+            LOGGER.Log("error", "Renderer.render() error: " + e.message + " stack: " + e.getStackTrace());
+         } finally {
+            // Ensure the canvas is unlocked even if an error occurs
+            this._canvas.unlock();
+         }
       }
       
       private function cull(param1:Vector.<RasterData>) : void
@@ -120,7 +126,7 @@ package com.monsters.rendering
             this._pt.y = entry._pt.y;
             if(entryBmd && !entry._blendMode && !entry._filter && (entry._scaleX & entry._scaleY) === 100)
             {
-               if(entry._alpha !== 4278190080)
+               if(entry._alpha !== 0xFF000000)
                {
                   alphaMask = new BitmapData(entryBmd.width,entryBmd.height,true,entry._alpha);
                }

--- a/client/scripts/com/monsters/rendering/Renderer.as
+++ b/client/scripts/com/monsters/rendering/Renderer.as
@@ -7,19 +7,17 @@ package com.monsters.rendering
    import flash.geom.Point;
    import flash.geom.Rectangle;
    
-   use namespace renderer_friend;
-   
    public class Renderer
    {
       
-      renderer_friend static var _debug:Boolean;
+      internal static var _debug:Boolean;
       
       private static var _debugShape:Shape;
        
       
-      renderer_friend var _canvas:BitmapData;
+      internal var _canvas:BitmapData;
       
-      renderer_friend var _viewRect:Rectangle;
+      internal var _viewRect:Rectangle;
       
       private const _matrix:Matrix = new Matrix();
       
@@ -34,47 +32,47 @@ package com.monsters.rendering
       public function Renderer(param1:BitmapData, param2:Rectangle)
       {
          super();
-         this.renderer_friend::_canvas = param1;
-         this.renderer_friend::_viewRect = param2;
+         this._canvas = param1;
+         this._viewRect = param2;
       }
       
       public static function get debug() : Boolean
       {
-         return renderer_friend::_debug;
+         return _debug;
       }
       
       public static function set debug(param1:Boolean) : void
       {
-         renderer_friend::_debug = param1;
-         if(renderer_friend::_debug)
+         _debug = param1;
+         if(_debug)
          {
             _debugShape = _debugShape || new Shape();
-            RasterData.renderer_friend::showDebug();
+            RasterData.showDebug();
          }
          else
          {
             _debugShape = null;
-            RasterData.renderer_friend::hideDebug();
+            RasterData.hideDebug();
          }
       }
       
       public function set canvas(param1:BitmapData) : void
       {
-         this.renderer_friend::_canvas = param1;
+         this._canvas = param1;
       }
       
       public function render() : void
       {
-         var _loc1_:Vector.<RasterData> = RasterData.renderer_friend::s_visibleData;
+         var _loc1_:Vector.<RasterData> = RasterData.s_visibleData;
          this._curCopyIndex = this._curDrawIndex = 0;
-         if(RasterData.renderer_friend::s_needsSort)
+         if(RasterData.s_needsSort)
          {
             _loc1_.sort(this.sortRasterData);
-            RasterData.renderer_friend::s_needsSort = false;
+            RasterData.s_needsSort = false;
          }
-         this.renderer_friend::_canvas.lock();
-         this.rasterize(RasterData.renderer_friend::s_unsortedData.concat(_loc1_));
-         this.renderer_friend::_canvas.unlock();
+         this._canvas.lock();
+         this.rasterize(RasterData.s_unsortedData.concat(_loc1_));
+         this._canvas.unlock();
       }
       
       private function cull(param1:Vector.<RasterData>) : void
@@ -84,9 +82,9 @@ package com.monsters.rendering
          var _loc2_:Vector.<RasterData> = param1;
          for each(_loc3_ in _loc2_)
          {
-            (_loc4_ = _loc3_.renderer_friend::_rect).x = _loc3_.renderer_friend::_pt.x;
-            _loc4_.y = _loc3_.renderer_friend::_pt.y;
-            if(this.renderer_friend::_viewRect.intersects(_loc4_))
+            (_loc4_ = _loc3_._rect).x = _loc3_._pt.x;
+            _loc4_.y = _loc3_._pt.y;
+            if(this._viewRect.intersects(_loc4_))
             {
                _loc2_[_loc2_.length] = _loc3_;
             }
@@ -95,7 +93,7 @@ package com.monsters.rendering
       
       private function sortRasterData(param1:RasterData, param2:RasterData) : Number
       {
-         return param1.renderer_friend::_depth - param2.renderer_friend::_depth;
+         return param1._depth - param2._depth;
       }
       
       private function rasterize(param1:Vector.<RasterData>) : void
@@ -112,21 +110,21 @@ package com.monsters.rendering
          while(i < len)
          {
             entry = entries[i];
-            if(!entry || entry.renderer_friend::_cleared || !entry.renderer_friend::_pt)
+            if(!entry || entry._cleared || !entry._pt)
             {
                i++;
                continue;
             }
-            entryBmd = entry.renderer_friend::_data as BitmapData;
-            this._pt.x = entry.renderer_friend::_pt.x;
-            this._pt.y = entry.renderer_friend::_pt.y;
-            if(entryBmd && !entry.renderer_friend::_blendMode && !entry.renderer_friend::_filter && (entry.renderer_friend::_scaleX & entry.renderer_friend::_scaleY) === 100)
+            entryBmd = entry._data as BitmapData;
+            this._pt.x = entry._pt.x;
+            this._pt.y = entry._pt.y;
+            if(entryBmd && !entry._blendMode && !entry._filter && (entry._scaleX & entry._scaleY) === 100)
             {
-               if(entry.renderer_friend::_alpha !== 4278190080)
+               if(entry._alpha !== 4278190080)
                {
-                  alphaMask = new BitmapData(entryBmd.width,entryBmd.height,true,entry.renderer_friend::_alpha);
+                  alphaMask = new BitmapData(entryBmd.width,entryBmd.height,true,entry._alpha);
                }
-               this.renderer_friend::_canvas.copyPixels(entryBmd,entryBmd.rect,this._pt,alphaMask);
+               this._canvas.copyPixels(entryBmd,entryBmd.rect,this._pt,alphaMask);
                if(alphaMask)
                {
                   alphaMask.dispose();
@@ -135,16 +133,16 @@ package com.monsters.rendering
             }
             else
             {
-               this._matrix.createBox(entry.renderer_friend::_scaleX * 0.01,entry.renderer_friend::_scaleY * 0.01,0,this._pt.x,this._pt.y);
-               if(Boolean(entry.renderer_friend::_filter) && Boolean(entryBmd))
+               this._matrix.createBox(entry._scaleX * 0.01,entry._scaleY * 0.01,0,this._pt.x,this._pt.y);
+               if(Boolean(entry._filter) && Boolean(entryBmd))
                {
                   this._bm.bitmapData = entryBmd;
-                  this._bm.filters = [entry.renderer_friend::_filter];
-                  this.renderer_friend::_canvas.draw(this._bm,this._matrix,null,entry.renderer_friend::_blendMode);
+                  this._bm.filters = [entry._filter];
+                  this._canvas.draw(this._bm,this._matrix,null,entry._blendMode);
                }
                else
                {
-                  this.renderer_friend::_canvas.draw(entry.renderer_friend::_data,this._matrix,null,entry.renderer_friend::_blendMode);
+                  this._canvas.draw(entry._data,this._matrix,null,entry._blendMode);
                }
             }
             i++;

--- a/client/scripts/com/monsters/rendering/renderer_friend.as
+++ b/client/scripts/com/monsters/rendering/renderer_friend.as
@@ -1,4 +1,0 @@
-package com.monsters.rendering
-{
-   public namespace renderer_friend;
-}


### PR DESCRIPTION
Note: this replaces PR #224, the PR branch was moved from my fork to the main repo.

# Summary

This PR deletes the `renderer_friend` namespace used by the `RasterData` and `Renderer` classes and fixes a critical bug inside the static `RasterData::clear` method, which surfaced following this refactor.

# Context

The `renderer_friend` namespace essentially allowed the two classes to internally share several properties while hiding them to the outside scope.

# Motivation

The reason for this change is somewhat related to my plan to attempt to port the client codebase to Haxe. As that that language does not support custom namespaces, it makes sense to limit the client codebase to a language subset that is shared between AS3 and Haxe.

# Impact

This change should not have any impact on the client behavior. The `renderer_friend` namespace was shared by the two classes mentioned above. As they both share the same package and no other class uses that namespace, migrating the namespace usage to the (package)-`internal` namespace effectively makes no difference.

The change would only be noticable if we started adding classes to the `com.monsters.renderer`- package, as the new classes would then be able to access the internal fields by `Renderer` and `RasterData`.

# Bugfix: `RasterData.clear()` only cleared half of its entries (opening the worldmap seg-faults the flash player on MacOS)

Opening the worldmap calls `BASE.Cleanup()` → `RasterData.clear()`, which could hard-crash the Flash Player on MacOS (it is untested whether other platforms were affected).

The static function `clear()` iterated the registry with `for each` while the instance-function `clear()` splices `this` (itself) out of that same vector:

```as3
for each(_loc2_ in s_rasterData)
{
   _loc2_.clear(param1);   // splices itself out of s_rasterData
}
```

`for each` over a `Vector` uses an incrementing index, so every splice shifts the remaining elements left *past* that cursor. Given `[A,B,C,D,E,F]` it visits `A`, `C`, `E` and stops, so `⌊N/2⌋` entries are never cleared. The trailing `length = 0` then dropped them from the registry regardless.

Those survivors are what crashes: they keep `_cleared == false` and a live `_data`, and `_cleared` is exactly the flag every defensive guard keys on (`Renderer.rasterize`, `set visible`). So a survivor looks valid to every guard while the bitmaps it points at are disposed around it, and it can re-add itself to `s_visibleData` through `set visible` — after which the renderer blits from a disposed `BitmapData`.

The fix drains the vector instead of iterating it, so every entry is visited exactly once:

```as3
while(s_rasterData.length > 0)
{
   rasterData = s_rasterData.pop();
   rasterData.clear(dispose, false);
}
```

`hideDebug()` was given the same treatment. The new `attemptSplice` parameter on the instance `clear()` lets the drain skip the now-pointless `indexOf` lookup, since `pop()` has already removed the entry.

----

# TL:DR

The PR replaces the `renderer_friend` namespace with the `internal` namespace.
This has no effect on the client logic, but makes later migration to Haxe easier.

It also fixes a modify-while-iterate bug in the static RasterData.clear() function that left half of all RasterData instances un-cleared, causing the Flash Player crash when opening the worldmap.