### PR TITLE
Fix yard planner logging players out mid-rebuild

### DIFF
--- a/client/scripts/com/monsters/baseplanner/popups/BasePlannerPopup.as
+++ b/client/scripts/com/monsters/baseplanner/popups/BasePlannerPopup.as
@@ -774,6 +774,7 @@ package com.monsters.baseplanner.popups
       public function onDesignStateChange(param1:Event = null) : void
       {
          this.hasBeenSaved = false;
+         GLOBAL.UpdateAFKTimer();
       }
       
       public function Remove() : void


### PR DESCRIPTION
## Summary
- The AFK/session timeout (`GLOBAL.AFK()`) logs a player out via `POPUPS.Timeout()` after 10 minutes without the session timer being reset.
- That reset normally happens on large stage mouse movement, with a couple of existing spots (`SPECIALEVENT.as`, `SPECIALEVENT_WM1.as`) explicitly calling `GLOBAL.UpdateAFKTimer()` for legitimate engagement that doesn't move the mouse much.
- The yard planner never did this: `BasePlannerPopup.onDesignStateChange` fires on every place/move/delete in the planner but never reset the timer, so players doing careful small-movement layout work for 10+ minutes were logged out and lost their in-progress rebuild.
- Added `GLOBAL.UpdateAFKTimer()` to `onDesignStateChange` so every yard planner modification now keeps the session alive like other actions do.

## Test plan
- [x] Open the yard planner and place/move/delete buildings continuously (small mouse movements only) for 10+ minutes; confirm no AFK timeout/logout occurs.
- [x] Confirm normal AFK timeout still triggers when genuinely idle (no input) for 10 minutes.