### PR TITLE
Fix bun db:init deadlock on fresh database (allOrNothing: false)

### DIFF
--- a/server/src/mikro-orm.config.ts
+++ b/server/src/mikro-orm.config.ts
@@ -55,5 +55,11 @@ export default defineConfig({
     path: path.join(import.meta.dirname, "./database/migrations"),
     pathTs: path.join(import.meta.dirname, "./database/migrations"),
     glob: "*.ts",
+    // Must be false: a non-transactional migration (CREATE INDEX CONCURRENTLY in
+    // 20260815_AddUniqueMainSaveIndex) cannot proceed while an earlier transactional
+    // migration in the same batch is still open on another connection - Postgres
+    // makes CONCURRENTLY wait for every in-flight transaction to finish, and the
+    // batch transaction only commits after the whole run succeeds. That's a deadlock.
+    allOrNothing: false,
   },
 });


### PR DESCRIPTION
## Summary
- Fixes #266 - `bun db:init` hangs forever on a fresh database when it reaches `20260815_AddUniqueMainSaveIndex`
- Root cause: that migration runs `CREATE INDEX CONCURRENTLY`, which cannot execute inside a transaction, so MikroORM runs it non-transactionally on a separate connection. With the migrator's default `allOrNothing: true`, every transactional migration ahead of it stays open in one shared batch transaction until the entire run finishes - but Postgres requires `CREATE INDEX CONCURRENTLY` to wait for all in-flight transactions to finish first. Neither side can proceed.
- Fix: set `allOrNothing: false` in `mikro-orm.config.ts` so each migration commits as it completes, instead of the whole run sharing one transaction.

## Test plan
- [x] Reproduced the hang on a clean database with the original config - confirmed via `pg_stat_activity` that one connection sat `idle in transaction` (holding the batch open) while another was `active`/blocked on a relation lock running `CREATE INDEX CONCURRENTLY`
- [x] Applied the fix, reset to a fresh database again, ran `bun db:init` - completed cleanly in seconds, all 20 migrations recorded in `mikro_orm_migrations`, and `save_one_main_per_user` confirmed present via `pg_indexes`
- [x] Repeated the before/after comparison a second time to confirm it wasn't a fluke
- [x] Restarted the dev server against the resulting database and confirmed it serves requests normally