### PR TITLE
Feature: add new route for mr2 viewer

### DIFF
--- a/server/src/app.routes.ts
+++ b/server/src/app.routes.ts
@@ -26,6 +26,7 @@ import { infernoMonsters } from "./controllers/inferno/infernoMonsters.js";
 import { getNeighbours } from "./controllers/maproom/getNeighbours.js";
 
 import { getArea } from "./controllers/maproom/v2/getArea.js";
+import { getMapRoomCellsV2ForViewer } from "./controllers/maproom/v2/getCells.js";
 import { takeoverCell } from "./controllers/maproom/v2/takeoverCell.js";
 import { transferMonsters } from "./controllers/maproom/v2/transferMonsters.js";
 import { saveBookmarks } from "./controllers/maproom/v2/saveBookmarks.js";
@@ -90,7 +91,8 @@ router.post("/api/:apiVersion/bm/neighbours/get", apiVersion, verifyUserAuth, lo
 /**  ────────────────────────────────────────────────
 * 📦 Map Room 2
 * ──────────────────────────────────────────────── */
-router.post("/worldmapv2/getarea", verifyUserAuth, verifyAccountStatus, logRequest, getArea);
+router.post("/worldmapv2/getarea",   verifyUserAuth, verifyAccountStatus, logRequest, getArea);
+router.post("/worldmapv2/getcellsforviewer", verifyUserAuth, verifyAccountStatus, logRequest, getMapRoomCellsV2ForViewer);
 router.post("/worldmapv2/setmapversion", verifyUserAuth, logRequest, setMapVersion);
 router.post("/worldmapv2/takeoverCell", verifyUserAuth, verifyAccountStatus, logRequest, takeoverCell);
 router.post("/worldmapv2/transferassets", verifyUserAuth, verifyAccountStatus, logRequest, transferMonsters);

--- a/server/src/app.routes.ts
+++ b/server/src/app.routes.ts
@@ -3,7 +3,7 @@ import Router from "@koa/router";
 import { logRequest } from "./middleware/logRequest.js";
 import { apiVersion } from "./middleware/apiVersioning.js";
 import { verifyUserAuth, verifyAccountStatus } from "./middleware/auth.js";
-import { getCellsLimiter, registerLimiter } from "./middleware/rateLimiters.js";
+import { getCellsLimiter, getMR2ViewerCellsLimiter, registerLimiter } from "./middleware/rateLimiters.js";
 import { Status } from "./enums/StatusCodes.js";
 
 import { init } from "./controllers/init.js";
@@ -92,7 +92,7 @@ router.post("/api/:apiVersion/bm/neighbours/get", apiVersion, verifyUserAuth, lo
 * 📦 Map Room 2
 * ──────────────────────────────────────────────── */
 router.post("/worldmapv2/getarea",   verifyUserAuth, verifyAccountStatus, logRequest, getArea);
-router.post("/worldmapv2/getcellsforviewer", verifyUserAuth, verifyAccountStatus, logRequest, getMapRoomCellsV2ForViewer);
+router.post("/worldmapv2/getcellsforviewer", verifyUserAuth, verifyAccountStatus, getMR2ViewerCellsLimiter, logRequest, getMapRoomCellsV2ForViewer);
 router.post("/worldmapv2/setmapversion", verifyUserAuth, logRequest, setMapVersion);
 router.post("/worldmapv2/takeoverCell", verifyUserAuth, verifyAccountStatus, logRequest, takeoverCell);
 router.post("/worldmapv2/transferassets", verifyUserAuth, verifyAccountStatus, logRequest, transferMonsters);

--- a/server/src/controllers/maproom/v2/getCells.ts
+++ b/server/src/controllers/maproom/v2/getCells.ts
@@ -8,9 +8,7 @@ import { MapRoom2, MapRoomVersion } from "../../../enums/MapRoom.js";
 import { Status } from "../../../enums/StatusCodes.js";
 import { createCellData } from "../../../services/maproom/v2/createCellData.js";
 import { generateNoise, getTerrainHeight } from "../../../services/maproom/v2/generateMap.js";
-import { getLastSeen } from "../../../services/maproom/getLastSeen.js";
 import { getTruces } from "../../../services/maproom/getTruces.js";
-import { BaseType } from "../../../enums/Base.js";
 import { mapRoomDisabledErr } from "../../../errors/errors.js";
 import { devConfig } from "../../../config/GameConfig.js";
 
@@ -111,16 +109,18 @@ export const getMapRoomCellsV2ForViewer: KoaController = async (ctx) => {
   const dbByCoord = new Map(dbCells.map((c) => [`${c.x},${c.y}`, c]));
   const ownerIds  = [...new Set(dbCells.map((c) => c.uid).filter(Boolean))] as number[];
 
-  const [ownersList, lastSeen, truces] = await Promise.all([
+  const [ownersList, truces] = await Promise.all([
     postgres.em.find(User, { userid: { $in: ownerIds } }, {
       populate: ["save"],
       fields: CELL_OWNER_FIELDS,
     }),
-    getLastSeen(ownerIds, BaseType.MAIN),
     getTruces(user.userid, ownerIds),
   ]);
 
-  ctx.state.lastSeen = lastSeen;
+  // Online presence is not needed for a read-only viewer — an empty map
+  // tells userCell no one is currently online, which is an acceptable
+  // approximation for strategic map browsing.
+  ctx.state.lastSeen = new Map();
   ctx.state.truces   = truces;
 
   const cellOwners = new Map<number, User>(

--- a/server/src/controllers/maproom/v2/getCells.ts
+++ b/server/src/controllers/maproom/v2/getCells.ts
@@ -117,9 +117,6 @@ export const getMapRoomCellsV2ForViewer: KoaController = async (ctx) => {
     getTruces(user.userid, ownerIds),
   ]);
 
-  // Online presence is not needed for a read-only viewer — an empty map
-  // tells userCell no one is currently online, which is an acceptable
-  // approximation for strategic map browsing.
   ctx.state.lastSeen = new Map();
   ctx.state.truces   = truces;
 

--- a/server/src/controllers/maproom/v2/getCells.ts
+++ b/server/src/controllers/maproom/v2/getCells.ts
@@ -1,0 +1,149 @@
+import { z } from "zod";
+
+import type { KoaController } from "../../../utils/KoaController.js";
+import { User } from "../../../models/user.model.js";
+import { WorldMapCell } from "../../../models/worldmapcell.model.js";
+import { postgres } from "../../../server.js";
+import { MapRoom2, MapRoomVersion } from "../../../enums/MapRoom.js";
+import { Status } from "../../../enums/StatusCodes.js";
+import { createCellData } from "../../../services/maproom/v2/createCellData.js";
+import { generateNoise, getTerrainHeight } from "../../../services/maproom/v2/generateMap.js";
+import { getLastSeen } from "../../../services/maproom/getLastSeen.js";
+import { getTruces } from "../../../services/maproom/getTruces.js";
+import { BaseType } from "../../../enums/Base.js";
+import { mapRoomDisabledErr } from "../../../errors/errors.js";
+import { devConfig } from "../../../config/GameConfig.js";
+
+const MAX_CELLS_PER_REQUEST = 20_000;
+
+const schema = z.object({
+  cellids: z.string().transform((s) => JSON.parse(s) as number[]),
+});
+
+const CELL_OWNER_FIELDS = [
+  "userid",
+  "username",
+  "pic_square",
+  "save.points",
+  "save.basevalue",
+] as const;
+
+const CELL_SAVE_FIELDS = [
+  "*",
+  "save.basesaveid",
+  "save.locked",
+  "save.flinger",
+  "save.protected",
+  "save.resources",
+  "save.damage",
+  "save.destroyed",
+  "save.points",
+  "save.basevalue",
+  "save.attackid",
+  "save.attacks",
+] as const;
+
+/**
+ * Bulk cell fetch for the MR2 map viewer.
+ *
+ * Accepts up to 20 000 1-based cell IDs (formula: y * 800 + x + 1), resolves
+ * claimed cells from the DB in a single bounding-box query, and generates
+ * terrain via Perlin noise for unclaimed cells.  Returns a flat celldata array
+ * each element of which includes the (x, y) coordinates alongside the normal
+ * cell fields so the viewer can ingest them without the old nested data[x][y]
+ * structure.
+ *
+ * Viewer sends batches sorted from the centre of the map outward, so each
+ * batch is roughly circular and the bounding box stays compact.
+ */
+export const getMapRoomCellsV2ForViewer: KoaController = async (ctx) => {
+  if (!devConfig.maproom) throw mapRoomDisabledErr();
+
+  const { cellids } = schema.parse(ctx.request.body);
+
+  if (cellids.length > MAX_CELLS_PER_REQUEST) {
+    ctx.status = Status.BAD_REQUEST;
+    ctx.body = { error: `Maximum ${MAX_CELLS_PER_REQUEST} cells per request.` };
+    return;
+  }
+
+  const user: User = ctx.authUser;
+  await postgres.em.populate(user, ["save"]);
+
+  const worldid = user.save?.worldid;
+
+  if (!worldid || !cellids.length) {
+    ctx.status = Status.OK;
+    ctx.body = { celldata: [] };
+    return;
+  }
+
+  // Convert 1-based cell IDs → (x, y).  id = y * WIDTH + x + 1.
+  const coords = cellids.map((id) => {
+    const zero = id - 1;
+    return { x: zero % MapRoom2.WIDTH, y: Math.floor(zero / MapRoom2.WIDTH) };
+  });
+
+  // Bounding box for the DB query.  Because the viewer sends batches sorted
+  // from centre outward each batch is approximately circular so the bounding
+  // box is compact rather than spanning the whole map.
+  let minX = MapRoom2.WIDTH,  maxX = 0;
+  let minY = MapRoom2.HEIGHT, maxY = 0;
+
+  for (const { x, y } of coords) {
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+
+  const dbCells = await postgres.em.find(
+    WorldMapCell,
+    {
+      world: worldid,
+      map_version: MapRoomVersion.V2,
+      x: { $gte: minX, $lte: maxX },
+      y: { $gte: minY, $lte: maxY },
+    },
+    { populate: ["save"], fields: CELL_SAVE_FIELDS },
+  );
+
+  const dbByCoord = new Map(dbCells.map((c) => [`${c.x},${c.y}`, c]));
+  const ownerIds  = [...new Set(dbCells.map((c) => c.uid).filter(Boolean))] as number[];
+
+  const [ownersList, lastSeen, truces] = await Promise.all([
+    postgres.em.find(User, { userid: { $in: ownerIds } }, {
+      populate: ["save"],
+      fields: CELL_OWNER_FIELDS,
+    }),
+    getLastSeen(ownerIds, BaseType.MAIN),
+    getTruces(user.userid, ownerIds),
+  ]);
+
+  ctx.state.lastSeen = lastSeen;
+  ctx.state.truces   = truces;
+
+  const cellOwners = new Map<number, User>(
+    (ownersList as unknown as User[]).map((u) => [u.userid, u]),
+  );
+
+  const noise    = generateNoise(worldid);
+  const celldata = [];
+
+  for (const { x, y } of coords) {
+    const db = dbByCoord.get(`${x},${y}`);
+
+    let cell: WorldMapCell;
+    if (db) {
+      cell = db as unknown as WorldMapCell;
+    } else {
+      cell = new WorldMapCell(undefined, x, y, getTerrainHeight(noise, x, y));
+    }
+
+    const data = await createCellData(cell, worldid, ctx, cellOwners);
+    if (data) celldata.push({ x, y, ...data });
+  }
+
+  ctx.status = Status.OK;
+  ctx.body = { celldata };
+};

--- a/server/src/middleware/rateLimiters.ts
+++ b/server/src/middleware/rateLimiters.ts
@@ -18,6 +18,22 @@ export const getCellsLimiter = RateLimit.middleware({
 });
 
 /**
+ * Rate limit for the MR2 map viewer bulk cell endpoint.
+ * A full map load is ~32 batches, so 60/min allows nearly two full loads per
+ * minute while blocking someone who is hammering the refresh button.
+ */
+export const getMR2ViewerCellsLimiter = RateLimit.middleware({
+  interval: { min: 1 },
+  max: 60,
+  prefixKey: "getcellsforviewer",
+  keyGenerator: async (ctx: Context) => String(ctx.authUser?.userid ?? ctx.ip),
+  handler: async (ctx: Context) => {
+    ctx.status = Status.TOO_MANY_REQUESTS;
+    ctx.body = { error: "Too many viewer cell requests. Please slow down." };
+  },
+});
+
+/**
  * Rate limit for user registration - 3 requests per hour in prod, per minute in dev.
  */
 export const registerLimiter = RateLimit.middleware({


### PR DESCRIPTION
  Server — new file controllers/maproom/v2/getCells.ts
  - Endpoint: POST /worldmapv2/getcellsforviewer — name makes clear this isn't the game client
  - Accepts up to 20,000 1-based cell IDs per request → 32 batches for the full map vs 6,400 before
  - Single bounding-box DB query per batch (efficient because the viewer sends cells sorted from centre outward, so each batch is roughly circular and the box stays compact)

Map is loaded for viewer in 32 requests. 

