### PR TITLE
Implemented truce system into Backyard Monsters Refitted

### DIFF
--- a/server/src/app.routes.ts
+++ b/server/src/app.routes.ts
@@ -34,6 +34,7 @@ import { getMessageThreads } from "./controllers/mail/getMessageThreads.js";
 import { getMessageThread } from "./controllers/mail/getMessageThread.js";
 import { sendMessage } from "./controllers/mail/sendMessage.js";
 import { reportMessageThread } from "./controllers/mail/reportMessageThread.js";
+import { requestTruce } from "./controllers/mail/requestTruce.js";
 import { getAvailableWorlds } from "./controllers/leaderboards/getAvailableWorlds.js";
 import { getLeaderboards } from "./controllers/leaderboards/getLeaderboards.js";
 import { getAttackLogs } from "./controllers/attacklogs/getAttackLogs.js";
@@ -437,6 +438,18 @@ router.post(
   verifyUserAuth,
   logRequest("Send message"),
   sendMessage
+);
+
+/**
+ * Request truce (legacy MR2 path — new clients use sendmessage with type=trucerequest)
+ * @name POST /api/:apiVersion/player/requesttruce
+ */
+router.post(
+  "/api/:apiVersion/player/requesttruce",
+  apiVersion,
+  verifyUserAuth,
+  logRequest("Request truce"),
+  requestTruce
 );
 
 /**

--- a/server/src/config/GameConfig.ts
+++ b/server/src/config/GameConfig.ts
@@ -1,4 +1,5 @@
 import { Env } from "../enums/Env.js";
+import { MessageType } from "../enums/MessageType.js";
 
 /** Visit our Wiki to get more information on each flag.
  * Wiki: https://github.com/bym-refitted/backyard-monsters-refitted/wiki/Dev-Settings-%E2%80%90-Configuration
@@ -82,10 +83,10 @@ export const devConfig = {
    * Sets the type of messages that are allowed to be sent by the client.
    */
   allowedMessageType: {
-    message: true,
-    trucerequest: false,
-    truceaccept: false,
-    trucereject: false,
-    migraterequest: false,
+    [MessageType.MESSAGE]: true,
+    [MessageType.TRUCE_REQUEST]: true,
+    [MessageType.TRUCE_ACCEPT]: true,
+    [MessageType.TRUCE_REJECT]: true,
+    [MessageType.MIGRATE_REQUEST]: false,
   },
 };

--- a/server/src/controllers/base/load/modes/baseModeAttack.ts
+++ b/server/src/controllers/base/load/modes/baseModeAttack.ts
@@ -9,20 +9,20 @@ import { User } from "../../../../models/user.model.js";
 import { tribeSaveHandler } from "../../../../services/maproom/tribeSaveHandler.js";
 import { getCurrentDateTime } from "../../../../utils/getCurrentDateTime.js";
 import { validateRange } from "../../../../services/maproom/v2/validateRange.js";
-import {
-  generateNoise,
-  getTerrainHeight,
-} from "../../../../services/maproom/v2/generateMap.js";
 import { getGeneratedCells, cellKey } from "../../../../services/maproom/v3/generateCells.js";
 import { createAttackLog } from "../../../../services/base/createAttackLog.js";
 import { updateResources, Operation } from "../../../../services/base/updateResources.js";
 import { isAttackActive } from "../../../../services/base/isAttackActive.js";
-import { baseUnderAttackErr, baseProtectedErr, userOnlineErr } from "../../../../errors/errors.js";
+import { baseUnderAttackErr, baseProtectedErr, userOnlineErr, truceActiveErr } from "../../../../errors/errors.js";
 import { redis } from "../../../../server.js";
-
+import { isTruceActive } from "../../../../services/mail/isTruceActive.js";
 import { MR1_TRIBE_IDS } from "../../../../game-data/tribes/v1/index.js";
 import { registerAttacker } from "../../../../services/maproom/v1/registerAttacker.js";
 import type { BuildingData } from "../../../../types/BuildingData.js";
+import {
+  generateNoise,
+  getTerrainHeight,
+} from "../../../../services/maproom/v2/generateMap.js";
 
 export interface AttackDetails {
   fbid?: string;
@@ -69,6 +69,10 @@ export const baseModeAttack = async ({ user, baseid, mapversion, attackCost }: B
       const lastSeen = await redis.get(`last-seen:${BaseType.MAIN}:${save.userid}`);
       if (lastSeen && parseInt(lastSeen) >= getCurrentDateTime() - 60) throw userOnlineErr();
     }
+
+    const activeTruce = await isTruceActive(user.userid, save.saveuserid);
+    
+    if (activeTruce) throw truceActiveErr();
   }
 
   if (save.attacks.length > 3) save.attacks = save.attacks.slice(-2);

--- a/server/src/controllers/mail/getMessageThreads.ts
+++ b/server/src/controllers/mail/getMessageThreads.ts
@@ -48,7 +48,7 @@ export const getMessageThreads: KoaController = async (ctx) => {
 
       lastMessage.messageid = index.toString();
       lastMessage.messagecount = thread.messagecount;
-      
+      lastMessage.trucestate = thread.trucestate ?? null;
       lastMessage.userid = isSender ? lastMessage.targetid : lastMessage.userid;
       lastMessage.reportid = "0";
 

--- a/server/src/controllers/mail/requestTruce.ts
+++ b/server/src/controllers/mail/requestTruce.ts
@@ -1,0 +1,113 @@
+import z from "zod";
+
+import { Status } from "../../enums/StatusCodes.js";
+import { TruceStatus } from "../../enums/TruceStatus.js";
+import { Message } from "../../models/message.model.js";
+import { Save } from "../../models/save.model.js";
+import { Truce } from "../../models/truce.model.js";
+import { User } from "../../models/user.model.js";
+import { postgres } from "../../server.js";
+import { countUnreadMessage } from "../../services/mail/countUnreadMessage.js";
+import { findOrCreateThread } from "../../services/mail/findOrCreateThread.js";
+import type { MessageData } from "../../types/EntityData.js";
+import { getCurrentDateTime } from "../../utils/getCurrentDateTime.js";
+import type { KoaController } from "../../utils/KoaController.js";
+import { mailboxErr, permissionErr } from "../../errors/errors.js";
+
+/**
+ * Duration (in seconds) for which a truce remains active after being accepted.
+ * After this period, the truce expires and a new request can be made.
+ * Currently set to 14 days.
+ */
+export const TRUCE_DURATION = 14 * 24 * 60 * 60;
+
+const TruceSchema = z.object({
+  baseid: z.string(),
+  message: z.string().max(580).min(1),
+});
+
+/**
+ * Creates a truce request between the authenticated user and the owner of the given base.
+ *
+ * - Resolves the target player from the provided baseid
+ * - Guards against self-truces, duplicate pending requests, and unexpired active truces
+ * - Creates a Truce record and a mailbox thread with the initial request message
+ *
+ * @param {Context} ctx - Koa context. Expects baseid and message in the request body.
+ */
+export const requestTruce: KoaController = async (ctx) => {
+  const user: User = ctx.authUser;
+  await postgres.em.populate(user, ["save"]);
+
+  const { baseid, message } = TruceSchema.parse(ctx.request.body);
+
+  const targetSave = await postgres.em.findOne(Save, { baseid });
+
+  if (!targetSave) throw mailboxErr();
+
+  if (targetSave.saveuserid === user.userid) throw permissionErr();
+
+  const targetUserid = targetSave.saveuserid;
+
+  const existingTruce = await postgres.em.findOne(Truce, {
+    $and: [
+      {
+        $or: [
+          { initiator_userid: user.userid, recipient_userid: targetUserid },
+          { initiator_userid: targetUserid, recipient_userid: user.userid },
+        ],
+      },
+      {
+        $or: [
+          { status: TruceStatus.REQUESTED },
+          { status: TruceStatus.ACCEPTED, expires_at: { $gt: getCurrentDateTime() } },
+        ],
+      },
+    ],
+  });
+
+  if (existingTruce) throw permissionErr();
+
+  const truce = postgres.em.create(Truce, {
+    initiator_userid: user.userid,
+    recipient_userid: targetUserid,
+    status: TruceStatus.REQUESTED,
+    created_at: new Date(),
+  });
+
+  postgres.em.persist(truce);
+  await postgres.em.flush();
+
+  const thread = await findOrCreateThread(0, targetUserid, user.userid);
+  thread.truce_id = truce.id;
+  thread.trucestate = TruceStatus.REQUESTED;
+
+  const newMessage = postgres.em.create(Message, {
+    threadid: thread.threadid,
+    userid: user.userid,
+    targetid: targetUserid,
+    messagetype: "trucerequest",
+    userUnread: 0,
+    targetUnread: 1,
+    subject: `Truce Request from ${user.username}`,
+    message,
+    updatetime: getCurrentDateTime(),
+  } as unknown as MessageData);
+
+  thread.messagecount++;
+  thread.lastMessage = newMessage;
+  
+  postgres.em.persist(thread);
+  await postgres.em.flush();
+
+  const recipient = await postgres.em.findOne(User, { userid: targetUserid }, { populate: ["save"] });
+
+  if (recipient?.save) {
+    recipient.save.unreadmessages = await countUnreadMessage(targetUserid);
+    postgres.em.persist(recipient);
+    await postgres.em.flush();
+  }
+
+  ctx.status = Status.OK;
+  ctx.body = { error: 0 };
+};

--- a/server/src/controllers/mail/sendMessage.ts
+++ b/server/src/controllers/mail/sendMessage.ts
@@ -1,4 +1,6 @@
 import { Status } from "../../enums/StatusCodes.js";
+import { TruceStatus } from "../../enums/TruceStatus.js";
+import { MessageType } from "../../enums/MessageType.js";
 import { User } from "../../models/user.model.js";
 import type { KoaController } from "../../utils/KoaController.js";
 import { devConfig } from "../../config/GameConfig.js";
@@ -8,6 +10,8 @@ import { Message } from "../../models/message.model.js";
 import { getCurrentDateTime } from "../../utils/getCurrentDateTime.js";
 import { findOrCreateThread } from "../../services/mail/findOrCreateThread.js";
 import { countUnreadMessage } from "../../services/mail/countUnreadMessage.js";
+import { handleTruceRequest } from "../../services/mail/handleTruceRequest.js";
+import { handleTruceResponse } from "../../services/mail/handleTruceResponse.js";
 import { mailboxErr } from "../../errors/errors.js";
 import { logger } from "../../utils/logger.js";
 import type { MessageData } from "../../types/EntityData.js";
@@ -19,6 +23,9 @@ import type { MessageData } from "../../types/EntityData.js";
  * - a thread starter will have correct request body for targetid
  * - another reply on a thread will always have request body for targetid set as current user,
  * so it need to be changed by getting up on the correct targetid when saved to DB
+ *
+ * For trucerequest: creates a Truce record and links it to the thread.
+ * For truceaccept/trucereject: updates the Truce record and thread state.
  *
  * @param {Context} ctx - The Koa context object, which includes the request body.
  * @returns {Promise<void>} - A promise that resolves when the controller is complete.
@@ -66,6 +73,20 @@ export const sendMessage: KoaController = async (ctx) => {
       ctx.status = Status.OK;
       ctx.body = { error: 1, message: "Cannot send message to this user" };
       return;
+    }
+
+    switch (message.type) {
+      case MessageType.TRUCE_REQUEST:
+        await handleTruceRequest(userid, messageTargetId, thread);
+        break;
+
+      case MessageType.TRUCE_ACCEPT:
+        await handleTruceResponse(userid, thread, TruceStatus.ACCEPTED);
+        break;
+        
+      case MessageType.TRUCE_REJECT:
+        await handleTruceResponse(userid, thread, TruceStatus.REJECTED);
+        break;
     }
 
     const newMessage = postgres.em.create(Message, {

--- a/server/src/controllers/mail/zod/SendMessageSchema.ts
+++ b/server/src/controllers/mail/zod/SendMessageSchema.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import { MessageType } from "../../../enums/MessageType.js";
 
 /**
  * Schema for validating and transforming send message data.
@@ -15,10 +16,10 @@ export const SendMessageSchema = z.object({
   subject: z.string(),
 
   /**
-   * The message type, possible value between message,trucerequest,truceaccept,trucereject,migraterequest
-   * @type {string}
+   * The message type.
+   * @type {MessageType}
    */
-  type: z.enum(["message", "trucerequest", "truceaccept", "trucereject", "migraterequest"]),
+  type: z.enum(MessageType),
 
   /**
    * the content of the message

--- a/server/src/controllers/maproom/inferno/getNeighbours.ts
+++ b/server/src/controllers/maproom/inferno/getNeighbours.ts
@@ -114,7 +114,7 @@ const getOverworldNeighbours: KoaController = async (ctx) => {
     await postgres.em.flush();
   }
 
-  const neighbours = await updateNeighbourData(maproom.neighbors, BaseType.MAIN);
+  const neighbours = await updateNeighbourData(maproom.neighbors, BaseType.MAIN, user.userid);
 
   ctx.status = Status.OK;
   ctx.body = { error: 0, wmbases: [], bases: neighbours };

--- a/server/src/controllers/maproom/v2/cells/userCell.ts
+++ b/server/src/controllers/maproom/v2/cells/userCell.ts
@@ -19,6 +19,7 @@ import { isAttackActive } from "../../../../services/base/isAttackActive.js";
  */
 export const userCell = async (ctx: Context, cell: WorldMapCell, cellOwners: Map<number, User>) => {
   const currentUser: User = ctx.authUser;
+  const { lastSeen, truces } = ctx.state;
 
   const mine = currentUser.userid === cell.uid;
   const cellOwner = mine ? currentUser : cellOwners.get(cell.uid);
@@ -30,7 +31,6 @@ export const userCell = async (ctx: Context, cell: WorldMapCell, cellOwners: Map
 
   const homeCell = cell.base_type === MapRoomCell.HOMECELL;
     
-  const lastSeen = ctx.state.lastSeen;
   const online = homeCell && (lastSeen.get(cell.uid) ?? 0) >= currentTime - 60;
   const isUnderAttack = homeCell && isAttackActive(cellSave);
 
@@ -44,8 +44,10 @@ export const userCell = async (ctx: Context, cell: WorldMapCell, cellOwners: Map
 
   const isProtected = cellSave.protected > 0 && cellSave.protected > currentTime;
   const protectionExpired = cellSave.protected > 0 && cellSave.protected <= currentTime;
-    
+
   const damage = protectionExpired ? 0 : cellSave.damage;
+
+  const truceExpiry = mine ? undefined : truces.get(cellOwner.userid)?.expires_at;
 
   return {
     uid: cellOwner.userid,
@@ -57,8 +59,8 @@ export const userCell = async (ctx: Context, cell: WorldMapCell, cellOwners: Map
     v: cellSave.empirevalue,
     mine: mine ? 1 : 0,
     f: cellSave.flinger,
-     c: cellSave.catapult,
-    t: 0,
+    c: cellSave.catapult,
+    t: truceExpiry,
     n: cellOwner.username,
     fr: 0,
     p: isProtected ? 1 : 0,
@@ -69,6 +71,6 @@ export const userCell = async (ctx: Context, cell: WorldMapCell, cellOwners: Map
     lo: locked,
     dm: damage,
     pic_square: cellOwner.pic_square,
-    im: cellOwner.pic_square
+    im: cellOwner.pic_square,
   };
 };

--- a/server/src/controllers/maproom/v2/getArea.ts
+++ b/server/src/controllers/maproom/v2/getArea.ts
@@ -10,6 +10,7 @@ import { createCellData } from "../../../services/maproom/v2/createCellData.js";
 import { generateNoise, getTerrainHeight } from "../../../services/maproom/v2/generateMap.js";
 import { MapRoomVersion } from "../../../enums/MapRoom.js";
 import { getLastSeen } from "../../../services/maproom/getLastSeen.js";
+import { getTruces } from "../../../services/maproom/getTruces.js";
 import { BaseType } from "../../../enums/Base.js";
 import { mapRoomDisabledErr } from "../../../errors/errors.js";
 
@@ -108,17 +109,19 @@ export const getArea: KoaController = async (ctx) => {
   // Batch load all unique cell owners in a single query
   const ownerIds = [...new Set(dbCells.map(cell => cell.uid).filter(Boolean))] as number[];
 
-  const [ownersList, lastSeen] = await Promise.all([
+  const [ownersList, lastSeen, truces] = await Promise.all([
     postgres.em.find(User, { userid: { $in: ownerIds } }, {
       populate: ["save"],
       fields: CELL_OWNER_FIELDS,
     }),
     getLastSeen(ownerIds, BaseType.MAIN),
+    getTruces(user.userid, ownerIds),
   ]);
 
   const cellOwners = new Map<number, User>((ownersList as unknown as User[]).map(u => [u.userid, u]));
 
   ctx.state.lastSeen = lastSeen;
+  ctx.state.truces = truces;
 
   const cells: Record<number, Record<number, unknown>> = {};
   for (const cell of dbCells) {

--- a/server/src/controllers/maproom/v3/cells/playerCell.ts
+++ b/server/src/controllers/maproom/v3/cells/playerCell.ts
@@ -24,6 +24,7 @@ export const playerCell = async (ctx: Context, cell: WorldMapCell, cellOwners: M
   const [cellX, cellY] = [cell.x, cell.y];
 
   const currentUser: User = ctx.authUser;
+  const { lastSeen = new Map(), truces } = ctx.state;
 
   const mine = currentUser.userid === cell.uid;
   const cellOwner = mine ? currentUser : cellOwners.get(cell.uid);
@@ -59,13 +60,14 @@ export const playerCell = async (ctx: Context, cell: WorldMapCell, cellOwners: M
   if (homeCell) 
     isProtected = cellSave.protected > 0 && cellSave.protected > currentTime;
 
-  const lastSeen = ctx.state.lastSeen ?? new Map();
   const online = homeCell && (lastSeen.get(cell.uid) ?? 0) >= currentTime - 60;
   const isUnderAttack = homeCell && isAttackActive(cellSave);
 
   let locked = 0;
   if (online || isUnderAttack) locked = 1;
   if (mine) locked = 0;
+
+  const hasTruce = !mine && !!truces.get(cellOwner.userid);
 
   return {
     uid: cellOwner.userid,
@@ -85,7 +87,7 @@ export const playerCell = async (ctx: Context, cell: WorldMapCell, cellOwners: M
     fr: 0,
     p: isProtected ? 1 : 0,
     d: (cellSave?.damage ?? 0) >= 90 ? 1 : 0,
-    t: 0,
+    t: hasTruce ? 1 : 0,
     rel: mine ? EnumBaseRelationship.SELF : EnumBaseRelationship.ENEMY,
     pic_square: cellOwner.pic_square ?? undefined,
   };

--- a/server/src/controllers/maproom/v3/getCells.ts
+++ b/server/src/controllers/maproom/v3/getCells.ts
@@ -16,6 +16,7 @@ import { getCellBounds, type Coord } from "../../../services/maproom/v3/utils/ge
 import { getDefenderLevels } from "../../../services/maproom/v3/getDefenderLevels.js";
 import { TRIBE_REGEN_TIME } from "../../../config/MapRoom3Config.js";
 import { getLastSeen } from "../../../services/maproom/getLastSeen.js";
+import { getTruces } from "../../../services/maproom/getTruces.js";
 import { BaseType } from "../../../enums/Base.js";
 import { devConfig } from "../../../config/GameConfig.js";
 
@@ -206,12 +207,13 @@ export const getMapRoomCells: KoaController = async (ctx) => {
     // =========================================================================
     const ownerIds = [...new Set(dbCells.map((cell) => cell.uid).filter(Boolean))];
 
-    const [ownersList, lastSeenMap] = await Promise.all([
+    const [ownersList, lastSeenMap, truces] = await Promise.all([
       postgres.em.find(User, { userid: { $in: ownerIds } }, {
         populate: ["save"],
         fields: CELL_OWNER_FIELDS,
       }),
       getLastSeen(ownerIds, BaseType.MAIN),
+      getTruces(user.userid, ownerIds),
     ]);
 
     const cellOwners = new Map<number, User>(
@@ -219,6 +221,7 @@ export const getMapRoomCells: KoaController = async (ctx) => {
     );
 
     ctx.state.lastSeen = lastSeenMap;
+    ctx.state.truces = truces;
 
     // =========================================================================
     // PHASE 5: Build cell data for all coordinates

--- a/server/src/database/migrations/20260427_AddTruceFieldsToThread.ts
+++ b/server/src/database/migrations/20260427_AddTruceFieldsToThread.ts
@@ -1,0 +1,19 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * Migration to add truce_id and trucestate fields to the thread table.
+ * This allows us to link threads to truces and track their status.
+ */
+export class Migration20260427_AddTruceFieldsToThread extends Migration {
+  async up(): Promise<void> {
+    await this.execute(`
+      ALTER TABLE bym.thread
+        ADD COLUMN truce_id INTEGER,
+        ADD COLUMN trucestate VARCHAR(10)
+    `);
+
+    await this.execute(`
+      CREATE INDEX thread_truce_id_idx ON bym.thread (truce_id)
+    `);
+  }
+}

--- a/server/src/database/migrations/20260427_CreateTruceTable.ts
+++ b/server/src/database/migrations/20260427_CreateTruceTable.ts
@@ -1,0 +1,28 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * Migration to create the "truce" table in the database.
+ * This table will store information about truces between users, including the initiator, recipient, status, expiration time, and creation time.
+ */
+export class Migration20260427_CreateTruceTable extends Migration {
+  async up(): Promise<void> {
+    await this.execute(`
+      CREATE TABLE bym.truce (
+        id SERIAL PRIMARY KEY,
+        initiator_userid INTEGER NOT NULL,
+        recipient_userid INTEGER NOT NULL,
+        status VARCHAR(10) NOT NULL DEFAULT 'requested',
+        expires_at BIGINT,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW()
+      )
+    `);
+
+    await this.execute(`
+      CREATE INDEX truce_initiator_userid_status_idx ON bym.truce (initiator_userid, status)
+    `);
+
+    await this.execute(`
+      CREATE INDEX truce_recipient_userid_status_idx ON bym.truce (recipient_userid, status)
+    `);
+  }
+}

--- a/server/src/enums/MapRoom.ts
+++ b/server/src/enums/MapRoom.ts
@@ -75,4 +75,5 @@ export enum AttackPermission {
   DAMAGE_PROTECTION = 5,
   SPECIAL_PROTECTION = 6,
   UNDER_ATTACK = 7,
+  TRUCE_ACTIVE = 9,
 }

--- a/server/src/enums/MessageType.ts
+++ b/server/src/enums/MessageType.ts
@@ -1,0 +1,11 @@
+/**
+ * Enum representing the types of messages that can be sent between players.
+ * @enum {string}
+ */
+export enum MessageType {
+  MESSAGE = "message",
+  TRUCE_REQUEST = "trucerequest",
+  TRUCE_ACCEPT = "truceaccept",
+  TRUCE_REJECT = "trucereject",
+  MIGRATE_REQUEST = "migraterequest",
+}

--- a/server/src/enums/TruceStatus.ts
+++ b/server/src/enums/TruceStatus.ts
@@ -1,0 +1,9 @@
+/**
+ * Enum representing the status of a truce between players.
+ * @enum {string}
+ */
+export enum TruceStatus {
+  REQUESTED = "requested",
+  ACCEPTED = "accepted",
+  REJECTED = "rejected",
+}

--- a/server/src/errors/errors.ts
+++ b/server/src/errors/errors.ts
@@ -180,3 +180,11 @@ export const townHallLevelErr = () =>
     isClientFriendly: true,
   });
 
+export const truceActiveErr = () =>
+  new ClientSafeError({
+    message: "You have an active truce with this player and cannot attack them.",
+    status: Status.FORBIDDEN,
+    data: {},
+    isClientFriendly: false,
+  });
+

--- a/server/src/mikro-orm.config.ts
+++ b/server/src/mikro-orm.config.ts
@@ -13,6 +13,7 @@ import { Maproom } from "./models/maproom.model.js";
 import { Message } from "./models/message.model.js";
 import { Thread } from "./models/thread.model.js";
 import { AttackLogs } from "./models/attacklogs.model.js";
+import { Truce } from "./models/truce.model.js";
 
 /**
  * List of entities to be used with MikroORM.
@@ -28,7 +29,8 @@ const entities = [
   Maproom,
   Message,
   Thread,
-  AttackLogs
+  AttackLogs,
+  Truce,
 ];
 
 /**

--- a/server/src/models/thread.model.ts
+++ b/server/src/models/thread.model.ts
@@ -1,6 +1,7 @@
 import { Entity, Index, OneToOne, PrimaryKey, Property } from "@mikro-orm/decorators/es";
 import { v4 } from "uuid";
 import { Message } from "./message.model.js";
+import type { TruceStatus } from "../enums/TruceStatus.js";
 
 @Index({ properties: ["userid", "threadid"] })
 @Index({ properties: ["targetid", "threadid"] })
@@ -24,6 +25,13 @@ export class Thread {
 
   @Property({ type: 'number' })
   messagecount!: number;
+
+  @Index()
+  @Property({ type: 'number', nullable: true })
+  truce_id?: number;
+
+  @Property({ type: 'string', nullable: true })
+  trucestate?: TruceStatus;
 
   @Property({ type: Date, onCreate: () => new Date() })
   createdAt: Date = new Date();

--- a/server/src/models/truce.model.ts
+++ b/server/src/models/truce.model.ts
@@ -1,0 +1,25 @@
+import { Entity, Index, PrimaryKey, Property } from "@mikro-orm/decorators/es";
+import { TruceStatus } from "../enums/TruceStatus.js";
+
+@Index({ properties: ["initiator_userid", "status"] })
+@Index({ properties: ["recipient_userid", "status"] })
+@Entity({ tableName: "truce" })
+export class Truce {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "number" })
+  initiator_userid!: number;
+
+  @Property({ type: "number" })
+  recipient_userid!: number;
+
+  @Property({ type: "string" })
+  status: TruceStatus = TruceStatus.REQUESTED;
+
+  @Property({ type: "number", nullable: true })
+  expires_at?: number;
+
+  @Property({ type: Date })
+  created_at: Date = new Date();
+}

--- a/server/src/services/mail/handleTruceRequest.ts
+++ b/server/src/services/mail/handleTruceRequest.ts
@@ -1,0 +1,50 @@
+import { TruceStatus } from "../../enums/TruceStatus.js";
+import { Truce } from "../../models/truce.model.js";
+import type { Thread } from "../../models/thread.model.js";
+import { postgres } from "../../server.js";
+import { getCurrentDateTime } from "../../utils/getCurrentDateTime.js";
+import { permissionErr } from "../../errors/errors.js";
+
+/**
+ * Creates a truce request from the current user to the message recipient.
+ *
+ * - Guards against duplicate pending requests and unexpired active truces
+ * - Creates a Truce record and links it to the thread
+ *
+ * @param userid - The authenticated user's ID
+ * @param recipientId - The target user's ID
+ * @param thread - The mailbox thread to link the truce to
+ */
+export const handleTruceRequest = async (userid: number, recipientId: number, thread: Thread) => {
+  const existingTruce = await postgres.em.findOne(Truce, {
+    $and: [
+      {
+        $or: [
+          { initiator_userid: userid, recipient_userid: recipientId },
+          { initiator_userid: recipientId, recipient_userid: userid },
+        ],
+      },
+      {
+        $or: [
+          { status: TruceStatus.REQUESTED },
+          { status: TruceStatus.ACCEPTED, expires_at: { $gt: getCurrentDateTime() } },
+        ],
+      },
+    ],
+  });
+
+  if (existingTruce) throw permissionErr();
+
+  const truce = postgres.em.create(Truce, {
+    initiator_userid: userid,
+    recipient_userid: recipientId,
+    status: TruceStatus.REQUESTED,
+    created_at: new Date(),
+  });
+
+  postgres.em.persist(truce);
+  await postgres.em.flush();
+
+  thread.truce_id = truce.id;
+  thread.trucestate = TruceStatus.REQUESTED;
+};

--- a/server/src/services/mail/handleTruceResponse.ts
+++ b/server/src/services/mail/handleTruceResponse.ts
@@ -1,0 +1,41 @@
+import { TruceStatus } from "../../enums/TruceStatus.js";
+import { Truce } from "../../models/truce.model.js";
+import type { Thread } from "../../models/thread.model.js";
+import { postgres } from "../../server.js";
+import { getCurrentDateTime } from "../../utils/getCurrentDateTime.js";
+import { mailboxErr, permissionErr } from "../../errors/errors.js";
+import { TRUCE_DURATION } from "../../controllers/mail/requestTruce.js";
+
+type TruceResponse = TruceStatus.ACCEPTED | TruceStatus.REJECTED;
+
+/**
+ * Accepts or rejects a pending truce request on behalf of the recipient.
+ *
+ * - Validates the thread has a linked truce
+ * - Validates the truce is still in REQUESTED state
+ * - Validates the caller is the truce recipient (not the initiator)
+ * - On accept: sets status to ACCEPTED and calculates expiry
+ * - On reject: sets status to REJECTED
+ *
+ * @param userid - The authenticated user's ID
+ * @param thread - The mailbox thread linked to the truce
+ * @param status - TruceStatus.ACCEPTED or TruceStatus.REJECTED
+ */
+export const handleTruceResponse = async (userid: number, thread: Thread, status: TruceResponse) => {
+  if (!thread.truce_id) throw mailboxErr();
+
+  const truce = await postgres.em.findOne(Truce, { id: thread.truce_id });
+
+  if (!truce || truce.status !== TruceStatus.REQUESTED) throw mailboxErr();
+  
+  if (truce.recipient_userid !== userid) throw permissionErr();
+
+  truce.status = status;
+  thread.trucestate = status;
+
+  if (status === TruceStatus.ACCEPTED) {
+    truce.expires_at = getCurrentDateTime() + TRUCE_DURATION;
+  }
+
+  postgres.em.persist(truce);
+};

--- a/server/src/services/mail/isTruceActive.ts
+++ b/server/src/services/mail/isTruceActive.ts
@@ -1,0 +1,29 @@
+import { TruceStatus } from "../../enums/TruceStatus.js";
+import { Truce } from "../../models/truce.model.js";
+import { postgres } from "../../server.js";
+import { getCurrentDateTime } from "../../utils/getCurrentDateTime.js";
+
+/**
+ * Returns true if an accepted, non-expired truce exists between the two users.
+ *
+ * @param userId - One party in the truce
+ * @param targetId - The other party
+ */
+export const isTruceActive = async (userId: number,targetId: number) => {
+  const truce = await postgres.em.findOne(Truce, {
+    $and: [
+      {
+        $or: [
+          { initiator_userid: userId, recipient_userid: targetId },
+          { initiator_userid: targetId, recipient_userid: userId },
+        ],
+      },
+      {
+        status: TruceStatus.ACCEPTED,
+        expires_at: { $gt: getCurrentDateTime() },
+      },
+    ],
+  });
+
+  return truce !== null;
+};

--- a/server/src/services/maproom/getTruces.ts
+++ b/server/src/services/maproom/getTruces.ts
@@ -1,0 +1,53 @@
+import { TruceStatus } from "../../enums/TruceStatus.js";
+import { Truce } from "../../models/truce.model.js";
+import { postgres } from "../../server.js";
+import { getCurrentDateTime } from "../../utils/getCurrentDateTime.js";
+
+export interface TruceInfo {
+  trucestate: TruceStatus;
+  expires_at?: number;
+}
+
+export type Truces = Map<number, TruceInfo>;
+
+/**
+ * Batch-loads active or pending truces between the current user and a list of cell owners.
+ *
+ * Returns a map keyed by the other party's userid for O(1) lookup per cell.
+ *
+ * @param currentUserId - The authenticated user's ID
+ * @param ownerIds - The cell owner userids to check against
+ */
+export const getTruces = async (currentUserId: number | undefined, ownerIds: number[]): Promise<Truces> => {
+  if (currentUserId === undefined || !ownerIds.length) return new Map();
+
+  const activeTruces: Truces = new Map();
+
+  const now = getCurrentDateTime();
+
+  const truces = await postgres.em.find(Truce, {
+    $and: [
+      {
+        $or: [
+          { initiator_userid: currentUserId, recipient_userid: { $in: ownerIds } },
+          { recipient_userid: currentUserId, initiator_userid: { $in: ownerIds } },
+        ],
+      },
+      {
+        $or: [
+          { status: TruceStatus.REQUESTED },
+          { status: TruceStatus.ACCEPTED, expires_at: { $gt: now } },
+        ],
+      },
+    ],
+  });
+
+  for (const truce of truces) {
+    const isInitiator = truce.initiator_userid === currentUserId;
+    const targetUserId = isInitiator ? truce.recipient_userid : truce.initiator_userid;
+
+    activeTruces.set(targetUserId, { trucestate: truce.status, expires_at: truce.expires_at });
+  }
+
+  return activeTruces;
+};

--- a/server/src/services/maproom/updateNeighbourData.ts
+++ b/server/src/services/maproom/updateNeighbourData.ts
@@ -1,8 +1,10 @@
 import { Save } from "../../models/save.model.js";
 import { postgres } from "../../server.js";
 import { AttackPermission } from "../../enums/MapRoom.js";
+import { TruceStatus } from "../../enums/TruceStatus.js";
 import { getCurrentDateTime } from "../../utils/getCurrentDateTime.js";
 import { getLastSeen } from "./getLastSeen.js";
+import { getTruces } from "./getTruces.js";
 import { isAttackActive } from "../base/isAttackActive.js";
 import { calculateBaseLevel } from "../base/calculateBaseLevel.js";
 import type { NeighbourData } from "../../types/NeighbourData.js";
@@ -34,12 +36,12 @@ const NEIGHBOUR_SAVE_FIELDS = [
  * @param {Base.MAIN | Base.INFERNO} baseType - Which save type to query for live updates
  * @returns {Promise<NeighbourData[]>} - Updated neighbour data with current attack permissions
  */
-export const updateNeighbourData = async (cachedNeighbours: NeighbourData[], baseType: Base): Promise<NeighbourData[]> => {
+export const updateNeighbourData = async (cachedNeighbours: NeighbourData[], baseType: Base, currentUserId?: number): Promise<NeighbourData[]> => {
   if (!cachedNeighbours.length) return cachedNeighbours;
 
   const userIds = cachedNeighbours.map((neighbour) => neighbour.userid);
 
-  const [neighbourSaves, lastSeens] = await Promise.all([
+  const [neighbourSaves, lastSeens, truces] = await Promise.all([
     postgres.em.find(
       Save,
       { type: baseType, userid: { $in: userIds } },
@@ -47,6 +49,7 @@ export const updateNeighbourData = async (cachedNeighbours: NeighbourData[], bas
     ) as unknown as Promise<Save[]>,
 
     getLastSeen(userIds, baseType),
+    getTruces(currentUserId, userIds),
   ]);
 
   const saves = new Map<number, Save>();
@@ -93,6 +96,18 @@ export const updateNeighbourData = async (cachedNeighbours: NeighbourData[], bas
 
     neighbour.level = calculateBaseLevel(neighbourSave.points, neighbourSave.basevalue);
     neighbour.saved = lastSeens.get(neighbour.userid) ?? 0;
+
+    const truce = truces.get(neighbour.userid);
+
+    if (!truce) return [neighbour];
+
+    neighbour.trucestate = truce.trucestate;
+    
+    if (truce.expires_at) neighbour.truceexpire = truce.expires_at - currentTime;
+    
+    if (truce.trucestate === TruceStatus.ACCEPTED) {
+      neighbour.attackpermitted = AttackPermission.TRUCE_ACTIVE;
+    }
 
     return [neighbour];
   });

--- a/server/src/types/koa.ts
+++ b/server/src/types/koa.ts
@@ -1,8 +1,10 @@
 import type { User } from "../models/user.model.js";
+import type { Truces } from "../services/maproom/getTruces.js";
 
 declare module "koa" {
   interface DefaultState {
     lastSeen: Map<number, number>;
+    truces: Truces;
   }
 
   interface DefaultContext {


### PR DESCRIPTION
## Overview

Players can request a truce with any other player via the mailbox. If accepted, both parties are protected from attacking each other for **14 days**. The truce is enforced both server-side (attack is rejected) and client-side (UI shows a truce indicator and disables the attack button).

## How It Works

### Requesting a Truce

A player sends a truce request from another player's base popup. This hits `POST /mail/requestTruce` which:

- Resolves the target player from the provided `baseid`
- Guards against self-truces, duplicate pending requests, and already-active truces
- Creates a `Truce` record (status: `requested`) in the database
- Creates a mailbox thread between the two players with the request message

### Accepting or Rejecting

The recipient responds via the mailbox. On accept, the truce status is set to `accepted` and `expires_at` is stamped as `now + 14 days`. On reject, the status is set to `rejected` and no expiry is set. Both outcomes update the thread's `trucestate` so the mailbox UI reflects the outcome.

### Enforcement

**Server-side:** `baseModeAttack` calls `isTruceActive(attacker, defender)` before allowing any attack. If an accepted, non-expired truce exists between the two players, the request is rejected with an error.

**Client-side:** Each map room receives truce data in its cell/neighbour response and surfaces it differently:

| Map Room | Field | Format | Client Behaviour |
|---|---|---|---|
| MR1 (neighbour list) | `trucestate` + `truceexpire` | status string + remaining seconds | Shows "Truce Active"/"Truce Requested" label and countdown timer; `attackpermitted = 9` disables the attack button |
| MR2 (`maproom_advanced`) | `t` | absolute Unix timestamp | Shows truce icon on cell; attack popup displays truce message and blocks attack |
| MR3 (`maproom3`) | `t` | `1` or `0` (boolean) | Truce icon visible on cell |

## Database

Two migrations:

- `20260427_CreateTruceTable` — new `truce` table with `initiator_userid`, `recipient_userid`, `status`, `expires_at`, and indexed on `(initiator_userid, status)` / `(recipient_userid, status)`
- `20260427_AddTruceFieldsToThread` — adds `truce_id` (FK to `truce`) and `trucestate` to the `thread` table so the mailbox can display request/accept/reject state