### PR TITLE
Rate limit MR2 getarea, validate coordinates, fix spoofable ctx.ip

### DIFF
--- a/server/src/app.routes.ts
+++ b/server/src/app.routes.ts
@@ -3,7 +3,13 @@ import Router from "@koa/router";
 import { logRequest } from "./middleware/logRequest.js";
 import { apiVersion } from "./middleware/apiVersioning.js";
 import { verifyUserAuth, verifyAccountStatus } from "./middleware/auth.js";
-import { changeUsernameLimiter, getCellsLimiter, loginLimiter, registerLimiter } from "./middleware/rateLimiters.js";
+import {
+  changeUsernameLimiter,
+  getAreaLimiter,
+  getCellsLimiter,
+  loginLimiter,
+  registerLimiter,
+} from "./middleware/rateLimiters.js";
 import { Status } from "./enums/StatusCodes.js";
 
 import { init } from "./controllers/init.js";
@@ -94,7 +100,7 @@ router.post("/api/:apiVersion/bm/neighbours/get", apiVersion, verifyUserAuth, lo
 /**  ────────────────────────────────────────────────
 * 📦 Map Room 2
 * ──────────────────────────────────────────────── */
-router.post("/worldmapv2/getarea", verifyUserAuth, verifyAccountStatus, logRequest, getArea);
+router.post("/worldmapv2/getarea", verifyUserAuth, verifyAccountStatus, getAreaLimiter, logRequest, getArea);
 router.post("/worldmapv2/setmapversion", verifyUserAuth, logRequest, setMapVersion);
 router.post("/worldmapv2/takeoverCell", verifyUserAuth, verifyAccountStatus, logRequest, takeoverCell);
 router.post("/worldmapv2/transferassets", verifyUserAuth, verifyAccountStatus, logRequest, transferMonsters);

--- a/server/src/controllers/maproom/v2/cells/userCell.ts
+++ b/server/src/controllers/maproom/v2/cells/userCell.ts
@@ -71,6 +71,5 @@ export const userCell = async (ctx: Context, cell: WorldMapCell, cellOwners: Map
     lo: locked,
     dm: damage,
     pic_square: cellOwner.pic_square,
-    im: cellOwner.pic_square,
   };
 };

--- a/server/src/controllers/maproom/v2/getArea.ts
+++ b/server/src/controllers/maproom/v2/getArea.ts
@@ -8,7 +8,7 @@ import { devConfig } from "../../../config/GameConfig.js";
 import { Status } from "../../../enums/StatusCodes.js";
 import { createCellData } from "../../../services/maproom/v2/createCellData.js";
 import { generateNoise, getTerrainHeight } from "../../../services/maproom/v2/generateMap.js";
-import { MapRoomVersion } from "../../../enums/MapRoom.js";
+import { MapRoom2, MapRoomVersion } from "../../../enums/MapRoom.js";
 import { getLastSeen } from "../../../services/maproom/getLastSeen.js";
 import { getTruces } from "../../../services/maproom/getTruces.js";
 import { BaseType } from "../../../enums/Base.js";
@@ -18,9 +18,9 @@ import { mapRoomDisabledErr } from "../../../errors/errors.js";
  * Schema for validating the request body when getting area data.
  */
 const getAreaSchema = z.object({
-  x: z.string().transform(x => parseInt(x, 10)),
-  y: z.string().transform(y => parseInt(y, 10)),
-  sendresources: z.string().optional().transform(res => res ? parseInt(res, 10) : 0),
+  x: z.coerce.number().int().min(0).max(MapRoom2.WIDTH - 1),
+  y: z.coerce.number().int().min(0).max(MapRoom2.HEIGHT - 1),
+  sendresources: z.coerce.number().optional().default(0),
 });
 
 /**
@@ -81,7 +81,6 @@ export const getArea: KoaController = async (ctx) => {
 
   if (!worldid) throw new Error(`${user.username} has no world ID.`);
 
-  // We ignore width & height sent by the client as it's already hardcoded to 10 x 10
   const width = 10;
   const height = 10;
 

--- a/server/src/middleware/rateLimiters.ts
+++ b/server/src/middleware/rateLimiters.ts
@@ -4,13 +4,35 @@ import { Status } from "../enums/StatusCodes.js";
 import type { Context } from "koa";
 
 /**
+ * Keys a limit by account, falling back to IP only for unauthenticated routes.
+ *
+ * @param {Context} ctx - The Koa context object.
+ * @returns {Promise<string>} The rate limit bucket key.
+ */
+const byUser = async (ctx: Context) => String(ctx.authUser?.userid ?? ctx.ip);
+
+/**
+ * Rate limit for MR2 getarea - 120 requests per minute per user.
+ */
+export const getAreaLimiter = RateLimit.middleware({
+  interval: { min: 1 },
+  max: 120,
+  prefixKey: "getarea",
+  keyGenerator: byUser,
+  handler: async (ctx: Context) => {
+    ctx.status = Status.TOO_MANY_REQUESTS;
+    ctx.body = { error: "Too many area requests. Please slow down." };
+  },
+});
+
+/**
  * Rate limit for MR3 getcells - 60 requests per minute per user.
  */
 export const getCellsLimiter = RateLimit.middleware({
   interval: { min: 1 },
   max: 60,
   prefixKey: "getcells",
-  keyGenerator: async (ctx: Context) => String(ctx.authUser?.userid ?? ctx.ip),
+  keyGenerator: byUser,
   handler: async (ctx: Context) => {
     ctx.status = Status.TOO_MANY_REQUESTS;
     ctx.body = { error: "Too many cell requests. Please slow down." };
@@ -40,7 +62,7 @@ export const changeUsernameLimiter = RateLimit.middleware({
   interval: { min: 60 },
   max: 5,
   prefixKey: "changeusername",
-  keyGenerator: async (ctx: Context) => String(ctx.authUser?.userid ?? ctx.ip),
+  keyGenerator: byUser,
   handler: async (ctx: Context) => {
     ctx.status = Status.TOO_MANY_REQUESTS;
     ctx.body = {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -20,6 +20,7 @@ import { startChatServer } from "./chat/chatServer.js";
 
 export const app = new Koa();
 app.proxy = true;
+app.proxyIpHeader = "CF-Connecting-IP";
 
 export const PORT = process.env.PORT || 3001;
 export const BASE_URL = process.env.BASE_URL;


### PR DESCRIPTION
`/worldmapv2/getarea` is the endpoint the MR2 client uses to load the world, ten cells at a time. It had **no rate limit of any kind**, and the IP address we key our other limits on was attacker-controlled. This PR closes both, and tightens the request validation on the way past.

---

## What changed

| File | Change |
|---|---|
| `server.ts` | Read the real client IP from `CF-Connecting-IP` instead of `X-Forwarded-For` |
| `middleware/rateLimiters.ts` | New `getAreaLimiter` (120/min per user); extracted the shared `byUser` key generator |
| `app.routes.ts` | Wire the limiter onto `/worldmapv2/getarea` |
| `controllers/maproom/v2/getArea.ts` | Validate `x` / `y` / `sendresources` properly in the Zod schema |
| `controllers/maproom/v2/cells/userCell.ts` | Drop a duplicated avatar field from every cell |

---

## 1. `ctx.ip` was caller-controlled

`app.proxy = true` was set with no proxy configuration, so Koa resolved `ctx.ip` as the **leftmost** `X-Forwarded-For` entry. Cloudflare *appends* to an inbound `X-Forwarded-For` rather than replacing it, so the leftmost value is whatever the caller put there.

That meant **every IP-keyed control we have was bypassable by rotating a fake header**:

- `registerLimiter` — 3 accounts/hour became unlimited
- `loginLimiter` — 30 attempts/5 min became unlimited (this is the brute-force control)
- The login and register audit logs recorded a value the caller chose

```ts
app.proxyIpHeader = "CF-Connecting-IP";
```

Cloudflare sets `CF-Connecting-IP` at its edge, and Koa falls back to the socket address when the header is absent, so local dev and direct access are unaffected. Reading it instead of `X-Forwarded-For` is Cloudflare's own documented recommendation.

**Caveat:** this only holds while the origin cannot be reached except through Cloudflare. Anything that can connect directly can still forge the header. Locking the origin down is infrastructure work and is *not* covered by this PR.

## 2. `getarea` had no rate limiter

The route was `verifyUserAuth, verifyAccountStatus, logRequest, getArea` and nothing else. MR3's `/getcells` has had a limiter at 60/min all along; MR2 — the older and more expensive endpoint — had none.

```ts
export const getAreaLimiter = RateLimit.middleware({
  interval: { min: 1 },
  max: 120,
  prefixKey: "getarea",
  keyGenerator: byUser,
  ...
});
```

**Keyed by account, not IP.** This matters: an external consumer proxying many players through one host would collapse its entire userbase into a single bucket, while each of those players is a distinct account to us. That is the mistake `loginLimiter` currently makes, and it is worth not repeating.

**Why 120?** Sized against what the Flash client actually does, which is less than it looks:

- `MapRoomPopup.Update` calls `MapRoom.GetCell` once per *visible cell* — hundreds of times per pan — but `RequestData` collapses those into at most one request per **zone**, per 30–40s freshness window. HTTP volume tracks newly-visible zones, not cells.
- Requests are strictly serial; concurrency is 1.
- A viewport (18×15 cells, zones are 10×10) straddles 4–9 zones. Crossing one zone boundary while panning reveals 2–3.

That works out to roughly **30/min for leisurely panning and ~75/min for brisk panning**. 120 clears both with margin. Only an unbroken minute of maximum-speed dragging across unseen map approaches it, which is a stress test rather than play.

It also caps a full 6,400-zone world sweep at ~53 minutes instead of ~2.

**What the limit is not.** It is per user, so N accounts get N×120 — it slows bulk scraping, it does not prevent it. The real answer to that is a purpose-built bulk endpoint (see below), not a tighter limit here. Lowering it to 60 would start blocking ordinary brisk panning while only moving a full sweep from ~53 to ~107 minutes: a live gameplay regression for no meaningful defensive gain.

## 3. `x` / `y` were unvalidated

```ts
// before
x: z.string().transform(x => parseInt(x, 10)),

// after
x: z.coerce.number().int().min(0).max(MapRoom2.WIDTH - 1),
```

The real bug: `parseInt("abc", 10)` returns `NaN`, and the old schema passed it straight through into the MikroORM query untested. The bounds and integer check also reject `x = -10`, `x = 5000000`, `x = "120abc"` and `x = "12.7"`, none of which the client can produce.

`z.coerce.number()` rejects `NaN` and infinities on its own in Zod v4, so no `.finite()` — that method is a deprecated no-op.

**This cannot reject a real request.** The client wraps cell coordinates into the world in its render loop before `GetCellZone` snaps them to a multiple of 10, so it only ever sends in-bounds integers in `{0, 10, …, 790}`. Old and new schemas produce byte-identical output for every input the client actually sends. One case *widened*: a JSON number is now accepted where a string was previously required, which the Flash client never sends anyway (it posts form-urlencoded).

## 4. Duplicate avatar field

`userCell.ts` was sending the player's avatar twice per owned cell:

```ts
pic_square: cellOwner.pic_square,
im: cellOwner.pic_square,   // removed
```

Verified unused by the client (`MapRoomCell.as`). Halves the avatar cost of every owned cell in every `getarea` response.
