### PR TITLE
Harden the public leaderboard routes: validate worldid, bound Redis growth

### DIFF
--- a/server/src/app.routes.ts
+++ b/server/src/app.routes.ts
@@ -8,6 +8,7 @@ import {
   getAreaLimiter,
   getCellsLimiter,
   loginLimiter,
+  publicReadLimiter,
   registerLimiter,
 } from "./middleware/rateLimiters.js";
 import { Status } from "./enums/StatusCodes.js";
@@ -136,8 +137,8 @@ router.post("/api/:apiVersion/bm/yardplanner/savetemplate", apiVersion, verifyUs
 /**  ────────────────────────────────────────────────
 * 📦 Leaderboards & Attack Logs
 * ──────────────────────────────────────────────── */
-router.get("/api/:apiVersion/worlds", getAvailableWorlds);
-router.get("/api/:apiVersion/leaderboards", getLeaderboards);
+router.get("/api/:apiVersion/worlds", publicReadLimiter, getAvailableWorlds);
+router.get("/api/:apiVersion/leaderboards", publicReadLimiter, getLeaderboards);
 router.get("/api/:apiVersion/attacklogs", verifyUserAuth, getAttackLogs);
 
 /**  ────────────────────────────────────────────────

--- a/server/src/controllers/leaderboards/getAvailableWorlds.ts
+++ b/server/src/controllers/leaderboards/getAvailableWorlds.ts
@@ -1,32 +1,17 @@
 import { Status } from "../../enums/StatusCodes.js";
-import { World } from "../../models/world.model.js";
-import { postgres, redis } from "../../server.js";
+import { getCachedWorlds } from "../../services/maproom/knownWorlds.js";
 import type { KoaController } from "../../utils/KoaController.js";
-import { LB_CACHE_TTL } from "./getLeaderboards.js";
 
 /**
  * Controller to handle the retrieval of available worlds.
  *
- * First checks if the world data is cached in Redis.
- * If not, it queries the database for the world data,
- * caches the result in Redis, and then returns the data to the client.
+ * The world list is Redis cached and shared with the world id validation used
+ * by the leaderboards, so both are served from a single cached read.
  *
- * @param {Context} ctx - The Koa context object, which includes the request body.
+ * @param {Context} ctx - The Koa request/response context object.
  * @returns {Promise<void>} - A promise that resolves when the controller is complete.
  */
 export const getAvailableWorlds: KoaController = async (ctx) => {
-  const cacheKey = "availableWorlds";
-  let worlds: World[] = [];
-
-  const cachedWorlds = await redis.get(cacheKey);
-
-  if (cachedWorlds) {
-    worlds = JSON.parse(cachedWorlds);
-  } else {
-    worlds = await postgres.em.find(World, {});
-    await redis.setex(cacheKey, LB_CACHE_TTL, JSON.stringify(worlds));
-  }
-
   ctx.status = Status.OK;
-  ctx.body = { worlds };
+  ctx.body = { worlds: await getCachedWorlds() };
 };

--- a/server/src/controllers/leaderboards/getLeaderboards.ts
+++ b/server/src/controllers/leaderboards/getLeaderboards.ts
@@ -2,6 +2,7 @@ import { MapRoomVersion } from "../../enums/MapRoom.js";
 import { Status } from "../../enums/StatusCodes.js";
 import { EnumYardType } from "../../enums/EnumYardType.js";
 import { postgres, redis } from "../../server.js";
+import { isKnownWorld } from "../../services/maproom/knownWorlds.js";
 import type { KoaController } from "../../utils/KoaController.js";
 
 interface MR2Leaderboard {
@@ -23,7 +24,7 @@ interface MR3Leaderboard {
  * Time-to-live (TTL) for leaderboard cache in Redis.
  * Two hours (7200 seconds).
  */
-export const LB_CACHE_TTL = 7200;
+const LB_CACHE_TTL = 7200;
 
 /**
  * Controller to handle the retrieval of leaderboards for a specific world.
@@ -49,6 +50,20 @@ export const getLeaderboards: KoaController = async (ctx) => {
   }
 
   const version = Number(mapversion);
+
+  if (version !== MapRoomVersion.V2 && version !== MapRoomVersion.V3) {
+    ctx.status = Status.BAD_REQUEST;
+    ctx.body = { error: "Unsupported map version" };
+    return;
+  }
+
+  const worldExists = await isKnownWorld(worldid);
+
+  if (!worldExists) {
+    ctx.status = Status.BAD_REQUEST;
+    ctx.body = { error: "Unknown worldid" };
+    return;
+  }
 
   const cacheKey = `leaderboards_${worldid}_v${version}`;
   const cachedData = await redis.get(cacheKey);

--- a/server/src/controllers/maproom/v2/takeoverCell.ts
+++ b/server/src/controllers/maproom/v2/takeoverCell.ts
@@ -1,6 +1,7 @@
 import type { KoaController } from "../../../utils/KoaController.js";
 import { User } from "../../../models/user.model.js";
-import { postgres, redis } from "../../../server.js";
+import { postgres } from "../../../server.js";
+import { invalidateWorldsCache } from "../../../services/maproom/knownWorlds.js";
 import { WorldMapCell } from "../../../models/worldmapcell.model.js";
 import { Status } from "../../../enums/StatusCodes.js";
 import { BaseType } from "../../../enums/Base.js";
@@ -117,7 +118,7 @@ export const takeoverCell: KoaController = async (ctx) => {
   postgres.em.persist([cellSave, currentUser]);
   await postgres.em.flush();
 
-  if (isOriginCell) await redis.del("availableWorlds");
+  if (isOriginCell) await invalidateWorldsCache();
 
   ctx.status = Status.OK;
   ctx.body = { error: 0 };

--- a/server/src/middleware/rateLimiters.ts
+++ b/server/src/middleware/rateLimiters.ts
@@ -26,6 +26,21 @@ export const getAreaLimiter = RateLimit.middleware({
 });
 
 /**
+ * Rate limit for the unauthenticated public read routes (worlds, leaderboards).
+ * Both are Redis cached, so this bounds cache misses rather than the cached
+ * path. Keyed by IP because there is no account to key on.
+ */
+export const publicReadLimiter = RateLimit.middleware({
+  interval: { min: 1 },
+  max: 30,
+  prefixKey: "public-read",
+  handler: async (ctx: Context) => {
+    ctx.status = Status.TOO_MANY_REQUESTS;
+    ctx.body = { error: "Too many requests. Please try again shortly." };
+  },
+});
+
+/**
  * Rate limit for MR3 getcells - 60 requests per minute per user.
  */
 export const getCellsLimiter = RateLimit.middleware({

--- a/server/src/services/maproom/knownWorlds.ts
+++ b/server/src/services/maproom/knownWorlds.ts
@@ -1,7 +1,7 @@
 import { World } from "../../models/world.model.js";
 import { postgres, redis } from "../../server.js";
 
-export const WORLDS_CACHE_TTL = 7200;
+export const WORLDS_CACHE_TTL = 86400;
 
 const WORLDS_CACHE_KEY = "availableWorlds";
 
@@ -21,6 +21,13 @@ export const getCachedWorlds = async (): Promise<World[]> => {
 
   return worlds;
 };
+
+/**
+ * Drops the cached world list.
+ *
+ * @returns {Promise<number>} Resolves once the key is dropped.
+ */
+export const invalidateWorldsCache = () => redis.del(WORLDS_CACHE_KEY);
 
 /**
  * Checks a caller-supplied world id against the known worlds.

--- a/server/src/services/maproom/knownWorlds.ts
+++ b/server/src/services/maproom/knownWorlds.ts
@@ -1,0 +1,37 @@
+import { World } from "../../models/world.model.js";
+import { postgres, redis } from "../../server.js";
+
+export const WORLDS_CACHE_TTL = 7200;
+
+const WORLDS_CACHE_KEY = "availableWorlds";
+
+/**
+ * Returns every world, from Redis when cached and from the database otherwise.
+ *
+ * @returns {Promise<World[]>} All known worlds.
+ */
+export const getCachedWorlds = async (): Promise<World[]> => {
+  const cached = await redis.get(WORLDS_CACHE_KEY);
+
+  if (cached) return JSON.parse(cached);
+
+  const worlds = await postgres.em.find(World, {});
+
+  await redis.setex(WORLDS_CACHE_KEY, WORLDS_CACHE_TTL, JSON.stringify(worlds));
+
+  return worlds;
+};
+
+/**
+ * Checks a caller-supplied world id against the known worlds.
+ *
+ * @param {string | string[] | undefined} worldid - The world id supplied by the caller.
+ * @returns {Promise<boolean>} True when the world exists.
+ */
+export const isKnownWorld = async (worldid: string | string[] | undefined): Promise<boolean> => {
+  if (typeof worldid !== "string" || !worldid) return false;
+
+  const worlds = await getCachedWorlds();
+
+  return worlds.some((world) => world.uuid === worldid);
+};

--- a/server/src/services/maproom/v2/joinOrCreateWorld.ts
+++ b/server/src/services/maproom/v2/joinOrCreateWorld.ts
@@ -6,6 +6,7 @@ import { World } from "../../../models/world.model.js";
 import { MapRoom2, MapRoomCell, MapRoomVersion } from "../../../enums/MapRoom.js";
 import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
 import { postgres } from "../../../server.js";
+import { invalidateWorldsCache } from "../knownWorlds.js";
 import { findFreeCell } from "./findFreeCell.js";
 import type { WorldData } from "../../../types/EntityData.js";
 
@@ -79,4 +80,6 @@ export const joinOrCreateWorld = async (
 
   em.persist([world, homeCell, save]);
   await em.flush();
+
+  await invalidateWorldsCache();
 };

--- a/server/src/services/maproom/v3/joinNewWorldMap.ts
+++ b/server/src/services/maproom/v3/joinNewWorldMap.ts
@@ -5,6 +5,7 @@ import { World } from "../../../models/world.model.js";
 import { MapRoom3, MapRoomVersion } from "../../../enums/MapRoom.js";
 import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
 import { postgres } from "../../../server.js";
+import { invalidateWorldsCache } from "../knownWorlds.js";
 import { findFreeSector } from "./findFreeSector.js";
 import { EnumYardType } from "../../../enums/EnumYardType.js";
 import { logger } from "../../../utils/logger.js";
@@ -78,4 +79,6 @@ export const joinNewWorldMap = async (
 
   em.persist([world, homeCell, save]);
   await em.flush();
+
+  await invalidateWorldsCache();
 };

--- a/server/src/services/user/renameUser.ts
+++ b/server/src/services/user/renameUser.ts
@@ -3,7 +3,8 @@ import { UniqueConstraintViolationException } from "@mikro-orm/core";
 import { User } from "../../models/user.model.js";
 import { Save } from "../../models/save.model.js";
 import { World } from "../../models/world.model.js";
-import { postgres, redis } from "../../server.js";
+import { postgres } from "../../server.js";
+import { invalidateWorldsCache } from "../maproom/knownWorlds.js";
 import { usernameUniqueErr } from "../../errors/errors.js";
 
 /** How long a player must wait between username changes. */
@@ -76,7 +77,7 @@ export const renameUser = async (user: User, username: string): Promise<Date> =>
   user.username = username;
   user.username_changed_at = changedAt;
 
-  if (worldsRenamed > 0) await redis.del("availableWorlds");
+  if (worldsRenamed > 0) await invalidateWorldsCache();
 
   return cooldownExpiry(changedAt);
 };


### PR DESCRIPTION
`/api/:apiVersion/leaderboards` and `/api/:apiVersion/worlds` are **fully public** — no `verifyUserAuth`, no rate limit. The leaderboard route also built its Redis cache key straight from an unvalidated query parameter, so any caller with no account at all could fill Redis with keys that live for two hours.

This is the follow-up to #261, which covered the MR2 map API. Same theme, different route family.

No client changes, no migrations.

---

## What changed

| File | Change |
|---|---|
| `services/maproom/knownWorlds.ts` | **New.** Cached world list, `isKnownWorld()` validation, `invalidateWorldsCache()` |
| `controllers/leaderboards/getLeaderboards.ts` | Validate `mapversion` and `worldid` before touching Redis or Postgres |
| `controllers/leaderboards/getAvailableWorlds.ts` | Serve from the shared cache instead of its own copy |
| `middleware/rateLimiters.ts` | New `publicReadLimiter` — 30/min, IP-keyed |
| `app.routes.ts` | Wire it onto both public routes |
| `joinOrCreateWorld.ts`, `joinNewWorldMap.ts` | Invalidate the world cache after creating a world |
| `takeoverCell.ts`, `renameUser.ts` | Use the shared helper instead of a hardcoded `redis.del` |

---

<br>

## 1. The cache key was built from unvalidated input

```ts
const cacheKey = `leaderboards_${worldid}_v${version}`;
...
await redis.setex(cacheKey, LB_CACHE_TTL, JSON.stringify(leaderboard));   // 2-hour TTL
```

`worldid` came straight from the query string with no checks. Every distinct value missed the cache, ran a DB aggregate, and then **wrote a Redis key that persisted for two hours**.

Because a query string can be roughly 16 KB (Node's `maxHeaderSize`), each request could mint a key of that size. Sustained at even a modest rate, that is gigabytes of Redis held at steady state — and Redis is not optional here, it holds auth tokens and the server will not start without it. Filling it degrades logins, not just leaderboards.

`mapversion` multiplied the same problem independently. It was only ever compared against `V3`, so anything else fell through to the MR2 branch and cached happily:

| Input | Old cache key suffix |
|---|---|
| `mapversion=999` | `_v999` |
| `mapversion=abc` | `_vNaN` |
| `mapversion=` | `_v0` |

**Fix:** validate both *before* any Redis or Postgres work, so a bogus request never reaches `setex`.

```ts
if (version !== MapRoomVersion.V2 && version !== MapRoomVersion.V3) { ...400 }

const worldExists = await isKnownWorld(worldid);

if (!worldExists) { ...400 }
```

Order matters: the two cheap synchronous checks run first, so junk input is rejected without spending the Redis read that `isKnownWorld` needs.

<br>

## 2. `knownWorlds.ts` — validation that does not cost a query

The obvious way to validate `worldid` is a database lookup per request. On an unauthenticated route that just trades one problem for another.

Instead the new service caches the world list in Redis under `availableWorlds`, and `isKnownWorld()` checks against that, so validation costs one Redis `GET` rather than a query per request. Worlds change rarely, but *when* they change is unpredictable — see the next section for why that means invalidation, not a short TTL.

`getAvailableWorlds` already cached the same data under the same key, so it now shares the helper rather than keeping its own copy. That removes a duplicated cache writer and an odd import (it was pulling `LB_CACHE_TTL` from the leaderboards controller); the constant is no longer exported.

The parameter is typed `string | string[] | undefined` to match Koa's `ParsedUrlQuery`, because a repeated parameter such as `?worldid=a&worldid=b` arrives as an **array**. Anything that is not a non-empty string is rejected before the cache is consulted.

<br>

## 3. Cache invalidation — the part that makes validation safe

Validating against a cache changes what staleness *costs*. Previously a stale world list meant `/worlds` omitted a new world for a while, which was cosmetic. With `isKnownWorld` in front of the leaderboards, a stale list makes a legitimate world return **`400 Unknown worldid`**.

That matters because worlds are not created on a schedule — both `joinOrCreateWorld` (V2) and `joinNewWorldMap` (V3) create one **on demand**, the moment every existing world hits `MAX_PLAYERS`:

```ts
if (shuffledWorlds.length > 0) { world = shuffledWorlds[0]; }
else {
  world = em.create(World, {} as unknown as WorldData);   // all worlds full
  world.name = "New World";
}
```

Neither invalidated the cache, so a player who landed in the brand-new world would have hit `400` on leaderboards until the TTL lapsed.

The codebase already had this pattern in two places (`takeoverCell.ts`, `renameUser.ts` both did `redis.del("availableWorlds")` when a world's name changed), so this generalises it:

```ts
export const invalidateWorldsCache = () => redis.del(WORLDS_CACHE_KEY);
```

Now called from all four mutation sites — the two creation paths (after `em.flush()`, so the world is committed before the cache is dropped) and the two existing rename paths. The cache key is no longer hardcoded in three separate files.

**With invalidation in place the TTL is a safety net rather than a correctness boundary, so it moved from 2 hours to 24.** Over-invalidating is harmless — the world table is tiny and a miss costs one query — whereas under-invalidating is the bug above.

<br>

## 4. Rate limiting

```ts
export const publicReadLimiter = RateLimit.middleware({
  interval: { min: 1 },
  max: 30,
  prefixKey: "public-read",
  ...
});
```

Both routes are Redis cached, so the common path is already cheap — this exists to bound cache *misses* and general request volume. Keyed by IP because there is no account to key on, which is only meaningful because #261 made `ctx.ip` trustworthy (`CF-Connecting-IP` rather than a caller-supplied `X-Forwarded-For`).

Validation is the actual fix here; the limiter is defence in depth.
