### PR TITLE
Username changes on a 6-month cooldown

### DIFF
--- a/server/src/app.routes.ts
+++ b/server/src/app.routes.ts
@@ -3,7 +3,7 @@ import Router from "@koa/router";
 import { logRequest } from "./middleware/logRequest.js";
 import { apiVersion } from "./middleware/apiVersioning.js";
 import { verifyUserAuth, verifyAccountStatus } from "./middleware/auth.js";
-import { getCellsLimiter, loginLimiter, registerLimiter } from "./middleware/rateLimiters.js";
+import { changeUsernameLimiter, getCellsLimiter, loginLimiter, registerLimiter } from "./middleware/rateLimiters.js";
 import { Status } from "./enums/StatusCodes.js";
 
 import { init } from "./controllers/init.js";
@@ -13,6 +13,8 @@ import { login } from "./controllers/auth/login.js";
 import { register } from "./controllers/auth/register.js";
 import { forgotPassword } from "./controllers/auth/forgotPassword.js";
 import { resetPassword } from "./controllers/auth/resetPassword.js";
+import { changeUsername } from "./controllers/auth/changeUsername.js";
+import { getAccount } from "./controllers/auth/getAccount.js";
 
 import { baseLoad } from "./controllers/base/load/baseLoad.js";
 import { baseSave } from "./controllers/base/save/baseSave.js";
@@ -68,6 +70,8 @@ router.post("/api/:apiVersion/player/register", apiVersion, registerLimiter, log
 router.post("/api/:apiVersion/player/forgotPassword", apiVersion, forgotPassword);
 router.post("/api/:apiVersion/player/reset-password", resetPassword);
 router.get("/api/:apiVersion/supportedLangs", apiVersion, logRequest, supportedLangs);
+router.get("/api/:apiVersion/player/account", apiVersion, verifyUserAuth, getAccount);
+router.post("/api/:apiVersion/player/changeusername", apiVersion, verifyUserAuth, changeUsernameLimiter, logRequest, changeUsername);
 
 /**  ────────────────────────────────────────────────
 * 📦 Base

--- a/server/src/controllers/auth/changeUsername.ts
+++ b/server/src/controllers/auth/changeUsername.ts
@@ -1,0 +1,34 @@
+import type { KoaController } from "../../utils/KoaController.js";
+import { User } from "../../models/user.model.js";
+import { Status } from "../../enums/StatusCodes.js";
+import { ChangeUsernameSchema } from "../../schemas/AuthSchemas.js";
+import { usernameCooldownErr } from "../../errors/errors.js";
+import { getUsernameCooldown, renameUser } from "../../services/user/renameUser.js";
+
+/**
+ * Controller to change the authenticated user's username.
+ *
+ * Enforces the rename cooldown, then hands off to the rename service, which owns every
+ * write involved. A running game client keeps the old name in memory until it is restarted.
+ *
+ * @param {Context} ctx - The Koa context object.
+ * @returns {Promise<void>} - A promise that resolves when the controller is complete.
+ * @throws {ClientSafeError} If the cooldown has not elapsed or the username is taken.
+ */
+export const changeUsername: KoaController = async (ctx) => {
+  const user: User = ctx.authUser;
+  const { username } = ChangeUsernameSchema.parse(ctx.request.body);
+
+  const cooldown = getUsernameCooldown(user);
+
+  if (cooldown) throw usernameCooldownErr(cooldown);
+
+  const nextChangeAt = await renameUser(user, username);
+
+  ctx.status = Status.OK;
+  ctx.body = {
+    error: 0,
+    username: user.username,
+    nextChangeAt: nextChangeAt.toISOString(),
+  };
+};

--- a/server/src/controllers/auth/getAccount.ts
+++ b/server/src/controllers/auth/getAccount.ts
@@ -1,0 +1,28 @@
+import type { KoaController } from "../../utils/KoaController.js";
+import { User } from "../../models/user.model.js";
+import { Status } from "../../enums/StatusCodes.js";
+import { getUsernameCooldown } from "../../services/user/renameUser.js";
+
+/**
+ * Controller to return the authenticated user's account details.
+ *
+ * @param {Context} ctx - The Koa context object.
+ * @returns {Promise<void>} - A promise that resolves when the controller is complete.
+ */
+export const getAccount: KoaController = async (ctx) => {
+  const user: User = ctx.authUser;
+  const cooldown = getUsernameCooldown(user);
+
+  const userDetails = {
+    userId: user.userid,
+    username: user.username,
+    email: user.email,
+    pic_square: user.pic_square,
+    discord_verified: user.discord_verified,
+    canChangeUsername: !cooldown,
+    nextChangeAt: cooldown?.toISOString() ?? null,
+  };
+
+  ctx.status = Status.OK;
+  ctx.body = { error: 0, ...userDetails };
+};

--- a/server/src/database/migrations/20260802_AddUsernameChangedAtToUser.ts
+++ b/server/src/database/migrations/20260802_AddUsernameChangedAtToUser.ts
@@ -1,0 +1,16 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * Adds user.username_changed_at to drive the rename cooldown.
+ *
+ * Null means the account has never been renamed, which the cooldown check treats as
+ * immediately eligible. Existing accounts are backfilled as null for that reason.
+ */
+export class AddUsernameChangedAtToUser extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "bym"."user"
+        ADD COLUMN IF NOT EXISTS "username_changed_at" timestamptz NULL;
+    `);
+  }
+}

--- a/server/src/errors/errors.ts
+++ b/server/src/errors/errors.ts
@@ -47,6 +47,14 @@ export const emailUniqueErr = () =>
     isClientFriendly: true,
   });
 
+export const usernameCooldownErr = (nextChangeAt: Date) =>
+  new ClientSafeError({
+    message: `You can only change your username once every 6 months. You can change it again on ${nextChangeAt.toUTCString()}.`,
+    status: Status.CONFLICT,
+    data: { nextChangeAt: nextChangeAt.toISOString() },
+    isClientFriendly: true,
+  });
+
 export const debugClientErr = () =>
   new ClientSafeError({
     message: "Sorry, it appears this cannot be found.",

--- a/server/src/middleware/rateLimiters.ts
+++ b/server/src/middleware/rateLimiters.ts
@@ -34,6 +34,22 @@ export const registerLimiter = RateLimit.middleware({
 });
 
 /**
+ * Rate limit for username changes - 5 requests per hour per user.
+ */
+export const changeUsernameLimiter = RateLimit.middleware({
+  interval: { min: 60 },
+  max: 5,
+  prefixKey: "changeusername",
+  keyGenerator: async (ctx: Context) => String(ctx.authUser?.userid ?? ctx.ip),
+  handler: async (ctx: Context) => {
+    ctx.status = Status.TOO_MANY_REQUESTS;
+    ctx.body = {
+      error: "Too many username change attempts. Please try again later.",
+    };
+  },
+});
+
+/**
  * Rate limit for login - 30 requests per 5 minutes in prod, 30 per minute in dev.
  */
 export const loginLimiter = RateLimit.middleware({

--- a/server/src/models/user.model.ts
+++ b/server/src/models/user.model.ts
@@ -25,6 +25,10 @@ export class User {
   @FrontendKey
   username!: string;
 
+  @FrontendKey
+  @Property({ type: "Date", nullable: true })
+  username_changed_at?: Date | null;
+
   @Property({ type: "boolean", default: false })
   banned: boolean = false;
 

--- a/server/src/schemas/AuthSchemas.ts
+++ b/server/src/schemas/AuthSchemas.ts
@@ -27,6 +27,21 @@ const passwordSchema = z.preprocess(
  */
 const emailSchema = z.email(emailError).trim().toLowerCase();
 
+const usernameCharsetError = "Usernames can only contain letters, numbers and underscores";
+const usernameLengthError = "Usernames must be between 2 and 12 characters";
+
+/**
+ * Schema to validate usernames.
+ * - Must be 2 to 12 characters long.
+ * - Letters, numbers and underscores only.
+ */
+const usernameSchema = z
+  .string()
+  .trim()
+  .min(2, usernameLengthError)
+  .max(12, usernameLengthError)
+  .regex(/^[a-zA-Z0-9_]+$/, usernameCharsetError);
+
 /**
  * Schema to validate user login data.
  * - Email is optional.
@@ -48,10 +63,16 @@ export const UserLoginSchema = z.object({
  * - Password must meet the password schema requirements.
  */
 export const UserRegistrationSchema = z.object({
-  username: z.string().min(2).max(12),
+  username: usernameSchema,
   email: emailSchema,
   password: passwordSchema,
 });
+
+/**
+ * Schema to validate a username change request.
+ * - Username must meet the username schema requirements.
+ */
+export const ChangeUsernameSchema = z.object({ username: usernameSchema });
 
 /**
  * Schema to validate password reset data.

--- a/server/src/services/maproom/updateNeighbourData.ts
+++ b/server/src/services/maproom/updateNeighbourData.ts
@@ -1,4 +1,5 @@
 import { Save } from "../../models/save.model.js";
+import { User } from "../../models/user.model.js";
 import { postgres } from "../../server.js";
 import { AttackPermission, MapRoomVersion } from "../../enums/MapRoom.js";
 import { TruceStatus } from "../../enums/TruceStatus.js";
@@ -30,6 +31,11 @@ const NEIGHBOUR_SAVE_FIELDS = [
 ] as const;
 
 /**
+ * User fields fetched to refresh the display details cached on each neighbour.
+ */
+const NEIGHBOUR_USER_FIELDS = ["userid", "username", "pic_square"] as const;
+
+/**
  * Updates dynamic fields on cached neighbour data with current save state.
  * Runs on every getNeighbours call to keep attack permissions and level up to date.
  * Filters out neighbours whose saves no longer exist in the database,
@@ -45,7 +51,13 @@ export const updateNeighbourData = async (cachedNeighbours: NeighbourData[], bas
   const userIds = cachedNeighbours.map((neighbour) => neighbour.userid);
   const mr1Filter = baseType === BaseType.MAIN ? { mapversion: MapRoomVersion.V1 } : {};
 
-  const [neighbourSaves, lastSeens, truces] = await Promise.all([
+  const [neighbourUsers, neighbourSaves, lastSeens, truces] = await Promise.all([
+    postgres.em.find(
+      User,
+      { userid: { $in: userIds } },
+      { fields: NEIGHBOUR_USER_FIELDS }
+    ) as unknown as Promise<User[]>,
+    
     postgres.em.find(
       Save,
       { type: baseType, userid: { $in: userIds }, ...mr1Filter },
@@ -53,11 +65,15 @@ export const updateNeighbourData = async (cachedNeighbours: NeighbourData[], bas
     ) as unknown as Promise<Save[]>,
 
     getLastSeen(userIds, baseType),
+
     getTruces(currentUserId, userIds),
   ]);
 
   const saves = new Map<number, Save>();
   neighbourSaves.forEach((save) => saves.set(save.userid, save));
+
+  const owners = new Map<number, User>();
+  neighbourUsers.forEach((owner) => owners.set(owner.userid, owner));
 
   const currentTime = getCurrentDateTime();
   let needsFlush = false;
@@ -107,6 +123,15 @@ export const updateNeighbourData = async (cachedNeighbours: NeighbourData[], bas
     neighbour.baseid = neighbourSave.baseid;
     neighbour.level = calculateBaseLevel(neighbourSave.points, neighbourSave.basevalue);
     neighbour.saved = lastSeens.get(neighbour.userid) ?? 0;
+
+    const owner = owners.get(neighbour.userid);
+
+    if (owner) {
+      neighbour.username = owner.username;
+      neighbour.basename = owner.username;
+      neighbour.ownerName = owner.username;
+      neighbour.pic = owner.pic_square || "";
+    }
 
     const truce = truces.get(neighbour.userid);
 

--- a/server/src/services/user/renameUser.ts
+++ b/server/src/services/user/renameUser.ts
@@ -1,0 +1,82 @@
+import { UniqueConstraintViolationException } from "@mikro-orm/core";
+
+import { User } from "../../models/user.model.js";
+import { Save } from "../../models/save.model.js";
+import { World } from "../../models/world.model.js";
+import { postgres, redis } from "../../server.js";
+import { usernameUniqueErr } from "../../errors/errors.js";
+
+/** How long a player must wait between username changes. */
+export const USERNAME_CHANGE_COOLDOWN_MONTHS = 6;
+
+/**
+ * When the cooldown started at changedAt expires.
+ *
+ * @param {Date} changedAt - When the rename happened
+ * @returns {Date} The expiry date
+ */
+const cooldownExpiry = (changedAt: Date): Date => {
+  const expiresAt = new Date(changedAt);
+
+  expiresAt.setUTCMonth(expiresAt.getUTCMonth() + USERNAME_CHANGE_COOLDOWN_MONTHS);
+  return expiresAt;
+};
+
+/**
+ * The account's remaining rename cooldown.
+ *
+ * @param {User} user - The account to check
+ * @returns {Date | null} When the cooldown expires, or null if they can rename now
+ */
+export const getUsernameCooldown = (user: User): Date | null => {
+  if (!user.username_changed_at) return null;
+
+  const expiresAt = cooldownExpiry(user.username_changed_at);
+
+  return expiresAt > new Date() ? expiresAt : null;
+};
+
+/**
+ * Renames an account and every copy of the old username the server owns.
+ *
+ * The single writer for username changes, moving user.username, the cooldown stamp,
+ * save.name on every yard they own and any world labelled after them together in
+ * one transaction.
+ *
+ * @param {User} user - The account being renamed, already loaded by the caller
+ * @param {string} username - The validated new username
+ * @returns {Promise<Date>} When the cooldown this rename started expires
+ */
+export const renameUser = async (user: User, username: string): Promise<Date> => {
+  const previousUsername = user.username;
+  const changedAt = new Date();
+
+  let worldsRenamed = 0;
+
+  try {
+    await postgres.em.transactional(async (em) => {
+      const existing = await em.findOne(User, { username });
+
+      if (existing) throw usernameUniqueErr();
+
+      await em.nativeUpdate(User, { userid: user.userid }, { username, username_changed_at: changedAt });
+      await em.nativeUpdate(Save, { saveuserid: user.userid }, { name: username });
+
+      worldsRenamed = await em.nativeUpdate(
+        World,
+        { name: { $in: [previousUsername, `${previousUsername} Server`] } },
+        { name: `${username} Server` }
+      );
+    });
+  } catch (err) {
+    if (err instanceof UniqueConstraintViolationException) throw usernameUniqueErr();
+    throw err;
+  }
+
+  user.username = username;
+  user.username_changed_at = changedAt;
+
+  if (worldsRenamed > 0) await redis.del("availableWorlds");
+
+  return cooldownExpiry(changedAt);
+};


### PR DESCRIPTION
# Username changes

Lets players change their username once every 6 months, from a new Account page in the launcher.

## Server

**New endpoints**

| Route | Purpose |
|---|---|
| `POST /api/:apiVersion/player/changeusername` | Performs the rename |
| `GET /api/:apiVersion/player/account` | Username + rename eligibility for the launcher |

Both sit behind `verifyUserAuth`. The change endpoint is rate limited to 5/hour per user — the 6 month cooldown already caps successful renames, this just stops the endpoint being used to probe which usernames are taken.

**Cooldown** is a single nullable `user.username_changed_at` column. `getUsernameCooldown()` returns the expiry date, or `null` when the player is eligible, so the comparison against the clock lives in one place.

**`renameUser()`** is the single writer. In one transaction it updates:

- `user.username` and the cooldown stamp
- `save.name` on every yard they own — main, inferno and every outpost, keyed on the indexed `saveuserid`
- `world.name`, for any world labelled after them by an MR2 origin-cell takeover

It then clears the `availableWorlds` Redis cache, but only if a world actually changed.

**MR1 / Inferno neighbour lists** cache the username inside a jsonb blob on *other players'* maproom rows, which can't be reached from the renaming user's id, and the cache only rebuilds every 2 weeks. `updateNeighbourData` now refreshes those names from the live user on read instead. This also fixes an existing bug where Discord avatar changes didn't reach neighbour lists either.

**Username validation** moved server-side. `UserRegistrationSchema` previously checked length only; the `^[a-zA-Z0-9_]+$` rule existed just in the launcher, so non-launcher clients could register names the game UI would never allow. Both registration and rename now share one `usernameSchema`.

## Notes

- Renaming does not log you out; the session token is keyed on email.
- A running game client keeps the old name until it's restarted.
- Leaderboards are cached for 2 hours, so they can show the old name for that long. The cache key is per world and map version, so it can't be invalidated for one player without dropping every world's cache and forcing a re-run of an expensive aggregate. Left to expire.