### PR TITLE
Error Handling Refactor: Fail-Fast Pattern & Attack Guards

### DIFF
--- a/server/src/controllers/base/load/baseLoad.ts
+++ b/server/src/controllers/base/load/baseLoad.ts
@@ -18,7 +18,6 @@ import { getHexDistance } from "../../../services/maproom/v3/getHexNeighborOffse
 import { Status } from "../../../enums/StatusCodes.js";
 import { baseModeView } from "./modes/baseModeView.js";
 import { baseModeBuild } from "./modes/baseModeBuild.js";
-import { logger } from "../../../utils/logger.js";
 import { baseModeAttack } from "./modes/baseModeAttack.js";
 import { mapUserSaveData } from "../mapUserSaveData.js";
 import { infernoModeDescent } from "./modes/infernoModeDescent.js";
@@ -42,209 +41,203 @@ export const baseLoad: KoaController = async (ctx) => {
   const user: User = ctx.authUser;
   await postgres.em.populate(user, ["save", "infernosave"]);
 
-  try {
-    const worldid = user.save?.worldid;
-    const { baseid, type, mapversion, attackData, attackcost } = BaseLoadSchema.parse(ctx.request.body);
+  const worldid = user.save?.worldid;
+  const { baseid, type, mapversion, attackData, attackcost } = BaseLoadSchema.parse(ctx.request.body);
 
-    let baseSave: Save | null = null;
+  let baseSave: Save | null = null;
 
-    switch (type) {
-      case BaseMode.BUILD:
-        baseSave = await baseModeBuild(user, baseid);
-        break;
+  switch (type) {
+    case BaseMode.BUILD:
+      baseSave = await baseModeBuild(user, baseid);
+      break;
 
-      case BaseMode.VIEW:
-      case BaseMode.IVIEW:
-        baseSave = await baseModeView(baseid, mapversion, worldid);
-        break;
+    case BaseMode.VIEW:
+    case BaseMode.IVIEW:
+      baseSave = await baseModeView(baseid, mapversion, worldid);
+      break;
 
-      case BaseMode.ATTACK:
-        if (!ctx.meetsDiscordAgeCheck) throw discordAgeErr();
+    case BaseMode.ATTACK:
+      if (!ctx.meetsDiscordAgeCheck) throw discordAgeErr();
 
-        await validateAttack(user, attackData, mapversion);
-        baseSave = await baseModeAttack({ user, baseid, mapversion, attackCost: attackcost });
-        break;
+      await validateAttack(user, attackData, mapversion);
+      baseSave = await baseModeAttack({ user, baseid, mapversion, attackCost: attackcost });
+      break;
 
-      case BaseMode.IDESCENT:
-        baseSave = await infernoModeDescent(user);
-        break;
+    case BaseMode.IDESCENT:
+      baseSave = await infernoModeDescent(user);
+      break;
 
-      case BaseMode.IBUILD:
-        baseSave = await infernoModeBuild(user);
-        break;
+    case BaseMode.IBUILD:
+      baseSave = await infernoModeBuild(user);
+      break;
 
-      case BaseMode.IWMVIEW:
-        baseSave = await infernoModeView(user, baseid);
-        break;
+    case BaseMode.IWMVIEW:
+      baseSave = await infernoModeView(user, baseid);
+      break;
 
-      case BaseMode.IATTACK:
-        if (!ctx.meetsDiscordAgeCheck) throw discordAgeErr();
+    case BaseMode.IATTACK:
+      if (!ctx.meetsDiscordAgeCheck) throw discordAgeErr();
 
-        await validateAttack(user, attackData, mapversion);
-        baseSave = await infernoModeAttack(user, baseid);
-        break;
+      await validateAttack(user, attackData, mapversion);
+      baseSave = await infernoModeAttack(user, baseid);
+      break;
 
-      case BaseMode.IWMATTACK:
-        await validateAttack(user, attackData, mapversion);
-        baseSave = await infernoModeAttack(user, baseid);
-        break;
+    case BaseMode.IWMATTACK:
+      await validateAttack(user, attackData, mapversion);
+      baseSave = await infernoModeAttack(user, baseid);
+      break;
         
-      default:
-        throw new Error(`Base type not handled, type: ${type}.`);
-    }
-
-    if (!baseSave) throw new Error("Base save not found.");
-
-    const filteredSave = FilterFrontendKeys(baseSave);
-    const isTutorialEnabled = devConfig.skipTutorial ? 205 : filteredSave.tutorialstage;
-
-    const flags = getFlags();
-    flags.discordOldEnough = Number(ctx.meetsDiscordAgeCheck);
-
-    const isOwner = baseSave.type !== BaseType.INFERNO && user.userid === filteredSave.userid;
-
-    let totalResourceRate = 0;
-    let totalResourceCapacity = 0;
-    let totalStrongholdBonus = 0;
-    let totalDefenderStrongholdBonus = 0;
-    let defenderReduction = 0;
-
-    if (mapversion === MapRoomVersion.V3) {
-      // Sum production rate and storage capacity from all player-owned MR3 resource outposts.
-      if (isOwner) {
-        const resourceOutposts = await postgres.em.find(Save, {
-          saveuserid: user.userid,
-          type: BaseType.OUTPOST,
-          wmid: EnumYardType.RESOURCE,
-        });
-
-        for (const { level } of resourceOutposts) {
-          totalResourceRate += RESOURCE_PRODUCTION_RATES[level];
-          totalResourceCapacity += RESOURCE_CAPACITIES[level];
-        }
-
-        // Auto-bank calculates and applies resources accumulated since the player's last session.
-        if (type === BaseMode.BUILD && totalResourceRate > 0) {
-          const userSave = user.save!;
-          const now = getCurrentDateTime();
-          const lastAccumulated = userSave.buildingresources?.t;
-
-          if (lastAccumulated) {
-            const elapsed = now - lastAccumulated;
-            const accumulated = Math.floor(totalResourceRate * elapsed);
-
-            if (accumulated > 0 && userSave.resources) {
-              for (const resource of ["r1", "r2", "r3", "r4"])
-                userSave.resources[resource] += accumulated;
-            }
-          }
-
-          userSave.buildingresources!.t = now;
-          postgres.em.persist(userSave);
-          await postgres.em.flush();
-        }
-      }
-
-      // Strongholds boost monster damage (attacker) and tower damage (defender),
-      // but only if the target cell falls within their attack range.
-      if (type === BaseMode.ATTACK && baseSave.cell) {
-        const targetCell: WorldMapCell = baseSave.cell;
-
-        const [attackerStrongholds, defenderStrongholds] = await Promise.all([
-          postgres.em.find(
-            Save,
-            {
-              saveuserid: user.userid,
-              type: BaseType.OUTPOST,
-              wmid: EnumYardType.STRONGHOLD,
-            },
-            { populate: ["cell"] },
-          ),
-          
-          postgres.em.find(
-            Save,
-            {
-              saveuserid: baseSave.saveuserid,
-              type: BaseType.OUTPOST,
-              wmid: EnumYardType.STRONGHOLD,
-            },
-            { populate: ["cell"] },
-          ),
-        ]);
-
-        const strongholdBonus = (strongholds: Save[]) => {
-          let bonus = 0;
-
-          for (const { level, cell } of strongholds) {
-            const distance = cell && getHexDistance(cell.x, cell.y, targetCell.x, targetCell.y);
-            
-            if (distance && distance <= STRUCTURE_RANGE[EnumYardType.STRONGHOLD][level])
-              bonus += STRONGHOLD_BONUSES[level];
-          }
-          return bonus;
-        };
-
-        totalStrongholdBonus = strongholdBonus(attackerStrongholds);
-        totalDefenderStrongholdBonus = strongholdBonus(defenderStrongholds);
-      }
-    }
-
-    // Set damage reduction buff for attacking bases with defenders
-    if (mapversion === MapRoomVersion.V3 && !isOwner && type === BaseMode.ATTACK) {
-      const attackedCell = baseSave.cell;
-
-      if (attackedCell?.uid && isDefensiveStructure(attackedCell.base_type)) {
-        const defenderCoords = getDefenderCoords(attackedCell.x, attackedCell.y, attackedCell.base_type);
-
-        const defenderCells = await postgres.em.find(WorldMapCell, {
-          $and: [
-            { $or: defenderCoords.map(([x, y]) => ({ x, y })) },
-            { base_type: EnumYardType.FORTIFICATION },
-            { uid: attackedCell.uid },
-            { map_version: MapRoomVersion.V3 },
-            { world: worldid },
-          ],
-        });
-
-        defenderReduction = DEFENDER_DAMAGE_REDUCTION[defenderCells.length];
-      }
-    }
-
-    const attackAllowed = canAttack(user.save!, baseSave, mapversion);
-
-    const response: Record<string, unknown> = {
-      ...filteredSave,
-      relationship: isOwner ? EnumBaseRelationship.SELF : EnumBaseRelationship.ENEMY,
-      canattack: attackAllowed,
-      flags,
-      worldsize: WORLD_SIZE,
-      error: 0,
-      id: filteredSave.basesaveid,
-      storeitems: storeItems,
-      tutorialstage: isTutorialEnabled,
-      currenttime: getCurrentDateTime(),
-      pic_square: `${process.env.AVATAR_URL}?seed=${filteredSave.name}&size=50`,
-      ...(isOwner && mapUserSaveData(user)),
-    };
-
-    if (isOwner && mapversion === MapRoomVersion.V3) {
-      response.player = { buffs: { 2: totalResourceRate, 10: totalResourceCapacity } };
-    }
-
-    if (defenderReduction > 0) {
-      response.player = { buffs: { 1: defenderReduction } };
-    }
-
-    if (type === BaseMode.ATTACK && mapversion === MapRoomVersion.V3) {
-      if (totalStrongholdBonus > 0) response.attackingplayer = { buffs: { 5: totalStrongholdBonus } };
-      if (totalDefenderStrongholdBonus > 0) response.defendingplayer = { buffs: { 6: totalDefenderStrongholdBonus } };
-    }
-
-    ctx.status = Status.OK;
-    ctx.body = response;
-  } catch (err) {
-    ctx.status = Status.INTERNAL_SERVER_ERROR;
-    ctx.body = { error: "The server failed to load this base." };
-    logger.error(`Failed to load base: ${err}`);
+    default:
+      throw new Error(`Base type not handled, type: ${type}.`);
   }
+
+  if (!baseSave) throw new Error("Base save not found.");
+
+  const filteredSave = FilterFrontendKeys(baseSave);
+  const isTutorialEnabled = devConfig.skipTutorial ? 205 : filteredSave.tutorialstage;
+
+  const flags = getFlags();
+  flags.discordOldEnough = Number(ctx.meetsDiscordAgeCheck);
+
+  const isOwner = baseSave.type !== BaseType.INFERNO && user.userid === filteredSave.userid;
+
+  let totalResourceRate = 0;
+  let totalResourceCapacity = 0;
+  let totalStrongholdBonus = 0;
+  let totalDefenderStrongholdBonus = 0;
+  let defenderReduction = 0;
+
+  if (mapversion === MapRoomVersion.V3) {
+    // Sum production rate and storage capacity from all player-owned MR3 resource outposts.
+    if (isOwner) {
+      const resourceOutposts = await postgres.em.find(Save, {
+        saveuserid: user.userid,
+        type: BaseType.OUTPOST,
+        wmid: EnumYardType.RESOURCE,
+      });
+
+      for (const { level } of resourceOutposts) {
+        totalResourceRate += RESOURCE_PRODUCTION_RATES[level];
+        totalResourceCapacity += RESOURCE_CAPACITIES[level];
+      }
+
+      // Auto-bank calculates and applies resources accumulated since the player's last session.
+      if (type === BaseMode.BUILD && totalResourceRate > 0) {
+        const userSave = user.save!;
+        const now = getCurrentDateTime();
+        const lastAccumulated = userSave.buildingresources?.t;
+
+        if (lastAccumulated) {
+          const elapsed = now - lastAccumulated;
+          const accumulated = Math.floor(totalResourceRate * elapsed);
+
+          if (accumulated > 0 && userSave.resources) {
+            for (const resource of ["r1", "r2", "r3", "r4"])
+              userSave.resources[resource] += accumulated;
+          }
+        }
+
+        userSave.buildingresources!.t = now;
+        postgres.em.persist(userSave);
+        await postgres.em.flush();
+      }
+    }
+
+    // Strongholds boost monster damage (attacker) and tower damage (defender),
+    // but only if the target cell falls within their attack range.
+    if (type === BaseMode.ATTACK && baseSave.cell) {
+      const targetCell: WorldMapCell = baseSave.cell;
+
+      const [attackerStrongholds, defenderStrongholds] = await Promise.all([
+        postgres.em.find(
+          Save,
+          {
+            saveuserid: user.userid,
+            type: BaseType.OUTPOST,
+            wmid: EnumYardType.STRONGHOLD,
+          },
+          { populate: ["cell"] },
+        ),
+          
+        postgres.em.find(
+          Save,
+          {
+            saveuserid: baseSave.saveuserid,
+            type: BaseType.OUTPOST,
+            wmid: EnumYardType.STRONGHOLD,
+          },
+          { populate: ["cell"] },
+        ),
+      ]);
+
+      const strongholdBonus = (strongholds: Save[]) => {
+        let bonus = 0;
+
+        for (const { level, cell } of strongholds) {
+          const distance = cell && getHexDistance(cell.x, cell.y, targetCell.x, targetCell.y);
+            
+          if (distance && distance <= STRUCTURE_RANGE[EnumYardType.STRONGHOLD][level])
+            bonus += STRONGHOLD_BONUSES[level];
+        }
+        return bonus;
+      };
+
+      totalStrongholdBonus = strongholdBonus(attackerStrongholds);
+      totalDefenderStrongholdBonus = strongholdBonus(defenderStrongholds);
+    }
+  }
+
+  // Set damage reduction buff for attacking bases with defenders
+  if (mapversion === MapRoomVersion.V3 && !isOwner && type === BaseMode.ATTACK) {
+    const attackedCell = baseSave.cell;
+
+    if (attackedCell?.uid && isDefensiveStructure(attackedCell.base_type)) {
+      const defenderCoords = getDefenderCoords(attackedCell.x, attackedCell.y, attackedCell.base_type);
+
+      const defenderCells = await postgres.em.find(WorldMapCell, {
+        $and: [
+          { $or: defenderCoords.map(([x, y]) => ({ x, y })) },
+          { base_type: EnumYardType.FORTIFICATION },
+          { uid: attackedCell.uid },
+          { map_version: MapRoomVersion.V3 },
+          { world: worldid },
+        ],
+      });
+
+      defenderReduction = DEFENDER_DAMAGE_REDUCTION[defenderCells.length];
+    }
+  }
+
+  const attackAllowed = canAttack(user.save!, baseSave, mapversion);
+
+  const response: Record<string, unknown> = {
+    ...filteredSave,
+    relationship: isOwner ? EnumBaseRelationship.SELF : EnumBaseRelationship.ENEMY,
+    canattack: attackAllowed,
+    flags,
+    worldsize: WORLD_SIZE,
+    error: 0,
+    id: filteredSave.basesaveid,
+    storeitems: storeItems,
+    tutorialstage: isTutorialEnabled,
+    currenttime: getCurrentDateTime(),
+    pic_square: `${process.env.AVATAR_URL}?seed=${filteredSave.name}&size=50`,
+    ...(isOwner && mapUserSaveData(user)),
+  };
+
+  if (isOwner && mapversion === MapRoomVersion.V3) {
+    response.player = { buffs: { 2: totalResourceRate, 10: totalResourceCapacity } };
+  }
+
+  if (defenderReduction > 0) {
+    response.player = { buffs: { 1: defenderReduction } };
+  }
+
+  if (type === BaseMode.ATTACK && mapversion === MapRoomVersion.V3) {
+    if (totalStrongholdBonus > 0) response.attackingplayer = { buffs: { 5: totalStrongholdBonus } };
+    if (totalDefenderStrongholdBonus > 0) response.defendingplayer = { buffs: { 6: totalDefenderStrongholdBonus } };
+  }
+
+  ctx.status = Status.OK;
+  ctx.body = response;
 };

--- a/server/src/controllers/base/load/modes/baseModeAttack.ts
+++ b/server/src/controllers/base/load/modes/baseModeAttack.ts
@@ -16,6 +16,8 @@ import {
 import { getGeneratedCells, cellKey } from "../../../../services/maproom/v3/generateCells.js";
 import { createAttackLog } from "../../../../services/base/createAttackLog.js";
 import { updateResources, Operation } from "../../../../services/base/updateResources.js";
+import { isAttackActive } from "../../../../services/base/isAttackActive.js";
+import { baseUnderAttackErr } from "../../../../errors/errors.js";
 
 export interface AttackDetails {
   fbid?: string;
@@ -47,6 +49,8 @@ export const baseModeAttack = async ({ user, baseid, mapversion, attackCost }: B
   if (!save) save = await tribeSaveHandler(baseid, mapversion, userSave.worldid);
 
   if (!save) throw new Error(`Save not found for baseid: ${baseid}`);
+
+  if (save.type !== BaseType.TRIBE && isAttackActive(save)) throw baseUnderAttackErr();
 
   if (save.attacks.length > 3) {
     save.attacks = save.attacks.slice(-2);

--- a/server/src/controllers/base/load/modes/infernoModeAttack.ts
+++ b/server/src/controllers/base/load/modes/infernoModeAttack.ts
@@ -12,6 +12,8 @@ import {
   type TribeData,
 } from "../../../../models/infernomaproom.model.js";
 import { damageProtection } from "../../../../services/maproom/v2/damageProtection.js";
+import { isAttackActive } from "../../../../services/base/isAttackActive.js";
+import { baseUnderAttackErr } from "../../../../errors/errors.js";
 
 /**
  * Handles Inferno mode attacks for both real players and AI tribes
@@ -35,6 +37,8 @@ export const infernoModeAttack = async (user: User, baseid: string) => {
   }
 
   if (!save) return infernoTribeSave(user, baseid);
+
+  if (isAttackActive(save)) throw baseUnderAttackErr();
 
   if (save.attacks.length > 3) {
     save.attacks = save.attacks.slice(-2);

--- a/server/src/controllers/base/save/baseSave.ts
+++ b/server/src/controllers/base/save/baseSave.ts
@@ -35,178 +35,167 @@ import { MapRoomVersion } from "../../../enums/MapRoom.js";
 export const baseSave: KoaController = async (ctx) => {
   const user: User = ctx.authUser;
   await postgres.em.populate(user, ["save"]);
-  
+
   const userSave = user.save!;
 
-  try {
-    const body = ctx.request.body as Record<string, unknown>;
-    const saveData = BaseSaveSchema.parse(body);
+  const body = ctx.request.body as Record<string, unknown>;
+  const saveData = BaseSaveSchema.parse(body);
 
-    const { basesaveid } = saveData;
-    const baseSave = await postgres.em.findOne(Save, { basesaveid });
+  const { basesaveid } = saveData;
+  const baseSave = await postgres.em.findOne(Save, { basesaveid });
 
-    if (!baseSave) throw saveFailureErr();
+  if (!baseSave) throw saveFailureErr();
 
-    const isOwner = baseSave.saveuserid === user.userid;
-    const isOutpostOwner = isOwner && baseSave.type === BaseType.OUTPOST;
-    const isAttack = !isOwner && baseSave.attackid !== 0;
+  const isOwner = baseSave.saveuserid === user.userid;
+  const isOutpostOwner = isOwner && baseSave.type === BaseType.OUTPOST;
+  const isAttack = !isOwner && baseSave.attackid !== 0;
 
-    // Not the owner and not in an attack
-    if (!isOwner && baseSave.attackid === 0) throw permissionErr();
+  // Not the owner and not in an attack
+  if (!isOwner && baseSave.attackid === 0) throw permissionErr();
 
-    await validateSave(user, baseSave, body);
+  await validateSave(user, baseSave, body);
 
-    // Standard save logic
-    for (const key of isAttack ? Save.attackSaveKeys : Save.saveKeys) {
-      const value = body[key] as string;
+  // Standard save logic
+  for (const key of isAttack ? Save.attackSaveKeys : Save.saveKeys) {
+    const value = body[key] as string;
 
-      switch (key) {
-        case SaveKeys.RESOURCES:
-          resourcesHandler(baseSave, value);
-          if (isOutpostOwner) {
-            const resources = JSON.parse(value);
-            userSave.resources = updateResources(resources, userSave.resources!);
-          }
-          break;
-
-        case SaveKeys.POINTS:
-          baseSave.points = value.toString();
-          break;
-
-        case SaveKeys.BASEVALUE:
-          baseSave.basevalue = value.toString();
-          break;
-
-        case SaveKeys.IRESOURCES:
-          resourcesHandler(baseSave, value, SaveKeys.IRESOURCES);
-          break;
-
-        case SaveKeys.ACADEMY:
-          academyHandler(ctx, baseSave);
-          break;
-
-        case SaveKeys.BUILDINGDATA:
-          if (saveData.buildingdata == null) break;
-          
-          if (isAttack) {
-            buildingDataHandler(saveData.buildingdata, baseSave);
-          } else {
-            baseSave[SaveKeys.BUILDINGDATA] = saveData.buildingdata;
-          }
-          break;
-
-        case SaveKeys.CHAMPION:
-          if (isAttack) {
-            if (saveData.attackerchampion) {
-              userSave.champion = saveData.attackerchampion;
-            }
-          } else {
-            if (saveData.champion) {
-              baseSave.champion = saveData.champion;
-            }
-          }
-          break;
-
-        case SaveKeys.ATTACKERSIEGE:
-          if (isAttack) {
-            userSave.siege = saveData.attackersiege;
-          }
-          break;
-
-        default:
-          if (value) {
-            const save = baseSave as unknown as Record<string, unknown>;
-            try {
-              save[key] = JSON.parse(value);
-            } catch (_) {
-              save[key] = value;
-            }
-          }
-      }
-
-      if (isOutpostOwner) updateOutposts(userSave, baseSave, key);
-    }
-
-    if (!isAttack && saveData.purchase) purchaseHandler(ctx, saveData.purchase, userSave);
-
-    let takeoverData: TakeoverData | null = null;
-
-    if (isAttack) {
-      if (saveData.monsterupdate) {
-        await monsterUpdateHandler(saveData.monsterupdate, userSave);
-      }
-
-      if (saveData.attackloot) {
-        attackLootHandler(saveData.attackloot, userSave);
-      }
-
-      postgres.em.persist(userSave);
-      await postgres.em.flush();
-
-      // MR3 Takeover Logic:
-      // If the attack is over and damage >= 90, trigger takeover or destroy logic.
-      // MR3 capturable structures (RESOURCE, STRONGHOLD, FORTIFICATION) allow re-capture
-      // from OUTPOST type (player-owned) in addition to first capture from TRIBE type.
-      if (saveData.over && baseSave.damage >= 90) {
-        if (isMR3Structure(baseSave.wmid)) {
-          if (baseSave.type === BaseType.TRIBE || baseSave.type === BaseType.OUTPOST) {
-            takeoverData = await takeoverCellMR3(baseSave, user, userSave);
-          }
-        } else if (baseSave.type === BaseType.TRIBE) {
-          const cell = await postgres.em.findOne(WorldMapCell, {
-            baseid: baseSave.baseid,
-            map_version: MapRoomVersion.V3,
-          });
-
-          if (cell && !cell.destroyed_at) cell.destroyed_at = new Date();
+    switch (key) {
+      case SaveKeys.RESOURCES:
+        resourcesHandler(baseSave, value);
+        if (isOutpostOwner) {
+          const resources = JSON.parse(value);
+          userSave.resources = updateResources(resources, userSave.resources!);
         }
-      }
-      // Grant damage protection to the defender main yard when the attack ends.
-      const isProtectable = baseSave.type === BaseType.MAIN || baseSave.type === BaseType.OUTPOST;
-      
-      if (saveData.over && isProtectable && !isMR3Structure(baseSave.wmid)) {
-        await damageProtection(baseSave);
-      }
+        break;
+
+      case SaveKeys.POINTS:
+        baseSave.points = value.toString();
+        break;
+
+      case SaveKeys.BASEVALUE:
+        baseSave.basevalue = value.toString();
+        break;
+
+      case SaveKeys.IRESOURCES:
+        resourcesHandler(baseSave, value, SaveKeys.IRESOURCES);
+        break;
+
+      case SaveKeys.ACADEMY:
+        academyHandler(ctx, baseSave);
+        break;
+
+      case SaveKeys.BUILDINGDATA:
+        if (saveData.buildingdata == null) break;
+
+        if (isAttack) {
+          buildingDataHandler(saveData.buildingdata, baseSave);
+        } else {
+          baseSave[SaveKeys.BUILDINGDATA] = saveData.buildingdata;
+        }
+        break;
+
+      case SaveKeys.CHAMPION:
+        if (isAttack) {
+          if (saveData.attackerchampion) {
+            userSave.champion = saveData.attackerchampion;
+          }
+        } else {
+          if (saveData.champion) {
+            baseSave.champion = saveData.champion;
+          }
+        }
+        break;
+
+      case SaveKeys.ATTACKERSIEGE:
+        if (isAttack) {
+          userSave.siege = saveData.attackersiege;
+        }
+        break;
+
+      default:
+        if (value) {
+          const save = baseSave as unknown as Record<string, unknown>;
+          try {
+            save[key] = JSON.parse(value);
+          } catch (_) {
+            save[key] = value;
+          }
+        }
     }
 
-    baseSave.attackid = saveData.over ? 0 : baseSave.attackid;
+    if (isOutpostOwner) updateOutposts(userSave, baseSave, key);
+  }
 
-    baseSave.id = baseSave.savetime;
-    baseSave.savetime = getCurrentDateTime();
+  if (!isAttack && saveData.purchase) purchaseHandler(ctx, saveData.purchase, userSave);
 
-    if (!isAttack) {
-      await redis.setex(`last-seen:main:${user.userid}`, 120, getCurrentDateTime().toString());
+  let takeoverData: TakeoverData | null = null;
+
+  if (isAttack) {
+    if (saveData.monsterupdate) {
+      await monsterUpdateHandler(saveData.monsterupdate, userSave);
     }
 
-    postgres.em.persist(baseSave);
+    if (saveData.attackloot) {
+      attackLootHandler(saveData.attackloot, userSave);
+    }
+
+    postgres.em.persist(userSave);
     await postgres.em.flush();
 
-    const filteredSave = FilterFrontendKeys(baseSave);
-    logger.info(`Saving ${user.username}'s base | IP: ${ctx.ip}`);
+    // MR3 Takeover Logic:
+    // If the attack is over and damage >= 90, trigger takeover or destroy logic.
+    // MR3 capturable structures (RESOURCE, STRONGHOLD, FORTIFICATION) allow re-capture
+    // from OUTPOST type (player-owned) in addition to first capture from TRIBE type.
+    if (saveData.over && baseSave.damage >= 90) {
+      if (isMR3Structure(baseSave.wmid)) {
+        if (baseSave.type === BaseType.TRIBE || baseSave.type === BaseType.OUTPOST) {
+          takeoverData = await takeoverCellMR3(baseSave, user, userSave);
+        }
+      } else if (baseSave.type === BaseType.TRIBE) {
+        const cell = await postgres.em.findOne(WorldMapCell, {
+          baseid: baseSave.baseid,
+          map_version: MapRoomVersion.V3,
+        });
 
-    const responseBody = {
-      error: 0,
-      basesaveid: baseSave.basesaveid,
-      ...filteredSave,
-      ...(takeoverData && { takeover: takeoverData }),
-    };
-
-    if (user.userid === filteredSave.userid) {
-      Object.assign(responseBody, mapUserSaveData(user));
+        if (cell && !cell.destroyed_at) cell.destroyed_at = new Date();
+      }
     }
+    // Grant damage protection to the defender main yard when the attack ends.
+    const isProtectable = baseSave.type === BaseType.MAIN || baseSave.type === BaseType.OUTPOST;
 
-    ctx.status = Status.OK;
-    ctx.body = responseBody;
-  } catch (err) {
-    if (err instanceof Error && 'isClientFriendly' in err) {
-      throw err;
+    if (saveData.over && isProtectable && !isMR3Structure(baseSave.wmid)) {
+      await damageProtection(baseSave);
     }
-
-    logger.error(`Failed to save base for user: ${user.username}: ${err}`);
-
-    ctx.status = Status.INTERNAL_SERVER_ERROR;
-    ctx.body = { error: `Failed to save for user: ${user.username}` };
   }
+
+  baseSave.attackid = saveData.over ? 0 : baseSave.attackid;
+
+  baseSave.id = baseSave.savetime;
+  baseSave.savetime = getCurrentDateTime();
+
+  if (!isAttack) {
+    await redis.setex(`last-seen:main:${user.userid}`, 120, getCurrentDateTime().toString());
+  }
+
+  postgres.em.persist(baseSave);
+  await postgres.em.flush();
+
+  const filteredSave = FilterFrontendKeys(baseSave);
+  logger.info(`Saving ${user.username}'s base | IP: ${ctx.ip}`);
+
+  const responseBody = {
+    error: 0,
+    basesaveid: baseSave.basesaveid,
+    ...filteredSave,
+    ...(takeoverData && { takeover: takeoverData }),
+  };
+
+  if (user.userid === filteredSave.userid) {
+    Object.assign(responseBody, mapUserSaveData(user));
+  }
+
+  ctx.status = Status.OK;
+  ctx.body = responseBody;
 };
 
 const updateOutposts = (

--- a/server/src/controllers/base/save/updateSaved.ts
+++ b/server/src/controllers/base/save/updateSaved.ts
@@ -13,7 +13,6 @@ import type { KoaController } from "../../../utils/KoaController.js";
 import { baseModeBuild } from "../load/modes/baseModeBuild.js";
 import { baseModeView } from "../load/modes/baseModeView.js";
 import { infernoModeView } from "../load/modes/infernoModeView.js";
-import { logger } from "../../../utils/logger.js";
 import { mapUserSaveData } from "../mapUserSaveData.js";
 
 const UpdateSavedSchema = z.object({
@@ -36,60 +35,52 @@ export const updateSaved: KoaController = async (ctx) => {
   await postgres.em.populate(user, ["save"]);
 
   const userSave = user.save!;
-  
-  try {
-    const worldid = user.save?.worldid;
-    const { baseid, type, mapversion } = UpdateSavedSchema.parse(ctx.request.body);
+  const worldid = user.save?.worldid;
+  const { baseid, type, mapversion } = UpdateSavedSchema.parse(ctx.request.body);
 
-    let baseSave: Save | null = null;
+  let baseSave: Save | null = null;
 
-    switch (type) {
-      case BaseMode.BUILD:
-        baseSave = await baseModeBuild(user, baseid);
-        break;
+  switch (type) {
+    case BaseMode.BUILD:
+      baseSave = await baseModeBuild(user, baseid);
+      break;
 
-      case BaseMode.IVIEW:
-      case BaseMode.IATTACK:
-        baseSave = await infernoModeView(user, baseid);
-        break;
+    case BaseMode.IVIEW:
+    case BaseMode.IATTACK:
+      baseSave = await infernoModeView(user, baseid);
+      break;
 
-      default:
-        baseSave = await baseModeView(baseid, mapversion, worldid);
-        break;
-    }
-
-    if (!baseSave) throw saveFailureErr();
-
-    baseSave.savetime = getCurrentDateTime();
-    baseSave.id = baseSave.savetime; // client expects this.
-
-    if (baseid !== BaseMode.DEFAULT && type === BaseMode.BUILD) {
-      postgres.em.persist(baseSave);
-      await postgres.em.flush();
-    }
-
-    const filteredSave = FilterFrontendKeys(baseSave);
-
-    const flags = getFlags();
-    flags.discordOldEnough = Number(ctx.meetsDiscordAgeCheck);
-
-    const responseBody = {
-      error: 0,
-      flags,
-      ...filteredSave,
-      credits: userSave.credits
-    };
-
-    if (baseSave.type !== BaseType.INFERNO && user.userid === filteredSave.userid) {
-      Object.assign(responseBody, mapUserSaveData(user));
-    }
-
-    ctx.status = Status.OK;
-    ctx.body = responseBody;
-  } catch (err) {
-    logger.error(`Failed to update save for user: ${user.username}: ${err}`);
-
-    ctx.status = Status.INTERNAL_SERVER_ERROR;
-    ctx.body = { error: `Failed to update save for user: ${user.username}` };
+    default:
+      baseSave = await baseModeView(baseid, mapversion, worldid);
+      break;
   }
+
+  if (!baseSave) throw saveFailureErr();
+
+  baseSave.savetime = getCurrentDateTime();
+  baseSave.id = baseSave.savetime; // client expects this.
+
+  if (baseid !== BaseMode.DEFAULT && type === BaseMode.BUILD) {
+    postgres.em.persist(baseSave);
+    await postgres.em.flush();
+  }
+
+  const filteredSave = FilterFrontendKeys(baseSave);
+
+  const flags = getFlags();
+  flags.discordOldEnough = Number(ctx.meetsDiscordAgeCheck);
+
+  const responseBody = {
+    error: 0,
+    flags,
+    ...filteredSave,
+    credits: userSave.credits
+  };
+
+  if (baseSave.type !== BaseType.INFERNO && user.userid === filteredSave.userid) {
+    Object.assign(responseBody, mapUserSaveData(user));
+  }
+
+  ctx.status = Status.OK;
+  ctx.body = responseBody;
 };

--- a/server/src/controllers/leaderboards/getLeaderboards.ts
+++ b/server/src/controllers/leaderboards/getLeaderboards.ts
@@ -48,73 +48,66 @@ export const getLeaderboards: KoaController = async (ctx) => {
 
   const version = Number(mapversion);
 
-  try {
-    const cacheKey = `leaderboards_${worldid}_v${version}`;
-    const cachedData = await redis.get(cacheKey);
+  const cacheKey = `leaderboards_${worldid}_v${version}`;
+  const cachedData = await redis.get(cacheKey);
 
-    if (cachedData) {
-      ctx.status = Status.OK;
-      ctx.body = { leaderboard: JSON.parse(cachedData) };
-      return;
-    }
-
-    let leaderboard: MR2Leaderboard[] | MR3Leaderboard[];
-
-    if (version === MapRoomVersion.V3) {
-      leaderboard = await postgres.em.getConnection().execute<MR3Leaderboard[]>(
-        `
-          SELECT
-            u.username,
-            u.discord_tag,
-            COUNT(*) FILTER (WHERE wmc.base_type = ?) AS stronghold_count,
-            COUNT(*) FILTER (WHERE wmc.base_type = ?) AS outpost_count
-          FROM bym.world_map_cell wmc
-          JOIN bym.user u ON u.userid = wmc.uid
-          WHERE wmc.world_id = ?
-            AND wmc.map_version = ?
-            AND wmc.base_type IN (?, ?)
-            AND wmc.destroyed_at IS NULL
-          GROUP BY u.userid, u.username, u.discord_tag
-          ORDER BY (COUNT(*) FILTER (WHERE wmc.base_type = ?) + COUNT(*) FILTER (WHERE wmc.base_type = ?)) DESC
-          LIMIT 25
-        `,
-        [
-          EnumYardType.STRONGHOLD,
-          EnumYardType.RESOURCE,
-          worldid,
-          MapRoomVersion.V3,
-          EnumYardType.STRONGHOLD,
-          EnumYardType.RESOURCE,
-          EnumYardType.STRONGHOLD,
-          EnumYardType.RESOURCE,
-        ],
-      );
-    } else {
-      leaderboard = await postgres.em.getConnection().execute<MR2Leaderboard[]>(
-        `
-          SELECT u.username, u.discord_tag, sub.outpost_count
-          FROM bym.user u
-          JOIN (
-              SELECT s.userid, COUNT(*) AS outpost_count
-              FROM bym.save s
-              WHERE s.type = 'outpost' AND s.worldid = ?
-              GROUP BY s.userid
-          ) AS sub ON u.userid = sub.userid
-          ORDER BY sub.outpost_count DESC
-          LIMIT 25
-        `,
-        [worldid],
-      );
-    }
-
-    await redis.setex(cacheKey, LB_CACHE_TTL, JSON.stringify(leaderboard));
-
+  if (cachedData) {
     ctx.status = Status.OK;
-    ctx.body = { leaderboard };
-  } catch (error) {
-    console.error("Error fetching leaderboard:", error);
-
-    ctx.status = Status.INTERNAL_SERVER_ERROR;
-    ctx.body = { error: "Failed to retrieve leaderboard data" };
+    ctx.body = { leaderboard: JSON.parse(cachedData) };
+    return;
   }
+
+  let leaderboard: MR2Leaderboard[] | MR3Leaderboard[];
+
+  if (version === MapRoomVersion.V3) {
+    leaderboard = await postgres.em.getConnection().execute<MR3Leaderboard[]>(
+      `
+        SELECT
+          u.username,
+          u.discord_tag,
+          COUNT(*) FILTER (WHERE wmc.base_type = ?) AS stronghold_count,
+          COUNT(*) FILTER (WHERE wmc.base_type = ?) AS outpost_count
+        FROM bym.world_map_cell wmc
+        JOIN bym.user u ON u.userid = wmc.uid
+        WHERE wmc.world_id = ?
+          AND wmc.map_version = ?
+          AND wmc.base_type IN (?, ?)
+          AND wmc.destroyed_at IS NULL
+        GROUP BY u.userid, u.username, u.discord_tag
+        ORDER BY (COUNT(*) FILTER (WHERE wmc.base_type = ?) + COUNT(*) FILTER (WHERE wmc.base_type = ?)) DESC
+        LIMIT 25
+      `,
+      [
+        EnumYardType.STRONGHOLD,
+        EnumYardType.RESOURCE,
+        worldid,
+        MapRoomVersion.V3,
+        EnumYardType.STRONGHOLD,
+        EnumYardType.RESOURCE,
+        EnumYardType.STRONGHOLD,
+        EnumYardType.RESOURCE,
+      ],
+    );
+  } else {
+    leaderboard = await postgres.em.getConnection().execute<MR2Leaderboard[]>(
+      `
+        SELECT u.username, u.discord_tag, sub.outpost_count
+        FROM bym.user u
+        JOIN (
+            SELECT s.userid, COUNT(*) AS outpost_count
+            FROM bym.save s
+            WHERE s.type = 'outpost' AND s.worldid = ?
+            GROUP BY s.userid
+        ) AS sub ON u.userid = sub.userid
+        ORDER BY sub.outpost_count DESC
+        LIMIT 25
+      `,
+      [worldid],
+    );
+  }
+
+  await redis.setex(cacheKey, LB_CACHE_TTL, JSON.stringify(leaderboard));
+
+  ctx.status = Status.OK;
+  ctx.body = { leaderboard };
 };

--- a/server/src/controllers/mail/reportMessageThread.ts
+++ b/server/src/controllers/mail/reportMessageThread.ts
@@ -5,7 +5,6 @@ import { postgres } from "../../server.js";
 import { Thread } from "../../models/thread.model.js";
 import { User } from "../../models/user.model.js";
 import { mailboxErr } from "../../errors/errors.js";
-import { logger } from "../../utils/logger.js";
 
 /**
  * Controller to report/block a user from a message thread
@@ -15,32 +14,26 @@ import { logger } from "../../utils/logger.js";
  * @throws {Error} - Throws an error if the request body is missing required fields or if logging fails.
  */
 export const reportMessageThread: KoaController = async (ctx) => {
-  try {
-    const user: User = ctx.authUser;
-    const { threadid } = ReportMessageSchema.parse(ctx.request.body);
+  const user: User = ctx.authUser;
+  const { threadid } = ReportMessageSchema.parse(ctx.request.body);
 
-    const thread = await postgres.em.findOne(Thread, { threadid });
+  const thread = await postgres.em.findOne(Thread, { threadid });
 
-    if (!thread) throw mailboxErr();
+  if (!thread) throw mailboxErr();
 
-    // Determine the other user in the thread
-    const blockedUserId = thread.userid === user.userid ? thread.targetid : thread.userid;
+  // Determine the other user in the thread
+  const blockedUserId = thread.userid === user.userid ? thread.targetid : thread.userid;
 
-    if (user.blockedUsers.includes(blockedUserId)) {
-      ctx.status = Status.OK;
-      ctx.body = { error: 0 };
-      return;
-    }
-
-    user.blockedUsers.push(blockedUserId);
-    postgres.em.persist(user);
-    await postgres.em.flush();
-
+  if (user.blockedUsers.includes(blockedUserId)) {
     ctx.status = Status.OK;
     ctx.body = { error: 0 };
-  } catch (error) {
-    ctx.status = Status.INTERNAL_SERVER_ERROR;
-    ctx.body = { error: 1 };
-    logger.error(`Error blocking user: ${error}`);
+    return;
   }
+
+  user.blockedUsers.push(blockedUserId);
+  postgres.em.persist(user);
+  await postgres.em.flush();
+
+  ctx.status = Status.OK;
+  ctx.body = { error: 0 };
 };

--- a/server/src/controllers/maproom/inferno/getNeighbours.ts
+++ b/server/src/controllers/maproom/inferno/getNeighbours.ts
@@ -6,7 +6,6 @@ import { InfernoMaproom } from "../../../models/infernomaproom.model.js";
 import { postgres } from "../../../server.js";
 import { BaseType } from "../../../enums/Base.js";
 import { calculateBaseLevel } from "../../../services/base/calculateBaseLevel.js";
-import { logger } from "../../../utils/logger.js";
 import { AttackPermission } from "../../../enums/MapRoom.js";
 import { getCurrentDateTime } from "../../../utils/getCurrentDateTime.js";
 import { createNeighbourData } from "../../../services/maproom/inferno/createNeighbourData.js";
@@ -49,73 +48,63 @@ export const getNeighbours: KoaController = async (ctx) => {
   const user: User = ctx.authUser;
   await postgres.em.populate(user, ["save", "infernosave"]);
 
-  try {
-    if (!user.save?.worldid) {
-      ctx.status = Status.OK;
-      ctx.body = { error: 0, bases: [] };
-      return;
-    }
+  if (!user.save?.worldid) {
+    ctx.status = Status.OK;
+    ctx.body = { error: 0, bases: [] };
+    return;
+  }
 
-    let infernoMaproom = await postgres.em.findOne(InfernoMaproom, {
-      userid: user.userid,
+  const infernoMaproom = await postgres.em.findOne(InfernoMaproom, {
+    userid: user.userid,
+  });
+
+  const currentDate = new Date();
+  const cacheExpiry = new Date(
+    currentDate.getTime() - CACHE_VALIDITY_HOURS * 60 * 60 * 1000
+  );
+
+  if (!infernoMaproom) throw new Error("Inferno maproom not found.");
+
+  // Check if we need to fetch new neighbours (cache expired or array empty)
+  const getNewNeighbours = isCacheExpired(infernoMaproom, cacheExpiry) || infernoMaproom.neighbors.length === 0;
+
+  if (getNewNeighbours) {
+    const foundNeighbours = await findNeighbours(user);
+
+    // Preserve previous attack data on attackers who may have attacked before defender seeded
+    const mergedNeighbors = foundNeighbours.map((newNeighbor) => {
+      const existing = infernoMaproom.neighbors.find(
+        (old) => old.userid === newNeighbor.userid
+      );
+
+      if (existing) {
+        return {
+          ...newNeighbor,
+          attacksfrom: existing.attacksfrom || 0,
+          attacksto: existing.attacksto || 0,
+          retaliatecount: existing.retaliatecount || 0,
+        };
+      }
+
+      return newNeighbor;
     });
 
-    const currentDate = new Date();
-    const cacheExpiry = new Date(
-      currentDate.getTime() - CACHE_VALIDITY_HOURS * 60 * 60 * 1000
-    );
+    infernoMaproom.neighbors = mergedNeighbors;
+    infernoMaproom.neighborsLastCalculated = currentDate;
 
-    if (!infernoMaproom) throw new Error("Inferno maproom not found.");
-
-    // Check if we need to fetch new neighbours (cache expired or array empty)
-    const getNewNeighbours = isCacheExpired(infernoMaproom, cacheExpiry) || infernoMaproom.neighbors.length === 0;
-
-    if (getNewNeighbours) {
-      const foundNeighbours = await findNeighbours(user);
-
-      // Preserve previous attack data on attackers who may have attacked before defender seeded
-      const mergedNeighbors = foundNeighbours.map((newNeighbor) => {
-        const existing = infernoMaproom.neighbors.find(
-          (old) => old.userid === newNeighbor.userid
-        );
-
-        if (existing) {
-          return {
-            ...newNeighbor,
-            attacksfrom: existing.attacksfrom || 0,
-            attacksto: existing.attacksto || 0,
-            retaliatecount: existing.retaliatecount || 0,
-          };
-        }
-
-        return newNeighbor;
-      });
-
-      infernoMaproom.neighbors = mergedNeighbors;
-      infernoMaproom.neighborsLastCalculated = currentDate;
-
-      postgres.em.persist(infernoMaproom);
-      await postgres.em.flush();
-    }
-
-    // Update attack permissions for cached neighbours based on current save state
-    const neighbours = await updateNeighbourData(infernoMaproom.neighbors);
-
-    ctx.status = Status.OK;
-    ctx.body = {
-      error: 0,
-      wmbases: [],
-      bases: neighbours,
-    };
-  } catch (error) {
-    logger.error(`Error fetching inferno neighbours: ${error}`);
-    ctx.status = Status.OK;
-    ctx.body = {
-      error: 0,
-      wmbases: [],
-      bases: [],
-    };
+    postgres.em.persist(infernoMaproom);
+    await postgres.em.flush();
   }
+
+  // Update attack permissions for cached neighbours based on current save state
+  const neighbours = await updateNeighbourData(infernoMaproom.neighbors);
+
+  ctx.status = Status.OK;
+  ctx.body = {
+    error: 0,
+    wmbases: [],
+    bases: neighbours,
+  };
 };
 
 /**

--- a/server/src/controllers/maproom/v2/cells/userCell.ts
+++ b/server/src/controllers/maproom/v2/cells/userCell.ts
@@ -2,7 +2,6 @@ import type { Context } from "koa";
 import type { User } from "../../../../models/user.model.js";
 import type { WorldMapCell } from "../../../../models/worldmapcell.model.js";
 import { calculateBaseLevel } from "../../../../services/base/calculateBaseLevel.js";
-import { logger } from "../../../../utils/logger.js";
 import { getCurrentDateTime } from "../../../../utils/getCurrentDateTime.js";
 import { MapRoomCell } from "../../../../enums/MapRoom.js";
 import { isAttackActive } from "../../../../services/base/isAttackActive.js";
@@ -21,59 +20,55 @@ import { isAttackActive } from "../../../../services/base/isAttackActive.js";
 export const userCell = async (ctx: Context, cell: WorldMapCell, cellOwners: Map<number, User>) => {
   const currentUser: User = ctx.authUser;
 
-  try {
-    const mine = currentUser.userid === cell.uid;
-    const cellOwner = mine ? currentUser : cellOwners.get(cell.uid);
+  const mine = currentUser.userid === cell.uid;
+  const cellOwner = mine ? currentUser : cellOwners.get(cell.uid);
 
-    const cellSave = cell.save;
-    if (!cellSave || !cellOwner?.save) return;
+  const cellSave = cell.save;
+  if (!cellSave || !cellOwner?.save) return;
 
-    const currentTime = getCurrentDateTime();
+  const currentTime = getCurrentDateTime();
 
-    const homeCell = cell.base_type === MapRoomCell.HOMECELL;
+  const homeCell = cell.base_type === MapRoomCell.HOMECELL;
     
-    const lastSeen = ctx.state.lastSeen;
-    const online = homeCell && (lastSeen.get(cell.uid) ?? 0) >= currentTime - 60;
-    const isUnderAttack = homeCell && isAttackActive(cellSave);
+  const lastSeen = ctx.state.lastSeen;
+  const online = homeCell && (lastSeen.get(cell.uid) ?? 0) >= currentTime - 60;
+  const isUnderAttack = homeCell && isAttackActive(cellSave);
 
-    let locked = cellSave.locked;
-    if (online || isUnderAttack) locked = 1;
-    if (mine) locked = 0;
+  let locked = cellSave.locked;
+  if (online || isUnderAttack) locked = 1;
+  if (mine) locked = 0;
 
-    const points = cellOwner.save.points;
-    const basevalue = cellOwner.save.basevalue;
-    const baseLevel = calculateBaseLevel(points, basevalue);
+  const points = cellOwner.save.points;
+  const basevalue = cellOwner.save.basevalue;
+  const baseLevel = calculateBaseLevel(points, basevalue);
 
-    const isProtected = cellSave.protected > 0 && cellSave.protected > currentTime;
-    const protectionExpired = cellSave.protected > 0 && cellSave.protected <= currentTime;
+  const isProtected = cellSave.protected > 0 && cellSave.protected > currentTime;
+  const protectionExpired = cellSave.protected > 0 && cellSave.protected <= currentTime;
     
-    const damage = protectionExpired ? 0 : cellSave.damage;
+  const damage = protectionExpired ? 0 : cellSave.damage;
 
-    return {
-      uid: cellOwner.userid,
-      b: cell.base_type,
-      pi: 0,
-      bid: cell.baseid,
-      aid: 0,
-      i: cell.terrainHeight,
-      v: cellSave.empirevalue,
-      mine: mine ? 1 : 0,
-      f: cellSave.flinger,
-      c: cellSave.catapult,
-      t: 0,
-      n: cellOwner.username,
-      fr: 0,
-      p: isProtected ? 1 : 0,
-      r: cellSave.resources,
-      m: cellSave.monsters || {},
-      l: baseLevel,
-      d: damage >= 90 ? 1 : 0,
-      lo: locked,
-      dm: damage,
-      pic_square: cellOwner.pic_square,
-      im: cellOwner.pic_square
-    };
-  } catch (error) {
-    logger.error(`Error fetching user cell data: ${error}`);
-  }
+  return {
+    uid: cellOwner.userid,
+    b: cell.base_type,
+    pi: 0,
+    bid: cell.baseid,
+    aid: 0,
+    i: cell.terrainHeight,
+    v: cellSave.empirevalue,
+    mine: mine ? 1 : 0,
+    f: cellSave.flinger,
+     c: cellSave.catapult,
+    t: 0,
+    n: cellOwner.username,
+    fr: 0,
+    p: isProtected ? 1 : 0,
+    r: cellSave.resources,
+    m: cellSave.monsters || {},
+    l: baseLevel,
+    d: damage >= 90 ? 1 : 0,
+    lo: locked,
+    dm: damage,
+    pic_square: cellOwner.pic_square,
+    im: cellOwner.pic_square
+  };
 };

--- a/server/src/controllers/maproom/v2/migrateBase.ts
+++ b/server/src/controllers/maproom/v2/migrateBase.ts
@@ -5,7 +5,6 @@ import { WorldMapCell } from "../../../models/worldmapcell.model.js";
 import { Status } from "../../../enums/StatusCodes.js";
 import { BaseType } from "../../../enums/Base.js";
 import { getCurrentDateTime } from "../../../utils/getCurrentDateTime.js";
-import { logger } from "../../../utils/logger.js";
 import {
   Operation,
   updateResources,
@@ -14,7 +13,6 @@ import { joinOrCreateWorld } from "../../../services/maproom/v2/joinOrCreateWorl
 import { leaveWorld } from "../../../services/maproom/v2/leaveWorld.js";
 import { MapRoomCell } from "../../../enums/MapRoom.js";
 import { relocateOutpostErr } from "../../../errors/errors.js";
-import { ClientSafeError } from "../../../middleware/clientSafeError.js";
 import { MigrateBaseSchema } from "../../../zod/MigrateBaseSchema.js";
 
 /**
@@ -37,112 +35,99 @@ const COOLDOWN_PERIOD = 24 * 60 * 60;
  * @throws Will throw an error if the base type is invalid, no homebase is found or if it catches an exception.
  */
 export const migrateBase: KoaController = async (ctx) => {
-  try {
-    const { baseid, resources, shiny, type } = MigrateBaseSchema.parse(ctx.request.body);
+  const { baseid, resources, shiny, type } = MigrateBaseSchema.parse(ctx.request.body);
 
-    const currentUser: User = ctx.authUser;
-    await postgres.em.populate(currentUser, ["save"]);
+  const currentUser: User = ctx.authUser;
+  await postgres.em.populate(currentUser, ["save"]);
 
-    const userSave = currentUser.save!;
-    const currentTime = getCurrentDateTime();
+  const userSave = currentUser.save!;
+  const currentTime = getCurrentDateTime();
 
-    // Check if the user is within the cooldown period.
-    if (userSave.cantmovetill && userSave.cantmovetill > currentTime) {
-      ctx.status = Status.OK;
-      ctx.body = {
-        error: 0,
-        cantMoveTill: userSave.cantmovetill,
-        currenttime: currentTime,
-      };
-      return;
-    }
-
-    // User is relocating due to their empire being overrun.
-    if (type === BaseType.RANDOM) {
-      if (userSave.outposts.length > 0) throw relocateOutpostErr();
-
-      await leaveWorld(currentUser, userSave);
-      await joinOrCreateWorld(currentUser, userSave, postgres.em, true);
-
-      ctx.status = Status.OK;
-      ctx.body = { error: 0 };
-      return;
-    }
-
-    // Otherwise, fetch the outpost cell (destination) and the user's homeCell (origin) for migration.
-    const cells = await postgres.em.find(
-      WorldMapCell,
-      {
-        baseid: { $in: [baseid, userSave.baseid] },
-      },
-      { populate: ["save"] }
-    );
-
-    const outpostCell = cells.find((cell) => cell.baseid === baseid);
-
-    const homeCell = cells.find(
-      (cell) =>
-        cell.baseid === userSave.baseid &&
-        cell.base_type === MapRoomCell.HOMECELL
-    );
-
-    if (!outpostCell || !outpostCell.save) {
-      ctx.status = Status.BAD_REQUEST;
-      ctx.body = { error: 1 };
-      throw new Error(`Invalid base or base type. Base ID: ${baseid}`);
-    }
-
-    if (!homeCell) {
-      ctx.status = Status.BAD_REQUEST;
-      ctx.body = { error: 1 };
-      throw new Error("Invalid home cell");
-    }
-    // Store outpost details before removing it
-    const [outpostX, outpostY] = [outpostCell.x, outpostCell.y];
-    const outpostHeight = outpostCell.terrainHeight;
-    const outpostBaseId = outpostCell.save.baseid;
-
-    // Update the user's homecell coordinates to the outpost cell
-    homeCell.x = outpostX;
-    homeCell.y = outpostY;
-    homeCell.terrainHeight = outpostHeight;
-
-    // Update user's homebase coordinates to the outpost cell
-    userSave.homebase = [outpostX.toString(), outpostY.toString()];
-
-    // Set the migration cooldown period before the user can move again
-    userSave.cantmovetill = currentTime + COOLDOWN_PERIOD;
-
-    // Remove the outpost from the user's save, 3rd element in the array is the baseid
-    userSave.outposts = userSave.outposts.filter(
-      (outpost) => outpost[2] !== baseid
-    );
-
-    // Remove baseid from building resources object
-    if (userSave.buildingresources) {
-      delete userSave.buildingresources[`b${outpostBaseId}`];
-    }
-
-    if (shiny) userSave.credits = userSave.credits - shiny;
-    if (resources)
-      userSave.resources = updateResources(resources, userSave.resources ?? {}, Operation.SUBTRACT);
-
-    await postgres.em.transactional(async (em) => {
-      em.persist([homeCell, userSave]);
-      em.remove([outpostCell.save, outpostCell]);
-      await em.flush();
-    });
-
+  // Check if the user is within the cooldown period.
+  if (userSave.cantmovetill && userSave.cantmovetill > currentTime) {
     ctx.status = Status.OK;
     ctx.body = {
       error: 0,
-      coords: [outpostX, outpostY],
+      cantMoveTill: userSave.cantmovetill,
+      currenttime: currentTime,
     };
-  } catch (error) {
-    if (error instanceof ClientSafeError) throw error;
-
-    ctx.status = Status.BAD_REQUEST;
-    ctx.body = { error: 1 };
-    logger.error(`Error migrating user base: ${error}`);
+    return;
   }
+
+  // User is relocating due to their empire being overrun.
+  if (type === BaseType.RANDOM) {
+    if (userSave.outposts.length > 0) throw relocateOutpostErr();
+
+    await leaveWorld(currentUser, userSave);
+    await joinOrCreateWorld(currentUser, userSave, postgres.em, true);
+
+    ctx.status = Status.OK;
+    ctx.body = { error: 0 };
+    return;
+  }
+
+  // Otherwise, fetch the outpost cell (destination) and the user's homeCell (origin) for migration.
+  const cells = await postgres.em.find(
+    WorldMapCell,
+    {
+      baseid: { $in: [baseid, userSave.baseid] }
+    },
+    { populate: ["save"] }
+  );
+
+  const outpostCell = cells.find((cell) => cell.baseid === baseid);
+
+  const homeCell = cells.find(
+    (cell) =>
+      cell.baseid === userSave.baseid &&
+      cell.base_type === MapRoomCell.HOMECELL
+  );
+
+  if (!outpostCell || !outpostCell.save) {
+    throw new Error(`Invalid base or base type. Base ID: ${baseid}`);
+  }
+
+  if (!homeCell) throw new Error("Invalid home cell");
+
+  // Store outpost details before removing it
+  const [outpostX, outpostY] = [outpostCell.x, outpostCell.y];
+  const outpostHeight = outpostCell.terrainHeight;
+  const outpostBaseId = outpostCell.save.baseid;
+
+  // Update the user's homecell coordinates to the outpost cell
+  homeCell.x = outpostX;
+  homeCell.y = outpostY;
+  homeCell.terrainHeight = outpostHeight;
+
+  // Update user's homebase coordinates to the outpost cell
+  userSave.homebase = [outpostX.toString(), outpostY.toString()];
+
+  // Set the migration cooldown period before the user can move again
+  userSave.cantmovetill = currentTime + COOLDOWN_PERIOD;
+
+  // Remove the outpost from the user's save, 3rd element in the array is the baseid
+  userSave.outposts = userSave.outposts.filter(
+    (outpost) => outpost[2] !== baseid
+  )
+
+  // Remove baseid from building resources object
+  if (userSave.buildingresources) {
+    delete userSave.buildingresources[`b${outpostBaseId}`];
+  }
+
+  if (shiny) userSave.credits = userSave.credits - shiny;
+  if (resources)
+    userSave.resources = updateResources(resources, userSave.resources ?? {}, Operation.SUBTRACT);
+
+  await postgres.em.transactional(async (em) => {
+    em.persist([homeCell, userSave]);
+    em.remove([outpostCell.save, outpostCell]);
+    await em.flush();
+  });
+
+  ctx.status = Status.OK;
+  ctx.body = {
+    error: 0,
+    coords: [outpostX, outpostY],
+  };
 };

--- a/server/src/controllers/maproom/v2/takeoverCell.ts
+++ b/server/src/controllers/maproom/v2/takeoverCell.ts
@@ -9,10 +9,10 @@ import {
   Operation,
   updateResources,
 } from "../../../services/base/updateResources.js";
-import { logger } from "../../../utils/logger.js";
 import { getCurrentDateTime } from "../../../utils/getCurrentDateTime.js";
 import { validateRange } from "../../../services/maproom/v2/validateRange.js";
 import { TakeoverCellSchema } from "../../../zod/TakeoverCellSchema.js";
+import { takeoverCellErr } from "../../../errors/errors.js";
 
 /**
  * Controller to handle the takeover of a cell on the world map via shiny or resources.
@@ -25,102 +25,91 @@ import { TakeoverCellSchema } from "../../../zod/TakeoverCellSchema.js";
  * @throws Will throw an error if the base or base type is invalid.
  */
 export const takeoverCell: KoaController = async (ctx) => {
-  try {
-    const { baseid, resources, shiny } = TakeoverCellSchema.parse(
-      ctx.request.body
-    );
+  const { baseid, resources, shiny } = TakeoverCellSchema.parse(ctx.request.body);
 
-    const currentUser: User = ctx.authUser;
-    await postgres.em.populate(currentUser, ["save"]);
+  const currentUser: User = ctx.authUser;
+  await postgres.em.populate(currentUser, ["save"]);
 
-    const userSave = currentUser.save!;
+  const userSave = currentUser.save!;
 
-    const cell = await postgres.em.findOne(
-      WorldMapCell,
-      { baseid, world: userSave.worldid },
-      { populate: ["save"] }
-    );
+  const cell = await postgres.em.findOne(
+    WorldMapCell,
+    { baseid, world: userSave.worldid },
+    { populate: ["save"] }
+  );
 
-    if (!cell || !cell.save || cell.save.type === BaseType.MAIN) {
-      ctx.status = Status.BAD_REQUEST;
-      ctx.body = { error: 1 };
-      throw new Error(`Invalid base or base type. Base ID: ${baseid}`);
-    }
-
-    const cellSave = cell.save;
-
-    if (cellSave.damage < 90)
-      throw new Error("Cell is not damaged enough to be taken over.");
-
-    const mapversion: MapRoomVersion = cell.map_version;
-
-    await validateRange(currentUser, userSave, mapversion, { attackCell: cell });
-
-    if (shiny) userSave.credits = userSave.credits - shiny;
-    if (resources)
-      userSave.resources = updateResources(
-        resources,
-        userSave.resources ?? {},
-        Operation.SUBTRACT
-      );
-
-    // Clean up previous owner's save if the cell was player-owned
-    const previousOwner = await postgres.em.findOne(
-      User,
-      { userid: cellSave.userid },
-      { populate: ["save"] }
-    );
-
-    if (previousOwner?.save) {
-      const { outposts } = previousOwner.save;
-
-      previousOwner.save.outposts = outposts.filter(
-        ([x, y, id]) => !(x === cell.x && y === cell.y && id === baseid)
-      );
-
-      if (previousOwner.save.buildingresources)
-        delete previousOwner.save.buildingresources[`b${baseid}`];
-
-      postgres.em.persist(previousOwner);
-    }
-
-    // Update save
-    const currentTime = getCurrentDateTime();
-    const twelveHours = 12 * 60 * 60;
-
-    cellSave.saveuserid = currentUser.userid;
-    cellSave.userid = userSave.userid;
-    cellSave.homebaseid = userSave.homebaseid;
-    cellSave.name = userSave.name;
-    cellSave.createtime = currentTime;
-    cellSave.protected = currentTime + twelveHours;
-    cellSave.attacks = [];
-    cellSave.resources = {};
-    cellSave.tutorialstage = 205;
-    cellSave.monsters = {};
-    
-    cellSave.takeoverDate = new Date();
-
-    if (cellSave.type === BaseType.TRIBE) {
-      cellSave.type = BaseType.OUTPOST;
-      cellSave.buildingdata = {};
-      cellSave.wmid = 0;
-    }
-
-    // Update cell
-    cell.uid = currentUser.userid;
-    cell.base_type = MapRoomCell.OUTPOST;
-
-    // Update user
-    userSave.outposts.push([cell.x, cell.y, baseid]);
-    postgres.em.persist([cellSave, currentUser]);
-    await postgres.em.flush();
-
-    ctx.status = Status.OK;
-    ctx.body = { error: 0 };
-  } catch (error) {
-    logger.error(`Error taking over cell: ${error}`);
-    ctx.status = Status.BAD_REQUEST;
-    ctx.body = { error: "The server attempted to take over this cell but failed unexpectedly." };
+  if (!cell || !cell.save || cell.save.type === BaseType.MAIN) {
+    throw new Error(`Invalid base or base type. Base ID: ${baseid}`);
   }
+
+  const cellSave = cell.save;
+
+  if (cellSave.damage < 90) throw takeoverCellErr();
+
+  const mapversion: MapRoomVersion = cell.map_version;
+
+  await validateRange(currentUser, userSave, mapversion, { attackCell: cell });
+
+  if (shiny) userSave.credits = userSave.credits - shiny;
+  if (resources)
+    userSave.resources = updateResources(
+      resources,
+      userSave.resources ?? {},
+      Operation.SUBTRACT
+    );
+
+  // Clean up previous owner's save if the cell was player-owned
+  const previousOwner = await postgres.em.findOne(
+    User,
+    { userid: cellSave.userid },
+    { populate: ["save"] }
+  );
+
+  if (previousOwner?.save) {
+    const { outposts } = previousOwner.save;
+
+    previousOwner.save.outposts = outposts.filter(
+      ([x, y, id]) => !(x === cell.x && y === cell.y && id === baseid)
+    );
+
+    if (previousOwner.save.buildingresources)
+      delete previousOwner.save.buildingresources[`b${baseid}`];
+
+    postgres.em.persist(previousOwner);
+  }
+
+  // Update save
+  const currentTime = getCurrentDateTime();
+  const twelveHours = 12 * 60 * 60;
+
+  cellSave.saveuserid = currentUser.userid;
+  cellSave.userid = userSave.userid;
+  cellSave.homebaseid = userSave.homebaseid;
+  cellSave.name = userSave.name;
+  cellSave.createtime = currentTime;
+  cellSave.protected = currentTime + twelveHours;
+  cellSave.attacks = [];
+  cellSave.resources = {};
+  cellSave.tutorialstage = 205;
+  cellSave.monsters = {};
+    
+  cellSave.takeoverDate = new Date();
+
+  if (cellSave.type === BaseType.TRIBE) {
+    cellSave.type = BaseType.OUTPOST;
+    cellSave.buildingdata = {};
+    cellSave.wmid = 0;
+  }
+
+  // Update cell
+  cell.uid = currentUser.userid;
+  cell.base_type = MapRoomCell.OUTPOST;
+
+  // Update user
+  userSave.outposts.push([cell.x, cell.y, baseid]);
+  postgres.em.persist([cellSave, currentUser]);
+  await postgres.em.flush();
+
+  ctx.status = Status.OK;
+  ctx.body = { error: 0 };
 };

--- a/server/src/controllers/maproom/v3/relocate.ts
+++ b/server/src/controllers/maproom/v3/relocate.ts
@@ -3,23 +3,16 @@ import { User } from "../../../models/user.model.js";
 import { BASE_URL, PORT, postgres } from "../../../server.js";
 import type { KoaController } from "../../../utils/KoaController.js";
 import { joinNewWorldMap } from "../../../services/maproom/v3/joinNewWorldMap.js";
-import { logger } from "../../../utils/logger.js";
 
 export const relocate: KoaController = async (ctx) => {
   const user: User = ctx.authUser;
   await postgres.em.populate(user, ["save"]);
 
-  try {
-    await joinNewWorldMap(user, user.save!);
+  await joinNewWorldMap(user, user.save!);
 
-    ctx.status = Status.OK;
-    ctx.body = {
-      error: 0,
-      mapheaderurl: `${BASE_URL}:${PORT}/api/bm/getnewmap`,
-    };
-  } catch (err) {
-    logger.error(`Failed to relocate MR3 base: ${err}`);
-    ctx.status = Status.INTERNAL_SERVER_ERROR;
-    ctx.body = { error: "Failed to relocate base. Please try again." };
-  }
+  ctx.status = Status.OK;
+  ctx.body = {
+    error: 0,
+    mapheaderurl: `${BASE_URL}:${PORT}/api/bm/getnewmap`,
+  };
 };

--- a/server/src/errors/errors.ts
+++ b/server/src/errors/errors.ts
@@ -131,3 +131,20 @@ export const relocateOutpostErr = () =>
     data: {},
     isClientFriendly: true,
   });
+
+export const baseUnderAttackErr = () =>
+  new ClientSafeError({
+    message: "This base is currently under attack by another player. Please try again later.",
+    status: Status.CONFLICT,
+    data: {},
+    isClientFriendly: false,
+  });
+
+export const takeoverCellErr = () =>
+  new ClientSafeError({
+    message: "The server attempted to take over this cell but failed unexpectedly. Please try again.",
+    status: Status.INTERNAL_SERVER_ERROR,
+    data: {},
+    isClientFriendly: false,
+  });
+


### PR DESCRIPTION
## Summary

This PR improves error handling architecture across the server, adds server-side attack concurrency guards, and fixes several bugs in the damage protection and locked-cell systems.

---

## Error Handling Architecture

### Problem

Several controllers wrapped their entire body in a `try-catch` that returned a hardcoded generic error for **all** failures — including specific `ClientSafeError` instances that were meant to surface meaningful messages to the client. This meant that throwing a specific error like `baseUnderAttackErr()` deep in a call chain would be silently swallowed and replaced with "The server failed to load this base."

This also violated the existing architecture: `ErrorInterceptor` already handles all unhandled errors at the top level, logging unknown errors server-side and returning a safe generic message to the client.

### Solution: Fail-Fast, No Catch-All

Removed blanket `try-catch` blocks from the following controllers, allowing errors to bubble freely to `ErrorInterceptor`:

- `baseLoad.ts`
- `baseSave.ts`
- `updateSaved.ts`
- `migrateBase.ts`
- `takeoverCell.ts`
- `relocate.ts`
- `reportMessageThread.ts`
- `getLeaderboards.ts`

At known, user-facing failure conditions, specific `ClientSafeError` instances are now thrown at the exact point of failure (fail-fast), rather than relying on a catch block at the bottom to infer what went wrong.

**Before:**
```typescript
try {
  // ... entire controller body
} catch (e) {
  ctx.status = Status.INTERNAL_SERVER_ERROR;
  ctx.body = { error: "The server failed to load this base." };
}
```

**After:**
```typescript
// Throw immediately at the known condition
if (isAttackActive(save)) throw baseUnderAttackErr();

// Everything else bubbles to ErrorInterceptor
```

This approach is more honest: if we *know* what failed, we say so. If we don't know, `ErrorInterceptor` logs it server-side and returns a generic message — which is more useful for debugging than a catch-all that silently hides the real exception.

---

## Server-Side Attack Concurrency Guard

### Problem

If two players simultaneously attacked the same base, the client had no guard for this race window. The second attacker would receive no meaningful feedback and the base save could enter a bad state.

### Solution

Added `isAttackActive()` checks in attack load controllers before `attackid` is set, throwing `baseUnderAttackErr()` if an attack is already in progress:

- `baseModeAttack.ts` — guards all non-tribe saves in MR2/MR3
- `infernoModeAttack.ts` — guards inferno saves

The error uses `isClientFriendly: false` so Flash receives it via the normal `handleBaseLoadSuccessful` path and displays it with `GLOBAL.ErrorMessage()`, showing the actual message to the player.

## New Errors

| Error | Message | Condition |
|-------|---------|-----------|
| `baseUnderAttackErr` | "This base is currently under attack by another player. Please try again later." | Attack attempted on a base with an active attack |
| `takeoverCellErr` | "The server attempted to take over this cell but failed unexpectedly. Please try again." | Takeover attempted when base damage < 90 |
