### PR TITLE
Fix monsters phasing through blocks on expanded yards

### DIFF
--- a/client/scripts/com/monsters/pathing/PATHING.as
+++ b/client/scripts/com/monsters/pathing/PATHING.as
@@ -33,9 +33,9 @@ package com.monsters.pathing
 
       private static const cPI180:Number = PI / 180;
 
-      private static var _gridWidth:int = 164;
+      private static var _gridWidth:int = 260;
 
-      private static var _gridHeight:int = 132;
+      private static var _gridHeight:int = 260;
 
       private static var _floods:Object = {};
 
@@ -47,13 +47,39 @@ package com.monsters.pathing
 
       private static var _resetRequested:Boolean = false;
 
+      private static var _dirtyMinX:int = int.MAX_VALUE;
+
+      private static var _dirtyMinY:int = int.MAX_VALUE;
+
+      private static var _dirtyMaxX:int = int.MIN_VALUE;
+
+      private static var _dirtyMaxY:int = int.MIN_VALUE;
+
       public function PATHING()
       {
          super();
       }
 
+      /**
+       * Empties the dirty region: the bounding box of cells Cost() has raised above the base
+       * cost of 10. Tracking it lets Tick() reset just those cells rather than all
+       * _gridWidth * _gridHeight of them on every ResetCosts.
+       *
+       * Cost() is the only writer of PATHINGobject.cost, and the box only grows around cells it
+       * actually wrote, so it cannot under cover and strand a raised cost. Empty is min > max,
+       * which makes the reset loops skip themselves.
+       */
+      private static function ClearDirtyRegion():void
+      {
+         _dirtyMinX = int.MAX_VALUE;
+         _dirtyMinY = int.MAX_VALUE;
+         _dirtyMaxX = int.MIN_VALUE;
+         _dirtyMaxY = int.MIN_VALUE;
+      }
+
       public static function Setup():void
       {
+         ClearDirtyRegion();
          for (var widthIdx:int = 0; widthIdx < _gridWidth; widthIdx++)
          {
             for (var heightIdx:int = 0; heightIdx < _gridHeight; heightIdx++)
@@ -86,10 +112,12 @@ package com.monsters.pathing
                if (_costs[gridKey])
                {
                   _costs[gridKey].cost += regionCost;
-                  if (_costs[gridKey].cost < 2)
-                  {
-                     _costs[gridKey].cost = 2;
-                  }
+                  if (_costs[gridKey].cost < 2) _costs[gridKey].cost = 2;
+
+                  if (xIdx < _dirtyMinX) _dirtyMinX = xIdx;
+                  if (xIdx > _dirtyMaxX) _dirtyMaxX = xIdx;
+                  if (yIdx < _dirtyMinY) _dirtyMinY = yIdx;
+                  if (yIdx > _dirtyMaxY) _dirtyMaxY = yIdx;
                }
             }
          }
@@ -127,9 +155,15 @@ package com.monsters.pathing
          {
             _resetRequested = false;
             Clear();
-            for (var widthIdx:int = 0; widthIdx < _gridWidth; widthIdx++)
+            var resetMinX:int = _dirtyMinX;
+            var resetMinY:int = _dirtyMinY;
+            var resetMaxX:int = _dirtyMaxX;
+            var resetMaxY:int = _dirtyMaxY;
+            ClearDirtyRegion();
+
+            for (var widthIdx:int = resetMinX; widthIdx <= resetMaxX; widthIdx++)
             {
-               for (var heightIdx:int = 0; heightIdx < _gridHeight; heightIdx++)
+               for (var heightIdx:int = resetMinY; heightIdx <= resetMaxY; heightIdx++)
                {
                   _costs[widthIdx * 1000 + heightIdx].cost = 10;
                }
@@ -185,9 +219,12 @@ package com.monsters.pathing
          if (!_costs[gridKeyStart])
          {
             // Starting point is out of bounds, nudge it towards the target to move it in bounds.
+            // Step one cell at a time instead of 5, the path is built from wherever this lands and the monster
+            // walks to it in a straight line with no wall checks, so overshooting the boundary
+            // lets it cut through anything in between.
             var angle:Number = 90 - Math.atan2(gridTargetRect.y - gridStart.y, gridTargetRect.x - gridStart.x) * 57.2957795;
-            var moveX:Number = Math.sin(angle * 0.0174532925) * 5;
-            var moveY:Number = Math.cos(angle * 0.0174532925) * 5;
+            var moveX:Number = Math.sin(angle * 0.0174532925);
+            var moveY:Number = Math.cos(angle * 0.0174532925);
             var attempts:int = 0;
             while (!_costs[gridKeyStart] && attempts < 2000)
             {
@@ -607,6 +644,7 @@ package com.monsters.pathing
          }
          _costs = {};
          _floods = {};
+         ClearDirtyRegion();
       }
 
       public static function LineOfSight(startX:int, startY:int, targetX:int, targetY:int, targetBuilding:BFOUNDATION = null, includeAllBuildings:Boolean = false):Boolean


### PR DESCRIPTION
## Problem

Attacking monsters walked straight through block walls instead of pathing around them or
attacking them. It was intermittent — typically a couple of monsters out of a wave, always the
ones entering on a screen diagonal — and got noticeably worse the more More Yardage (`ENL`)
expansions a yard had.

## Cause

`PATHING`'s grid was sized to the yard, but it needs to cover everywhere a monster can stand.

Attackers spawn on a ring well outside the yard (`WMATTACK.SpawnA` / `SpawnB`), reaching roughly
1245 units out on a fully expanded yard. The grid was `164 x 132` cells, covering `±820 / ±660`
— smaller than a maxed yard, and short on the vertical axis, which is the one that renders as a
diagonal on screen.

Anything outside the grid has no `_costs` entry, and every wall check in `PATHING` is guarded by
one. So `GetPathB` fell back to nudging the path start inwards until it landed in bounds — which
on a large yard meant *inside the walls* — and the monster then walked a straight, unchecked line
to that point.

## Changes

All in `client/scripts/com/monsters/pathing/PATHING.as`:

- **Grid `164 x 132` → `260 x 260`.** This is the fix. It matches `GRID`'s own `±1300` hard
  limit, so every position a monster can legally occupy now resolves to a real cell.
- **Out-of-bounds nudge steps 1 cell instead of 5.** Shouldn't ever run now, kept as a guard
  against the same failure mode.
- **Cost resets bounded to a dirty region.** The bigger grid would otherwise make `ResetCosts`
  (which fires on every building destroyed mid-attack) ~3x more expensive. Tracking which cells
  `Cost()` actually raised means the reset now touches ~8k cells on a default yard instead of
  67.6k — cheaper than before this PR.

## Testing

Repeated waves via the Monster Baiter on a fully expanded yard, against a solid side-by-side
block wall. Before: monsters entering on the diagonal phased through. After: all monsters path
around or attack the wall.
