### PR TITLE
Attack battle reports — PR 1a (data pipeline)

### DIFF
--- a/client/scripts/ATTACK.as
+++ b/client/scripts/ATTACK.as
@@ -628,6 +628,7 @@ package
                   _flungSpace.Add(CREATURES.GetProperty(_loc8_,"bucket") * _flingerBucket[_loc8_].Get());
                   _loc7_ = KEYS.Get(CREATURELOCKER._creatures[_loc8_].name);
                   _loc6_.push([_flingerBucket[_loc8_].Get(),_loc7_]);
+                  AttackReport.RecordFlung(_loc8_,_flingerBucket[_loc8_].Get());
                   _loc13_ = 0;
                   while(_loc13_ < _flingerBucket[_loc8_].Get())
                   {

--- a/client/scripts/ATTACK.as
+++ b/client/scripts/ATTACK.as
@@ -159,6 +159,7 @@ package
          _flingCount = 0;
          _log = [];
          _attackStart = GLOBAL.Timestamp();
+         AttackReport.Reset();
          _flungSpace = new SecNum(0);
          _loot = {
             "r1":new SecNum(0),
@@ -1027,6 +1028,7 @@ package
          BucketClear();
          if(!_sentOver)
          {
+            AttackReport.RecordOutcomeRetreat();
             if(BASE._saveOver != 1)
             {
                BASE.Save(1,false,true);

--- a/client/scripts/AttackReport.as
+++ b/client/scripts/AttackReport.as
@@ -13,6 +13,7 @@ package
    {
       private static var _buildings:Object;
       private static var _lootTotal:Array;      // [r1,r2,r3,r4]
+      private static var _flung:Object;         // creatureID string -> cumulative int count flung this attack
       private static var _siege:Object;
       private static var _catapult:Object;
       private static var _retreated:Boolean;
@@ -23,6 +24,7 @@ package
       {
          _buildings = {};
          _lootTotal = [0, 0, 0, 0];
+         _flung = {};
          _siege = {};
          _catapult = {};
          _retreated = false;
@@ -50,12 +52,29 @@ package
          if(b) b.l += amount;
       }
 
-      public static function AddLootTotal(r1:Number, r2:Number, r3:Number, r4:Number) : void
+      /**
+       * Records monsters flung/sent this attack, accumulating across fling waves.
+       * Called at the fling site (ATTACK.Spawn) with the per-wave bucket count for
+       * one creature type. This — NOT the attacker's remaining roster — is what
+       * report.atk.m must reflect.
+       */
+      public static function RecordFlung(creatureId:String, count:int) : void
       {
-         _lootTotal[0] += Math.max(0, r1);
-         _lootTotal[1] += Math.max(0, r2);
-         _lootTotal[2] += Math.max(0, r3);
-         _lootTotal[3] += Math.max(0, r4);
+         if(count <= 0) return;
+         _flung[creatureId] = int(_flung[creatureId] || 0) + count;
+      }
+
+      /**
+       * Sets the loot 4-tuple to the running attack total. ATTACK._loot is already
+       * the cumulative grand total for the whole attack, so this is an assignment,
+       * not an accumulation — calling it repeatedly across mid-attack saves is safe.
+       */
+      public static function SetLootTotal(r1:Number, r2:Number, r3:Number, r4:Number) : void
+      {
+         _lootTotal[0] = Math.max(0, r1);
+         _lootTotal[1] = Math.max(0, r2);
+         _lootTotal[2] = Math.max(0, r3);
+         _lootTotal[3] = Math.max(0, r4);
       }
 
       public static function RecordSiege(siegeId:String) : void
@@ -75,7 +94,7 @@ package
          _retreated = true;
       }
 
-      public static function Serialize(attackMonsters:Object, attackerChampion:Object) : String
+      public static function Serialize(attackerChampion:Object) : String
       {
          if(!_buildings) return "";
 
@@ -86,7 +105,7 @@ package
          report.o = outcome(report.d);
          report.loot = [int(_lootTotal[0]), int(_lootTotal[1]), int(_lootTotal[2]), int(_lootTotal[3])];
          report.b = buildingArray();
-         report.atk = attackForce(attackMonsters, attackerChampion);
+         report.atk = attackForce(attackerChampion);
 
          var s:Array = countObjectToPairs(_siege, AttackReportEnums.SIEGE);
          if(s.length > 0) report.s = s;
@@ -132,18 +151,21 @@ package
          return out;
       }
 
-      private static function attackForce(monsters:Object, champion:Object) : Object
+      /**
+       * report.atk.m is "monsters flung/sent this attack" — accumulated at the fling
+       * site via RecordFlung, NOT derived from the attacker's roster (which per mode
+       * is either the un-sent remainder or the whole owned army). The champion still
+       * comes from the passed-in guardian-save object.
+       */
+      private static function attackForce(champion:Object) : Object
       {
          var m:Array = [];
          var key:String;
-         if(monsters)
+         for(key in _flung)
          {
-            for(key in monsters)
-            {
-               var enumId:int = AttackReportEnums.monsterId(key);
-               var count:int = monsterCount(monsters[key]);
-               if(enumId >= 0 && count > 0) m.push([enumId, count]);
-            }
+            var enumId:int = AttackReportEnums.monsterId(key);
+            var count:int = int(_flung[key]);
+            if(enumId >= 0 && count > 0) m.push([enumId, count]);
          }
          var c:int = -1;
          if(champion)
@@ -152,20 +174,6 @@ package
             if(ck) c = AttackReportEnums.championId(ck);
          }
          return {"m":m, "c":c};
-      }
-
-      /**
-       * attackMonsters comes from GLOBAL.attackingPlayer.exportMonsters() — an object
-       * keyed by creatureID. Each value is either a number (count) or an object with a
-       * countable field. Adjust monsterCount / championKey to that structure once
-       * verified against a real trace (Step 4); the shape below is the expected one.
-       */
-      private static function monsterCount(v:*) : int
-      {
-         if(v is Number) return int(v);
-         if(v && v.hasOwnProperty("count")) return int(v.count);
-         if(v is Array) return (v as Array).length;
-         return 0;
       }
 
       private static function championKey(v:*) : String

--- a/client/scripts/AttackReport.as
+++ b/client/scripts/AttackReport.as
@@ -170,10 +170,12 @@ package
 
       private static function championKey(v:*) : String
       {
+         if(v is Array) return (v as Array).length > 0 ? championKey((v as Array)[0]) : null;
          if(v is String) return v as String;
-         if(v && v.hasOwnProperty("type")) return String(v.type);
-         if(v && v.hasOwnProperty("t")) return String(v.t);
-         return null;
+         var raw:* = (v && v.hasOwnProperty("type")) ? v.type : ((v && v.hasOwnProperty("t")) ? v.t : null);
+         if(raw == null) return null;
+         var s:String = String(raw);
+         return s.charAt(0) == "G" ? s : "G" + s;
       }
 
       private static function countObjectToPairs(counts:Object, enumTable:Array) : Array

--- a/client/scripts/AttackReport.as
+++ b/client/scripts/AttackReport.as
@@ -1,0 +1,191 @@
+package
+{
+   /**
+    * Structured battle report accumulated during an attack, uploaded on attack end
+    * as saveData.battlereport. Populated beside the existing ATTACK.Log() sites.
+    *
+    * PR 1a scope: building damage/HP/loot, loot totals, attacking force, siege,
+    * catapult. dd/k/ml (combat-path attribution) are PR 1b and not recorded here.
+    *
+    * See docs/superpowers/specs/2026-08-29-attack-battle-reports-design.md.
+    */
+   public class AttackReport
+   {
+      private static var _buildings:Object;
+      private static var _lootTotal:Array;      // [r1,r2,r3,r4]
+      private static var _siege:Object;
+      private static var _catapult:Object;
+      private static var _retreated:Boolean;
+
+      public function AttackReport() { super(); }
+
+      public static function Reset() : void
+      {
+         _buildings = {};
+         _lootTotal = [0, 0, 0, 0];
+         _siege = {};
+         _catapult = {};
+         _retreated = false;
+      }
+
+      public static function RecordBuilding(id:String, t:int, x:int, y:int, hp:int, mhp:int) : void
+      {
+         var b:Object = _buildings[id];
+         if(!b)
+         {
+            b = {"t":t, "x":x, "y":y, "hp":hp, "mhp":mhp, "l":0};
+            _buildings[id] = b;
+         }
+         else
+         {
+            b.hp = hp;
+            b.mhp = mhp;
+         }
+      }
+
+      public static function RecordLoot(id:String, amount:Number) : void
+      {
+         if(amount <= 0) return;
+         var b:Object = _buildings[id];
+         if(b) b.l += amount;
+      }
+
+      public static function AddLootTotal(r1:Number, r2:Number, r3:Number, r4:Number) : void
+      {
+         _lootTotal[0] += Math.max(0, r1);
+         _lootTotal[1] += Math.max(0, r2);
+         _lootTotal[2] += Math.max(0, r3);
+         _lootTotal[3] += Math.max(0, r4);
+      }
+
+      public static function RecordSiege(siegeId:String) : void
+      {
+         if(AttackReportEnums.siegeId(siegeId) < 0) return;
+         _siege[siegeId] = int(_siege[siegeId] || 0) + 1;
+      }
+
+      public static function RecordCatapult(bombId:String) : void
+      {
+         if(AttackReportEnums.powerupId(bombId) < 0) return;
+         _catapult[bombId] = int(_catapult[bombId] || 0) + 1;
+      }
+
+      public static function RecordOutcomeRetreat() : void
+      {
+         _retreated = true;
+      }
+
+      public static function Serialize(attackMonsters:Object, attackerChampion:Object) : String
+      {
+         if(!_buildings) return "";
+
+         var report:Object = {};
+         report.v = 1;
+         report.d = damagePercent();
+         report.dur = int(GLOBAL.Timestamp() - ATTACK._attackStart);
+         report.o = outcome(report.d);
+         report.loot = [int(_lootTotal[0]), int(_lootTotal[1]), int(_lootTotal[2]), int(_lootTotal[3])];
+         report.b = buildingArray();
+         report.atk = attackForce(attackMonsters, attackerChampion);
+
+         var s:Array = countObjectToPairs(_siege, AttackReportEnums.SIEGE);
+         if(s.length > 0) report.s = s;
+         var cat:Array = countObjectToPairs(_catapult, AttackReportEnums.POWERUPS);
+         if(cat.length > 0) report.cat = cat;
+
+         // Empty attack — nothing worth sending.
+         if(report.b.length == 0 && report.atk.m.length == 0 && report.atk.c == -1
+            && !report.s && !report.cat)
+         {
+            return "";
+         }
+
+         return JSON.stringify(report);
+      }
+
+      private static function damagePercent() : int
+      {
+         var max:Number = Number(BFOUNDATION.totalBuildingMaxHP);
+         if(max <= 0) return 0;
+         var pct:Number = 100 - (100 * Number(BFOUNDATION.totalBuildingHP) / max);
+         return Math.max(0, Math.min(100, Math.round(pct)));
+      }
+
+      private static function outcome(damage:int) : int
+      {
+         if(damage >= 100) return 2;      // flattened
+         if(_retreated) return 0;          // retreat
+         return 1;                          // timeout
+      }
+
+      private static function buildingArray() : Array
+      {
+         var out:Array = [];
+         var id:String;
+         for(id in _buildings)
+         {
+            var b:Object = _buildings[id];
+            var e:Object = {"t":int(b.t), "x":int(b.x), "y":int(b.y), "hp":int(b.hp), "mhp":int(b.mhp)};
+            if(b.l > 0) e.l = int(b.l);
+            out.push(e);
+         }
+         return out;
+      }
+
+      private static function attackForce(monsters:Object, champion:Object) : Object
+      {
+         var m:Array = [];
+         var key:String;
+         if(monsters)
+         {
+            for(key in monsters)
+            {
+               var enumId:int = AttackReportEnums.monsterId(key);
+               var count:int = monsterCount(monsters[key]);
+               if(enumId >= 0 && count > 0) m.push([enumId, count]);
+            }
+         }
+         var c:int = -1;
+         if(champion)
+         {
+            var ck:String = championKey(champion);
+            if(ck) c = AttackReportEnums.championId(ck);
+         }
+         return {"m":m, "c":c};
+      }
+
+      /**
+       * attackMonsters comes from GLOBAL.attackingPlayer.exportMonsters() — an object
+       * keyed by creatureID. Each value is either a number (count) or an object with a
+       * countable field. Adjust monsterCount / championKey to that structure once
+       * verified against a real trace (Step 4); the shape below is the expected one.
+       */
+      private static function monsterCount(v:*) : int
+      {
+         if(v is Number) return int(v);
+         if(v && v.hasOwnProperty("count")) return int(v.count);
+         if(v is Array) return (v as Array).length;
+         return 0;
+      }
+
+      private static function championKey(v:*) : String
+      {
+         if(v is String) return v as String;
+         if(v && v.hasOwnProperty("type")) return String(v.type);
+         if(v && v.hasOwnProperty("t")) return String(v.t);
+         return null;
+      }
+
+      private static function countObjectToPairs(counts:Object, enumTable:Array) : Array
+      {
+         var out:Array = [];
+         var key:String;
+         for(key in counts)
+         {
+            var id:int = enumTable.indexOf(key);
+            if(id >= 0 && counts[key] > 0) out.push([id, int(counts[key])]);
+         }
+         return out;
+      }
+   }
+}

--- a/client/scripts/AttackReportEnums.as
+++ b/client/scripts/AttackReportEnums.as
@@ -1,0 +1,31 @@
+package
+{
+   /**
+    * Mirror of server/src/services/attacklogs/attackReportEnums.ts.
+    * APPEND-ONLY. Never reorder — the index is the wire value.
+    * Kept in sync via attackReportEnums.fixture.json.
+    */
+   public class AttackReportEnums
+   {
+      public static const MONSTERS:Array = [
+         "C1","C2","C3","C4","C5","C6","C7","C8","C9","C10",
+         "C11","C12","C13","C14","C15","C16","C17","C18","C19",
+         "IC1","IC2","IC3","IC4","IC5","IC6","IC7","IC8"
+      ];
+
+      public static const CHAMPIONS:Array = ["G1","G2","G3","G4","G5"];
+
+      public static const SIEGE:Array = ["decoy","vacuum","jars"];
+
+      public static const POWERUPS:Array = [
+         "tw0","tw1","tw2","pb0","pb1","pb2","pb3","pu0","pu1","pu2","pu3"
+      ];
+
+      public function AttackReportEnums() { super(); }
+
+      public static function monsterId(key:String) : int { return MONSTERS.indexOf(key); }
+      public static function championId(key:String) : int { return CHAMPIONS.indexOf(key); }
+      public static function siegeId(key:String) : int { return SIEGE.indexOf(key); }
+      public static function powerupId(key:String) : int { return POWERUPS.indexOf(key); }
+   }
+}

--- a/client/scripts/BASE.as
+++ b/client/scripts/BASE.as
@@ -3870,6 +3870,16 @@ package
             {
                saveData.attackerchampion = JSON.stringify(attackerChampion);
             }
+            AttackReport.AddLootTotal(
+               ATTACK._loot.r1.Get(), ATTACK._loot.r2.Get(),
+               ATTACK._loot.r3.Get(), ATTACK._loot.r4.Get());
+            var battleReport:String = AttackReport.Serialize(
+               GLOBAL.attackingPlayer ? GLOBAL.attackingPlayer.exportMonsters() : null,
+               attackerChampion);
+            if (battleReport != "")
+            {
+               saveData.battlereport = battleReport;
+            }
          }
          if (MapRoomManager.instance.isInMapRoom2 && !GLOBAL.InfernoMode(GLOBAL._loadmode))
          {

--- a/client/scripts/BASE.as
+++ b/client/scripts/BASE.as
@@ -3675,7 +3675,7 @@ package
 
       private static function getOrderedSaveVariablesFromObject(param1:Object):Array
       {
-         var _loc2_:Array = ["baseid", "lastupdate", "resources", "academy", "stats", "mushrooms", "basename", "baseseed", "buildingdata", "researchdata", "lockerdata", "quests", "basevalue", "points", "tutorialstage", "basesaveid", "clienttime", "monsters", "attacks", "monsterbaiter", "version", "attackreport", "over", "protect", "monsterupdate", "attackid", "aiattacks", "effects", "catapult", "flinger", "gifts", "sentgifts", "sentinvites", "purchase", "inventory", "timeplayed", "destroyed", "damage", "type", "attackcreatures", "attackloot", "lootreport"
+         var _loc2_:Array = ["baseid", "lastupdate", "resources", "academy", "stats", "mushrooms", "basename", "baseseed", "buildingdata", "researchdata", "lockerdata", "quests", "basevalue", "points", "tutorialstage", "basesaveid", "clienttime", "monsters", "attacks", "monsterbaiter", "version", "attackreport", "battlereport", "over", "protect", "monsterupdate", "attackid", "aiattacks", "effects", "catapult", "flinger", "gifts", "sentgifts", "sentinvites", "purchase", "inventory", "timeplayed", "destroyed", "damage", "type", "attackcreatures", "attackloot", "lootreport"
                , "empirevalue", "champion", "attackerchampion", "attackersiege", "purchasecomplete", "achieved", "fbpromos", "iresources", "siege", "buildingresources", "frontpage", "events", "buildinghealthdata", "healtime", "lootbonus"];
          var _loc3_:int = int(GLOBAL.player.handlers.length);
          var _loc4_:int = 0;

--- a/client/scripts/BASE.as
+++ b/client/scripts/BASE.as
@@ -3870,15 +3870,16 @@ package
             {
                saveData.attackerchampion = JSON.stringify(attackerChampion);
             }
-            AttackReport.AddLootTotal(
-               ATTACK._loot.r1.Get(), ATTACK._loot.r2.Get(),
-               ATTACK._loot.r3.Get(), ATTACK._loot.r4.Get());
-            var battleReport:String = AttackReport.Serialize(
-               GLOBAL.attackingPlayer ? GLOBAL.attackingPlayer.exportMonsters() : null,
-               attackerChampion);
-            if (battleReport != "")
+            if (_saveOver)
             {
-               saveData.battlereport = battleReport;
+               AttackReport.SetLootTotal(
+                  ATTACK._loot.r1.Get(), ATTACK._loot.r2.Get(),
+                  ATTACK._loot.r3.Get(), ATTACK._loot.r4.Get());
+               var battleReport:String = AttackReport.Serialize(attackerChampion);
+               if (battleReport != "")
+               {
+                  saveData.battlereport = battleReport;
+               }
             }
          }
          if (MapRoomManager.instance.isInMapRoom2 && !GLOBAL.InfernoMode(GLOBAL._loadmode))

--- a/client/scripts/BFOUNDATION.as
+++ b/client/scripts/BFOUNDATION.as
@@ -2371,6 +2371,7 @@ package
                   "v2":KEYS.Get(this._buildingProps.name)
                }) + "</font>");
             }
+            AttackReport.RecordBuilding("b" + this._id,this._type,_mc.x,_mc.y,int(health),int(maxHealth));
             this.Update(true);
             this.GridCost(false);
             PATHING.ResetCosts();

--- a/client/scripts/BFOUNDATION.as
+++ b/client/scripts/BFOUNDATION.as
@@ -563,6 +563,7 @@ package
                "v2":KEYS.Get(this._buildingProps.name),
                "v3":100 - int(100 / maxHealth * health)
             }) + "</font>");
+            AttackReport.RecordBuilding("b" + this._id,this._type,_mc.x,_mc.y,int(health),int(maxHealth));
          }
          if(Boolean(param2) && !this._destroyed)
          {

--- a/client/scripts/BHEAVYTRAP.as
+++ b/client/scripts/BHEAVYTRAP.as
@@ -120,6 +120,7 @@ package
                   "v2":_loc8_
                }) + "</font>");
             }
+            AttackReport.RecordBuilding("htrap" + _id,_type,_mc.x,_mc.y,int(health),int(maxHealth));
             EFFECTS.Scorch(new Point(_mc.x,_mc.y + 5));
          }
          _hasTargets = false;

--- a/client/scripts/BHEAVYTRAP.as
+++ b/client/scripts/BHEAVYTRAP.as
@@ -120,7 +120,7 @@ package
                   "v2":_loc8_
                }) + "</font>");
             }
-            AttackReport.RecordBuilding("htrap" + _id,_type,_mc.x,_mc.y,int(health),int(maxHealth));
+            AttackReport.RecordBuilding("htrap" + _id,_type,_mc.x,_mc.y,0,int(maxHealth));
             EFFECTS.Scorch(new Point(_mc.x,_mc.y + 5));
          }
          _hasTargets = false;

--- a/client/scripts/BSTORAGE.as
+++ b/client/scripts/BSTORAGE.as
@@ -114,6 +114,7 @@ package
          var _loc2_:Number = NaN;
          var _loc3_:int = 0;
          var _loc4_:int = 0;
+         var _loc5_:Number = 0;
          if(param1 && !_destroyed)
          {
             _loc2_ = _LOOT_PCT_BASE;
@@ -170,6 +171,7 @@ package
                   BASE._deltaResources.dirty = true;
                   BASE._hpDeltaResources.dirty = true;
                   ATTACK.Loot(_loc3_,_loc4_,_mc.x,int(_mc.y + 20 - _loc3_ * 10),12);
+                  _loc5_ += _loc4_;
                }
                _loc3_++;
             }
@@ -178,6 +180,8 @@ package
                "v2":_buildingProps.name,
                "v3":int(100 * _loc2_)
             }));
+            AttackReport.RecordBuilding("b" + _id,_type,_mc.x,_mc.y,int(health),int(maxHealth));
+            AttackReport.RecordLoot("b" + _id,_loc5_);
          }
          else
          {
@@ -185,6 +189,7 @@ package
                "v1":_lvl.Get(),
                "v2":_buildingProps.name
             }));
+            AttackReport.RecordBuilding("b" + _id,_type,_mc.x,_mc.y,int(health),int(maxHealth));
          }
          super.Destroyed(param1);
       }

--- a/client/scripts/BTRAP.as
+++ b/client/scripts/BTRAP.as
@@ -154,7 +154,7 @@ package
                   "v2":_loc8_
                }) + "</font>");
             }
-            AttackReport.RecordBuilding("trap" + _id,_type,_mc.x,_mc.y,int(health),int(maxHealth));
+            AttackReport.RecordBuilding("trap" + _id,_type,_mc.x,_mc.y,0,int(maxHealth));
             EFFECTS.Scorch(new Point(_mc.x,_mc.y + 5));
          }
          this._hasTargets = false;

--- a/client/scripts/BTRAP.as
+++ b/client/scripts/BTRAP.as
@@ -154,6 +154,7 @@ package
                   "v2":_loc8_
                }) + "</font>");
             }
+            AttackReport.RecordBuilding("trap" + _id,_type,_mc.x,_mc.y,int(health),int(maxHealth));
             EFFECTS.Scorch(new Point(_mc.x,_mc.y + 5));
          }
          this._hasTargets = false;

--- a/client/scripts/HOUSINGBUNKER.as
+++ b/client/scripts/HOUSINGBUNKER.as
@@ -431,6 +431,7 @@ package
                "v2":KEYS.Get(_buildingProps.name),
                "v3":100 - int(100 / maxHealth * health)
             }) + "</font>");
+            AttackReport.RecordBuilding("b" + _id,_type,_mc.x,_mc.y,int(health),int(maxHealth));
          }
          return super.modifyHealth(param1);
       }

--- a/client/scripts/com/monsters/effects/ResourceBombs.as
+++ b/client/scripts/com/monsters/effects/ResourceBombs.as
@@ -352,6 +352,7 @@ package com.monsters.effects
             "v1":GLOBAL.FormatNumber(_loc2_.cost),
             "v2":GLOBAL._resourceNames[_loc2_.resource - 1]
          }) + "</font>");
+         AttackReport.RecordCatapult(ResourceBombs._bombid);
          _state = 0;
          if(_mc)
          {

--- a/client/scripts/com/monsters/siege/SiegeWeapons.as
+++ b/client/scripts/com/monsters/siege/SiegeWeapons.as
@@ -67,6 +67,7 @@ package com.monsters.siege
          }
          activeWeaponID = param1;
          ATTACK.Log("siegeWeaponActivation","<font color=\"#0000FF\">" + _loc4_.logMessage + "</font>");
+         AttackReport.RecordSiege(param1);
          if(_loc4_.duration > 0)
          {
             activeWeaponTimer = new Timer(1000,_loc4_.duration);

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,8 @@
     "db:seed:mr2": "bun src/database/seeds/seed_maproom2.ts",
     "db:seed:mr3": "bun src/database/seeds/seed_maproom3.ts",
     "migration:up": "bun --bun x mikro-orm migration:up",
-    "typecheck": "bunx tsc --noEmit"
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test"
   },
   "engines": {
     "bun": ">=1.0.0"

--- a/server/scripts/_forceEphemeralPort.ts
+++ b/server/scripts/_forceEphemeralPort.ts
@@ -1,0 +1,12 @@
+/**
+ * Side-effect module: neutralise PORT before src/server.ts enters the graph.
+ *
+ * verify-battle-report.ts imports this FIRST. A bare `process.env.PORT = "0"`
+ * statement in that script would not work: ES module `import` declarations are
+ * hoisted and their modules fully evaluated before any sibling top-level
+ * statement runs, so `import { postgres } from "../src/server.js"` — and its
+ * `app.listen(PORT)` IIFE — would fire while PORT is still "3001" (from .env),
+ * colliding with a running dev server. Doing it in a dependency-free module that
+ * is imported before server.js guarantees it runs first.
+ */
+process.env.PORT = "0";

--- a/server/scripts/setup-mr3-attack-test.ts
+++ b/server/scripts/setup-mr3-attack-test.ts
@@ -1,0 +1,184 @@
+/**
+ * DEV-ONLY setup: give `test` (userid 1) an attackable MR3 opponent.
+ *
+ * Creates one opponent account ("victim") with a full sandbox base, spins up /
+ * joins an MR3 world, and places both `test` and `victim` in it. `test`'s save
+ * is switched to MR3 and given the same sandbox base so it loads cleanly.
+ *
+ * Idempotent: re-running tears down the previous `victim` and re-places `test`.
+ *
+ * Run from server/:  bun scripts/setup-mr3-attack-test.ts
+ *
+ * Wiring note: joinNewWorldMap / leaveWorld read the module-level `postgres` from
+ * src/server.ts, so that module (and its app.listen IIFE) is in the import graph.
+ * ./_forceEphemeralPort neutralises the port bind (PORT=0) so a running dev
+ * server is untouched; we let the IIFE do the single MikroORM.init.
+ */
+
+import "./_forceEphemeralPort.js";
+
+import bcrypt from "bcrypt";
+import { RequestContext } from "@mikro-orm/core";
+import { postgres } from "../src/server.js";
+import { User } from "../src/models/user.model.js";
+import { Save } from "../src/models/save.model.js";
+import { WorldMapCell } from "../src/models/worldmapcell.model.js";
+import { BaseType } from "../src/enums/Base.js";
+import { EnumYardType } from "../src/enums/EnumYardType.js";
+import { MapRoomVersion } from "../src/enums/MapRoom.js";
+import { getDefaultBaseData } from "../src/game-data/getDefaultBaseData.js";
+import { overworldYardSandbox } from "../src/utils/sandbox/overworldYard.js";
+import { joinNewWorldMap } from "../src/services/maproom/v3/joinNewWorldMap.js";
+import { leaveWorld } from "../src/services/maproom/v2/leaveWorld.js";
+import { getCurrentDateTime } from "../src/utils/getCurrentDateTime.js";
+
+const VICTIM_EMAIL = "victim@bymr.test";
+const VICTIM_NAME = "victim";
+const VICTIM_PASS = "Dev12345!";
+const TEST_USERID = 1;
+
+/** Rich base fields copied from the sandbox onto a minimal default save. */
+const RICH_KEYS = [
+  "buildingdata",
+  "buildinghealthdata",
+  "buildingkeydata",
+  "resources",
+  "iresources",
+  "monsters",
+  "champion",
+  "stats",
+  "academy",
+  "researchdata",
+  "coords",
+  "quests",
+  "level",
+  "points",
+  "basevalue",
+  "empirevalue",
+] as const;
+
+const overlaySandbox = (save: Save, user: User) => {
+  const sandbox = overworldYardSandbox(user) as Record<string, unknown>;
+  for (const k of RICH_KEYS) {
+    if (sandbox[k] !== undefined) (save as unknown as Record<string, unknown>)[k] = sandbox[k];
+  }
+  save.mapversion = MapRoomVersion.V3;
+  save.protected = 0;
+  save.canattack = true;
+  save.catapult = 1;
+  save.flinger = 1;
+  save.savetime = getCurrentDateTime();
+};
+
+const waitForOrm = async () => {
+  for (let i = 0; i < 120; i++) {
+    if (postgres.orm && postgres.em) return;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error("postgres.orm never became ready (server.ts IIFE init timed out)");
+};
+
+const homeCellFor = (uid: number) =>
+  postgres.em.findOne(WorldMapCell, {
+    uid,
+    base_type: EnumYardType.PLAYER,
+    map_version: MapRoomVersion.V3,
+  });
+
+const main = async () => {
+  await waitForOrm();
+
+  await RequestContext.create(postgres.em, async () => {
+    const em = postgres.em;
+
+    // 1. Tear down any prior victim (and its world membership + cells).
+    const prior = await em.findOne(
+      User,
+      { email: VICTIM_EMAIL },
+      { populate: ["save"] },
+    );
+    if (prior) {
+      if (prior.save?.worldid) await leaveWorld(prior, prior.save);
+      await em.nativeDelete(Save, { userid: prior.userid });
+      await em.nativeDelete(WorldMapCell, { uid: prior.userid });
+      await em.nativeDelete(User, { userid: prior.userid });
+      em.clear();
+      console.log(`Removed previous "${VICTIM_NAME}" (userid ${prior.userid}).`);
+    }
+
+    // 2. Create the opponent user.
+    const victim = em.create(User, {
+      username: VICTIM_NAME,
+      email: VICTIM_EMAIL,
+      password: await bcrypt.hash(VICTIM_PASS, 10),
+    } as unknown as User);
+    em.persist(victim);
+    await em.flush();
+
+    // 3. Opponent MAIN save: minimal default skeleton + sandbox base overlay.
+    const skeleton = getDefaultBaseData(victim, BaseType.MAIN);
+    const vsave = em.create(Save, {
+      ...skeleton,
+      saveuserid: victim.userid,
+      userid: victim.userid,
+      type: BaseType.MAIN,
+    } as unknown as Save);
+    const [{ baseid }] = await em.execute<[{ baseid: string }]>(
+      `SELECT nextval('bym.user_baseid_seq') AS baseid`,
+    );
+    vsave.baseid = baseid;
+    vsave.homebaseid = parseInt(baseid, 10);
+    vsave.worldid = "";
+    overlaySandbox(vsave, victim);
+    victim.save = vsave;
+    em.persist(vsave);
+    await em.flush();
+
+    // 4. Join / create the MR3 world (also lays down victim's 6 defender cells).
+    await joinNewWorldMap(victim, vsave, em);
+
+    // 5. Move `test` into the same MR3 world with a matching sandbox base.
+    const test = await em.findOne(
+      User,
+      { userid: TEST_USERID },
+      { populate: ["save"] },
+    );
+    if (!test?.save) throw new Error(`user ${TEST_USERID} has no save row`);
+    const tsave = test.save;
+    tsave.type = BaseType.MAIN;
+    if (!tsave.worldid) tsave.worldid = "";
+    overlaySandbox(tsave, test);
+    em.persist(tsave);
+    await em.flush();
+    await joinNewWorldMap(test, tsave, em);
+
+    // 6. Report.
+    const vcell = await homeCellFor(victim.userid);
+    const tcell = await homeCellFor(TEST_USERID);
+    em.clear();
+    const freshV = await em.findOne(Save, { userid: victim.userid, type: BaseType.MAIN });
+
+    console.log("\n===========================================================");
+    console.log(" MR3 attack test ready");
+    console.log("===========================================================");
+    console.log(` World uuid   : ${freshV?.worldid}`);
+    console.log(` Opponent     : ${VICTIM_NAME} / ${VICTIM_EMAIL} / ${VICTIM_PASS}`);
+    console.log(`   userid ${victim.userid}  baseid ${freshV?.baseid}  cell (${vcell?.x}, ${vcell?.y})`);
+    console.log(` test (userid 1) cell (${tcell?.x}, ${tcell?.y}), now mapversion V3`);
+    console.log("");
+    console.log(" Log in as `test`, open the Map Room, find `victim`'s base and attack it.");
+    console.log(" After the attack ends, the battle report lands in bym.attack_logs;");
+    console.log(" check it with:");
+    console.log(`   SELECT id, attackid, loot, jsonb_pretty(attackreport)`);
+    console.log(`     FROM bym.attack_logs ORDER BY id DESC LIMIT 1;`);
+    console.log("===========================================================\n");
+  });
+
+  await postgres.orm.close(true);
+  process.exit(0);
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/scripts/verify-battle-report.ts
+++ b/server/scripts/verify-battle-report.ts
@@ -1,0 +1,255 @@
+/**
+ * THROWAWAY end-to-end verification for PR 1a "attack battle reports".
+ *
+ * Exercises the real server pipeline against local Postgres + Redis WITHOUT
+ * standing up the HTTP server:
+ *   seed attack_logs row -> persistBattleReport() -> re-fetch + assert
+ *   -> negative cases -> decodeAttackReport() -> cleanup.
+ *
+ * Run from server/:  bun scripts/verify-battle-report.ts
+ *
+ * Note on wiring: persistBattleReport.ts reads the module-level `postgres` /
+ * `redis` from src/server.ts, so that module (and its IIFE) is unavoidably in the
+ * import graph. We neutralise the IIFE's port bind by forcing PORT=0 before the
+ * import (ephemeral throwaway port, never clashes with a running dev server), and
+ * we let the IIFE perform the single MikroORM.init. We then wait for
+ * `postgres.orm` to be ready and run all DB work inside a RequestContext so the
+ * global EntityManager is usable with allowGlobalContext:false.
+ */
+
+process.env.PORT = "0";
+
+import { RequestContext } from "@mikro-orm/core";
+import { postgres, redis } from "../src/server.js";
+import { AttackLogs } from "../src/models/attacklogs.model.js";
+import { persistBattleReport } from "../src/services/attacklogs/persistBattleReport.js";
+import { decodeAttackReport } from "../src/services/attacklogs/attackReportCodec.js";
+
+let pass = 0;
+let fail = 0;
+const check = (name: string, cond: boolean, detail = "") => {
+  if (cond) {
+    pass++;
+    console.log(`PASS  ${name}`);
+  } else {
+    fail++;
+    console.log(`FAIL  ${name}${detail ? `  -- ${detail}` : ""}`);
+  }
+};
+const eq = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b);
+
+const DEFENDER = 999001;
+
+const goodReport = {
+  v: 1,
+  d: 73,
+  dur: 88,
+  o: 1,
+  loot: [12000, 3400, 0, 900],
+  b: [
+    { t: 24, x: 100, y: 200, hp: 0, mhp: 1200, l: 5400 },
+    { t: 8, x: 50, y: 60, hp: 120, mhp: 900 },
+  ],
+  atk: { m: [[6, 40], [19, 12]], c: 2 },
+  s: [[0, 2]],
+  cat: [[7, 1]],
+};
+
+const waitForOrm = async () => {
+  for (let i = 0; i < 120; i++) {
+    if (postgres.orm && postgres.em) return;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error("postgres.orm never became ready (server.ts IIFE init timed out)");
+};
+
+const main = async () => {
+  // Step 1 - stack up
+  await waitForOrm();
+  let redisOk = false;
+  try {
+    const pong = await redis.send("PING", []);
+    redisOk = String(pong).toUpperCase().includes("PONG");
+  } catch {
+    redisOk = false;
+  }
+  check("Step 1: Redis reachable (PING)", redisOk);
+  check("Step 1: Postgres/MikroORM ready", !!postgres.orm && !!postgres.em);
+
+  await RequestContext.create(postgres.orm.em, async () => {
+    const em = postgres.em;
+
+    // pre-clean any leftovers from a previous run
+    await em.nativeDelete(AttackLogs, { defender_userid: DEFENDER });
+
+    // Step 2 - seed the primary row
+    const rowA = em.create(AttackLogs, {
+      attacker_userid: 1,
+      attacker_username: "test",
+      defender_userid: DEFENDER,
+      defender_username: "e2e-victim",
+      type: "main",
+      attackid: 55555,
+      loot: {},
+      attackreport: {},
+      attacktime: new Date(),
+    });
+    // second row for the malformed-report negative case
+    const rowB = em.create(AttackLogs, {
+      attacker_userid: 1,
+      attacker_username: "test",
+      defender_userid: DEFENDER,
+      defender_username: "e2e-victim",
+      type: "main",
+      attackid: 55556,
+      loot: {},
+      attackreport: {},
+      attacktime: new Date(),
+    });
+    await em.flush();
+    check("Step 2: seeded two attack_logs rows", !!rowA.id && !!rowB.id);
+
+    // Step 3/4 - persist a realistic compact report against attackid 55555
+    await persistBattleReport({
+      attackerUserId: 1,
+      defenderUserId: DEFENDER,
+      attackId: 55555,
+      rawReport: goodReport,
+    });
+    await em.flush();
+
+    // Step 5 - re-fetch in a fresh fork and assert
+    let snapshotA = "";
+    {
+      const fork = postgres.orm.em.fork();
+      const row = await fork.findOne(AttackLogs, {
+        defender_userid: DEFENDER,
+        attackid: 55555,
+      });
+      snapshotA = JSON.stringify(row?.attackreport);
+      check("Step 5: row re-fetched", !!row);
+      check(
+        "Step 5: attackreport.v === 1",
+        !!row && (row.attackreport as any).v === 1,
+        row ? `got ${JSON.stringify((row.attackreport as any).v)}` : "no row"
+      );
+      check(
+        "Step 5: loot deep-equals {r1:12000,r2:3400,r3:0,r4:900}",
+        !!row && eq(row.loot, { r1: 12000, r2: 3400, r3: 0, r4: 900 }),
+        row ? JSON.stringify(row.loot) : "no row"
+      );
+    }
+
+    // Step 6a - unknown attackid: must not throw, must not touch row 55555
+    let threw = false;
+    try {
+      await persistBattleReport({
+        attackerUserId: 1,
+        defenderUserId: DEFENDER,
+        attackId: 44444,
+        rawReport: goodReport,
+      });
+      await em.flush();
+    } catch {
+      threw = true;
+    }
+    check("Step 6a: unknown attackid does not throw", !threw);
+    {
+      const fork = postgres.orm.em.fork();
+      const row = await fork.findOne(AttackLogs, {
+        defender_userid: DEFENDER,
+        attackid: 55555,
+      });
+      check(
+        "Step 6a: row 55555 attackreport still the good report (v===1, byte-identical to pre-noop snapshot)",
+        !!row &&
+          (row.attackreport as any).v === 1 &&
+          JSON.stringify(row.attackreport) === snapshotA,
+        row ? JSON.stringify(row.attackreport) : "no row"
+      );
+    }
+
+    // Step 6b - malformed report {v:2} against a second seeded row (55556):
+    // must not throw, row's attackreport must stay {}
+    threw = false;
+    try {
+      await persistBattleReport({
+        attackerUserId: 1,
+        defenderUserId: DEFENDER,
+        attackId: 55556,
+        rawReport: { v: 2 },
+      });
+      await em.flush();
+    } catch {
+      threw = true;
+    }
+    check("Step 6b: malformed report does not throw", !threw);
+    {
+      const fork = postgres.orm.em.fork();
+      const row = await fork.findOne(AttackLogs, {
+        defender_userid: DEFENDER,
+        attackid: 55556,
+      });
+      check(
+        "Step 6b: row 55556 attackreport still {} (untouched)",
+        !!row && eq(row.attackreport, {})
+      );
+    }
+
+    // Step 7 - decode the stored good blob directly
+    {
+      const fork = postgres.orm.em.fork();
+      const row = await fork.findOne(AttackLogs, {
+        defender_userid: DEFENDER,
+        attackid: 55555,
+      });
+      const view = decodeAttackReport(row!.attackreport as any);
+      check("Step 7: outcome === 'timeout'", view.outcome === "timeout", view.outcome);
+      check("Step 7: buildings.length === 2", view.buildings.length === 2, `${view.buildings.length}`);
+      check(
+        "Step 7: buildings[0].looted === 5400",
+        view.buildings[0]?.looted === 5400,
+        `${view.buildings[0]?.looted}`
+      );
+      check(
+        "Step 7: attackingForce.monsters === [C7x40, IC1x12]",
+        eq(view.attackingForce.monsters, [
+          { monster: "C7", count: 40 },
+          { monster: "IC1", count: 12 },
+        ]),
+        JSON.stringify(view.attackingForce.monsters)
+      );
+      check(
+        "Step 7: attackingForce.champion === 'Fomor'",
+        view.attackingForce.champion === "Fomor",
+        `${view.attackingForce.champion}`
+      );
+      check(
+        "Step 7: siege === [{type:'decoy',count:2}]",
+        eq(view.siege, [{ type: "decoy", count: 2 }]),
+        JSON.stringify(view.siege)
+      );
+      check(
+        "Step 7: catapult === [{powerUp:'pu0',count:1}]",
+        eq(view.catapult, [{ powerUp: "pu0", count: 1 }]),
+        JSON.stringify(view.catapult)
+      );
+    }
+
+    // Step 8 - cleanup
+    const deleted = await em.nativeDelete(AttackLogs, { defender_userid: DEFENDER });
+    check("Step 8: cleanup removed seeded rows", deleted >= 2, `deleted ${deleted}`);
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  await postgres.orm.close(true);
+  try {
+    redis.close();
+  } catch {}
+  process.exit(fail === 0 ? 0 : 1);
+};
+
+main().catch((e) => {
+  console.error("verify-battle-report crashed:", e);
+  process.exit(1);
+});

--- a/server/scripts/verify-battle-report.ts
+++ b/server/scripts/verify-battle-report.ts
@@ -10,14 +10,16 @@
  *
  * Note on wiring: persistBattleReport.ts reads the module-level `postgres` /
  * `redis` from src/server.ts, so that module (and its IIFE) is unavoidably in the
- * import graph. We neutralise the IIFE's port bind by forcing PORT=0 before the
- * import (ephemeral throwaway port, never clashes with a running dev server), and
- * we let the IIFE perform the single MikroORM.init. We then wait for
- * `postgres.orm` to be ready and run all DB work inside a RequestContext so the
- * global EntityManager is usable with allowGlobalContext:false.
+ * import graph. We neutralise the IIFE's port bind via the ./_forceEphemeralPort
+ * side-effect import (PORT=0 — ephemeral throwaway port, never clashes with a
+ * running dev server), and we let the IIFE perform the single MikroORM.init. We
+ * then wait for `postgres.orm` to be ready and run all DB work inside a
+ * RequestContext so the global EntityManager is usable with allowGlobalContext:false.
  */
 
-process.env.PORT = "0";
+// MUST be the first import: sets PORT=0 before src/server.js is evaluated (import
+// hoisting means a bare `process.env.PORT = "0"` statement here would run too late).
+import "./_forceEphemeralPort.js";
 
 import { RequestContext } from "@mikro-orm/core";
 import { postgres, redis } from "../src/server.js";
@@ -109,14 +111,17 @@ const main = async () => {
     await em.flush();
     check("Step 2: seeded two attack_logs rows", !!rowA.id && !!rowB.id);
 
-    // Step 3/4 - persist a realistic compact report against attackid 55555
-    await persistBattleReport({
+    // Step 3/4 - persist a realistic compact report against attackid 55555.
+    // persistBattleReport no longer busts caches itself (I3): it returns the keys
+    // and the caller deletes them AFTER the flush. Mirror baseSave's flow here.
+    const bustKeys = await persistBattleReport({
       attackerUserId: 1,
       defenderUserId: DEFENDER,
       attackId: 55555,
       rawReport: goodReport,
     });
     await em.flush();
+    if (bustKeys) await Promise.all(bustKeys.map((k) => redis.del(k)));
 
     // Step 5 - re-fetch in a fresh fork and assert
     let snapshotA = "";

--- a/server/src/app.routes.ts
+++ b/server/src/app.routes.ts
@@ -61,6 +61,7 @@ import { saveTemplate } from "./controllers/yardplanner/saveTemplate.js";
 import { getAvailableWorlds } from "./controllers/leaderboards/getAvailableWorlds.js";
 import { getLeaderboards } from "./controllers/leaderboards/getLeaderboards.js";
 import { getAttackLogs } from "./controllers/attacklogs/getAttackLogs.js";
+import { getAttackLogDetail } from "./controllers/attacklogs/getAttackLogDetail.js";
 
 import { wildMonsterInvasion } from "./controllers/events/wildMonsterInvasion.js";
 import { recordDebugData } from "./controllers/debug/recordDebugData.js";
@@ -146,6 +147,7 @@ router.post("/api/:apiVersion/bm/yardplanner/savetemplate", apiVersion, verifyUs
 router.get("/api/:apiVersion/worlds", publicReadLimiter, getAvailableWorlds);
 router.get("/api/:apiVersion/leaderboards", publicReadLimiter, getLeaderboards);
 router.get("/api/:apiVersion/attacklogs", verifyUserAuth, getAttackLogs);
+router.get("/api/:apiVersion/attacklogs/:id", verifyUserAuth, getAttackLogDetail);
 
 /**  ────────────────────────────────────────────────
 * 📦 Events

--- a/server/src/controllers/attacklogs/getAttackLogDetail.ts
+++ b/server/src/controllers/attacklogs/getAttackLogDetail.ts
@@ -1,0 +1,66 @@
+import { Status } from "../../enums/StatusCodes.js";
+import { loadFailureErr, permissionErr } from "../../errors/errors.js";
+import { AttackLogs } from "../../models/attacklogs.model.js";
+import { postgres, redis } from "../../server.js";
+import { decodeAttackReport } from "../../services/attacklogs/attackReportCodec.js";
+import { CompactAttackReportSchema } from "../../schemas/AttackReportSchema.js";
+import type { KoaController } from "../../utils/KoaController.js";
+import type { User } from "../../models/user.model.js";
+
+/** 30 minutes, matching getAttackLogs. */
+const DETAIL_CACHE_TTL = 1800;
+
+/**
+ * GET /api/:apiVersion/attacklogs/:id
+ *
+ * Returns the decoded battle report for one attack_logs row, for the attacker or
+ * the defender only. Rows with no stored report return { report: null } so the
+ * launcher can show a "no report available" state.
+ */
+export const getAttackLogDetail: KoaController = async (ctx) => {
+  const { userid }: User = ctx.authUser;
+  const id = Number((ctx.params as { id?: string }).id);
+
+  if (!Number.isInteger(id) || id <= 0) throw loadFailureErr();
+
+  const cacheKey = `attackLogDetail:${id}`;
+  const cached = await redis.get(cacheKey);
+  if (cached) {
+    const payload = JSON.parse(cached);
+    if (payload.attacker === userid || payload.defender === userid) {
+      ctx.status = Status.OK;
+      ctx.body = { report: payload.report };
+      return;
+    }
+  }
+
+  const row = await postgres.em.findOne(AttackLogs, { id });
+  if (!row) throw loadFailureErr();
+
+  if (row.attacker_userid !== userid && row.defender_userid !== userid) {
+    throw permissionErr();
+  }
+
+  const stored = row.attackreport;
+  const hasReport =
+    stored && typeof stored === "object" && Object.keys(stored).length > 0;
+
+  let report = null;
+  if (hasReport) {
+    const parsed = CompactAttackReportSchema.safeParse(stored);
+    report = parsed.success ? decodeAttackReport(parsed.data) : null;
+  }
+
+  await redis.setex(
+    cacheKey,
+    DETAIL_CACHE_TTL,
+    JSON.stringify({
+      attacker: row.attacker_userid,
+      defender: row.defender_userid,
+      report,
+    })
+  );
+
+  ctx.status = Status.OK;
+  ctx.body = { report };
+};

--- a/server/src/controllers/attacklogs/getAttackLogs.ts
+++ b/server/src/controllers/attacklogs/getAttackLogs.ts
@@ -25,7 +25,10 @@ export const getAttackLogs: KoaController = async (ctx) => {
   const { userid }: User = ctx.authUser;
 
   const filterType = (filter as string) || "both";
-  const cacheKey = `attackLogs:${userid}:${filter}`;
+  // Key on the normalised filterType, not the raw query string: `?filter=garbage`
+  // falls through to `both` data, and keying it under `garbage` would cache that
+  // under a key persistBattleReport can never bust.
+  const cacheKey = `attackLogs:${userid}:${filterType}`;
 
   try {
     const cachedAttackLogs = await redis.get(cacheKey);
@@ -58,9 +61,27 @@ export const getAttackLogs: KoaController = async (ctx) => {
         break;
     }
 
+    // Explicit projection: the list view never needs the (potentially large)
+    // `attackreport` jsonb — that is served per-row by GET /attacklogs/:id — and
+    // `attackid` is an internal correlation key. Excluding `attackreport` here
+    // also keeps it out of the 30-minute Redis cache.
     const attackLogs = await postgres.em.find(AttackLogs, whereCondition, {
       orderBy: { attacktime: "DESC" },
       limit: 50,
+      fields: [
+        "id",
+        "attacker_userid",
+        "attacker_username",
+        "attacker_pic_square",
+        "defender_userid",
+        "defender_username",
+        "defender_pic_square",
+        "type",
+        "x",
+        "y",
+        "loot",
+        "attacktime",
+      ],
     });
 
     await redis.setex(cacheKey, AL_CACHE_TTL, JSON.stringify(attackLogs));

--- a/server/src/controllers/base/save/baseSave.ts
+++ b/server/src/controllers/base/save/baseSave.ts
@@ -188,8 +188,11 @@ export const baseSave: KoaController = async (ctx) => {
 
     // Bust the attack-log caches only AFTER the row is flushed, so a concurrent
     // GET /attacklogs in the gap can't re-cache the pre-report row for 30 min.
+    // Best-effort: a Redis fault here must not fail a save already committed to Postgres.
     if (battleReportCacheKeys?.length) {
-      await Promise.all(battleReportCacheKeys.map((k) => redis.del(k)));
+      await Promise.all(
+        battleReportCacheKeys.map((k) => redis.del(k).catch(() => {})),
+      );
     }
 
     // MR3 Takeover Logic:

--- a/server/src/controllers/base/save/baseSave.ts
+++ b/server/src/controllers/base/save/baseSave.ts
@@ -173,8 +173,9 @@ export const baseSave: KoaController = async (ctx) => {
       postgres.em.persist(lootTarget);
     }
 
+    let battleReportCacheKeys: string[] | null = null;
     if (saveData.over) {
-      await persistBattleReport({
+      battleReportCacheKeys = await persistBattleReport({
         attackerUserId: user.userid,
         defenderUserId: baseSave.saveuserid,
         attackId: Number(saveData.attackid),
@@ -184,6 +185,12 @@ export const baseSave: KoaController = async (ctx) => {
 
     postgres.em.persist(userSave);
     await postgres.em.flush();
+
+    // Bust the attack-log caches only AFTER the row is flushed, so a concurrent
+    // GET /attacklogs in the gap can't re-cache the pre-report row for 30 min.
+    if (battleReportCacheKeys?.length) {
+      await Promise.all(battleReportCacheKeys.map((k) => redis.del(k)));
+    }
 
     // MR3 Takeover Logic:
     // If the attack is over and damage >= 90, trigger takeover or destroy logic.

--- a/server/src/controllers/base/save/baseSave.ts
+++ b/server/src/controllers/base/save/baseSave.ts
@@ -16,6 +16,7 @@ import { permissionErr, saveFailureErr } from "../../../errors/errors.js";
 import { attackLootHandler } from "./handlers/attackLootHandler.js";
 import { defenderLootHandler } from "./handlers/defenderLootHandler.js";
 import { monsterUpdateHandler } from "./handlers/monsterUpdateHandler.js";
+import { persistBattleReport } from "../../../services/attacklogs/persistBattleReport.js";
 import { validateSave } from "../../../scripts/anticheat/anticheat.js";
 import { getOutpostOwnerSave } from "../../../services/base/getOutpostOwnerSave.js";
 import { championHandler } from "./handlers/championHandler.js";
@@ -170,6 +171,15 @@ export const baseSave: KoaController = async (ctx) => {
 
       defenderLootHandler(saveData.resources, lootTarget);
       postgres.em.persist(lootTarget);
+    }
+
+    if (saveData.over) {
+      await persistBattleReport({
+        attackerUserId: user.userid,
+        defenderUserId: baseSave.saveuserid,
+        attackId: Number(saveData.attackid),
+        rawReport: saveData.battlereport,
+      });
     }
 
     postgres.em.persist(userSave);

--- a/server/src/database/migrations/20260829_AddAttackIdToAttackLogs.ts
+++ b/server/src/database/migrations/20260829_AddAttackIdToAttackLogs.ts
@@ -1,0 +1,26 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * Adds attack_logs.attackid — the join key between an attack_logs row (created at
+ * attack start in baseModeAttack / infernoModeAttack) and the battle report that
+ * arrives later on the attacker's base-save request. save.attackid is a random
+ * 1–99999 set immediately before createAttackLog, and the client echoes it back
+ * as saveData.attackid on the final save.
+ */
+export class AddAttackIdToAttackLogs extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "bym"."attack_logs"
+        ADD COLUMN IF NOT EXISTS "attackid" integer NULL;
+    `);
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "attack_logs_attackid_index"
+        ON "bym"."attack_logs" ("attackid");
+    `);
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`DROP INDEX IF EXISTS "bym"."attack_logs_attackid_index";`);
+    this.addSql(`ALTER TABLE "bym"."attack_logs" DROP COLUMN IF EXISTS "attackid";`);
+  }
+}

--- a/server/src/models/attacklogs.model.ts
+++ b/server/src/models/attacklogs.model.ts
@@ -30,6 +30,9 @@ export class AttackLogs {
   type!: string;
 
   @Property({ type: 'number', nullable: true })
+  attackid?: number;
+
+  @Property({ type: 'number', nullable: true })
   x?: number;
 
   @Property({ type: 'number', nullable: true })

--- a/server/src/schemas/AttackReportSchema.test.ts
+++ b/server/src/schemas/AttackReportSchema.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test";
+import { CompactAttackReportSchema } from "./AttackReportSchema.js";
+
+const valid = () => ({
+  v: 1,
+  d: 87,
+  dur: 143,
+  o: 1,
+  loot: [12000, 4300, 0, 900],
+  b: [{ t: 24, x: 15, y: 20, hp: 0, mhp: 1200, l: 5400 }],
+  atk: { m: [[3, 40], [7, 12]], c: 2 },
+  s: [[0, 3]],
+  cat: [[8, 2]],
+});
+
+test("accepts a well-formed report", () => {
+  expect(CompactAttackReportSchema.safeParse(valid()).success).toBe(true);
+});
+
+test("accepts a minimal report (no optional keys)", () => {
+  const r = { v: 1, d: 0, dur: 0, o: 0, loot: [0, 0, 0, 0], b: [], atk: { m: [], c: -1 } };
+  expect(CompactAttackReportSchema.safeParse(r).success).toBe(true);
+});
+
+test("rejects a wrong schema version", () => {
+  expect(CompactAttackReportSchema.safeParse({ ...valid(), v: 2 }).success).toBe(false);
+});
+
+test("rejects more than 600 building entries", () => {
+  const b = Array.from({ length: 601 }, () => ({ t: 1, x: 0, y: 0, hp: 0, mhp: 1 }));
+  expect(CompactAttackReportSchema.safeParse({ ...valid(), b }).success).toBe(false);
+});
+
+test("rejects a negative loot value", () => {
+  expect(CompactAttackReportSchema.safeParse({ ...valid(), loot: [-1, 0, 0, 0] }).success).toBe(false);
+});
+
+test("rejects loot that is not a 4-tuple", () => {
+  expect(CompactAttackReportSchema.safeParse({ ...valid(), loot: [1, 2, 3] }).success).toBe(false);
+});
+
+test("rejects an oversized ml array on a building", () => {
+  const ml = Array.from({ length: 31 }, () => [0, 1]);
+  const b = [{ t: 1, x: 0, y: 0, hp: 0, mhp: 1, ml }];
+  expect(CompactAttackReportSchema.safeParse({ ...valid(), b }).success).toBe(false);
+});
+
+test("strips unknown top-level keys", () => {
+  const parsed = CompactAttackReportSchema.parse({ ...valid(), bogus: 123 });
+  expect("bogus" in parsed).toBe(false);
+});

--- a/server/src/schemas/AttackReportSchema.ts
+++ b/server/src/schemas/AttackReportSchema.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+/**
+ * Compact attack battle report — the exact shape the AS3 client uploads as
+ * `saveData.battlereport` and that is stored verbatim in attack_logs.attackreport.
+ *
+ * Lenient on presence (the report is best-effort), strict on magnitude (a tampered
+ * client must not be able to bloat the table). Unknown keys are stripped, not
+ * rejected, so a future additive client field never breaks an older server.
+ *
+ * See docs/superpowers/specs/2026-08-29-attack-battle-reports-design.md.
+ */
+
+const int = (min: number, max: number) => z.number().int().min(min).max(max);
+
+const pair = z.tuple([int(0, 100_000), int(0, 1_000_000)]);
+
+const building = z
+  .object({
+    t: int(0, 100_000),
+    x: int(-100_000, 100_000),
+    y: int(-100_000, 100_000),
+    hp: int(0, 2_000_000_000),
+    mhp: int(0, 2_000_000_000),
+    l: int(0, 2_000_000_000).optional(),
+    dd: int(0, 2_000_000_000).optional(),
+    k: int(0, 1_000_000).optional(),
+    ml: z.array(pair).max(30).optional(),
+  })
+  .strip();
+
+export const CompactAttackReportSchema = z
+  .object({
+    v: z.literal(1),
+    d: int(0, 100),
+    dur: int(0, 86_400),
+    o: int(0, 2),
+    loot: z.tuple([
+      int(0, 2_000_000_000),
+      int(0, 2_000_000_000),
+      int(0, 2_000_000_000),
+      int(0, 2_000_000_000),
+    ]),
+    b: z.array(building).max(600),
+    atk: z
+      .object({
+        m: z.array(pair).max(60),
+        c: int(-1, 1_000),
+        ml: z.array(pair).max(60).optional(),
+      })
+      .strip(),
+    s: z.array(pair).max(10).optional(),
+    cat: z.array(pair).max(20).optional(),
+  })
+  .strip();
+
+export type CompactAttackReport = z.infer<typeof CompactAttackReportSchema>;

--- a/server/src/schemas/BaseSaveSchema.ts
+++ b/server/src/schemas/BaseSaveSchema.ts
@@ -97,7 +97,14 @@ export const BaseSaveSchema = z.object({
   battlereport: z
     .string()
     .optional()
-    .transform((data) => (data ? JSON.parse(data) : undefined)),
+    .transform((data) => {
+      if (!data) return undefined;
+      try {
+        return JSON.parse(data);
+      } catch {
+        return undefined;
+      }
+    }),
 
   /**
    * The resource delta for the base being saved. During an attack this is the

--- a/server/src/schemas/BaseSaveSchema.ts
+++ b/server/src/schemas/BaseSaveSchema.ts
@@ -89,6 +89,17 @@ export const BaseSaveSchema = z.object({
     .transform((data) => (data ? (JSON.parse(data) as Resources) : undefined)),
 
   /**
+   * The structured battle report — a compact enum-coded JSON string produced by
+   * AttackReport.Serialize() on the attacking client. Parsed here but NOT validated;
+   * persistBattleReport validates it against CompactAttackReportSchema so a malformed
+   * report never rejects the whole save.
+   */
+  battlereport: z
+    .string()
+    .optional()
+    .transform((data) => (data ? JSON.parse(data) : undefined)),
+
+  /**
    * The resource delta for the base being saved. During an attack this is the
    * defender's, reported by the attacking client.
    * @type {Resources | undefined}

--- a/server/src/services/attacklogs/attackReportCodec.test.ts
+++ b/server/src/services/attacklogs/attackReportCodec.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import type { CompactAttackReport } from "../../schemas/AttackReportSchema.js";
+import { decodeAttackReport } from "./attackReportCodec.js";
+
+const compact: CompactAttackReport = {
+  v: 1,
+  d: 87,
+  dur: 143,
+  o: 2,
+  loot: [12000, 4300, 0, 900],
+  b: [
+    { t: 24, x: 15, y: 20, hp: 0, mhp: 1200, l: 5400 },
+    { t: 8, x: 3, y: 4, hp: 50, mhp: 900 },
+  ],
+  atk: { m: [[6, 40], [19, 12]], c: 2 }, // index 6 = C7, index 19 = IC1, champion 2 = G3 = Fomor
+  s: [[0, 3]],   // SIEGE_ENUM[0] = "decoy"
+  cat: [[7, 2]], // POWERUP_ENUM[7] = "pu0"
+};
+
+test("expands every field to the friendly view", () => {
+  const v = decodeAttackReport(compact);
+  expect(v.version).toBe(1);
+  expect(v.damagePercent).toBe(87);
+  expect(v.durationSeconds).toBe(143);
+  expect(v.outcome).toBe("flattened");
+  expect(v.lootTotals).toEqual({ r1: 12000, r2: 4300, r3: 0, r4: 900 });
+
+  expect(v.buildings[0]).toEqual({
+    type: 24, x: 15, y: 20, hp: 0, maxHp: 1200,
+    looted: 5400, damageDealt: 0, kills: 0, monstersLost: [],
+  });
+  expect(v.buildings[1].looted).toBe(0);
+
+  expect(v.attackingForce.monsters).toEqual([
+    { monster: "C7", count: 40 },
+    { monster: "IC1", count: 12 },
+  ]);
+  expect(v.attackingForce.champion).toBe("Fomor");
+  expect(v.attackingForce.monsterLosses).toEqual([]);
+
+  expect(v.siege).toEqual([{ type: "decoy", count: 3 }]);
+  expect(v.catapult).toEqual([{ powerUp: "pu0", count: 2 }]);
+});
+
+test("champion -1 decodes to null", () => {
+  const v = decodeAttackReport({ ...compact, atk: { m: [], c: -1 } });
+  expect(v.attackingForce.champion).toBeNull();
+});
+
+test("outcome 0 and 1 map correctly", () => {
+  expect(decodeAttackReport({ ...compact, o: 0 }).outcome).toBe("retreat");
+  expect(decodeAttackReport({ ...compact, o: 1 }).outcome).toBe("timeout");
+});
+
+test("an out-of-range enum id decodes to 'unknown'", () => {
+  const v = decodeAttackReport({ ...compact, atk: { m: [[999, 1]], c: 999 } });
+  expect(v.attackingForce.monsters[0].monster).toBe("unknown");
+  expect(v.attackingForce.champion).toBe("unknown");
+});

--- a/server/src/services/attacklogs/attackReportCodec.ts
+++ b/server/src/services/attacklogs/attackReportCodec.ts
@@ -1,0 +1,85 @@
+import { championStats } from "../../game-data/stats/championStats.js";
+import type { CompactAttackReport } from "../../schemas/AttackReportSchema.js";
+import {
+  CHAMPION_ENUM,
+  MONSTER_ENUM,
+  POWERUP_ENUM,
+  SIEGE_ENUM,
+} from "./attackReportEnums.js";
+
+export interface AttackReportView {
+  version: number;
+  damagePercent: number;
+  durationSeconds: number;
+  outcome: "retreat" | "timeout" | "flattened";
+  lootTotals: { r1: number; r2: number; r3: number; r4: number };
+  buildings: Array<{
+    type: number;
+    x: number;
+    y: number;
+    hp: number;
+    maxHp: number;
+    looted: number;
+    damageDealt: number;
+    kills: number;
+    monstersLost: Array<{ monster: string; count: number }>;
+  }>;
+  attackingForce: {
+    monsters: Array<{ monster: string; count: number }>;
+    champion: string | null;
+    monsterLosses: Array<{ monster: string; count: number }>;
+  };
+  siege: Array<{ type: string; count: number }>;
+  catapult: Array<{ powerUp: string; count: number }>;
+}
+
+const OUTCOMES = ["retreat", "timeout", "flattened"] as const;
+
+const at = (table: readonly string[], i: number) => table[i] ?? "unknown";
+
+const monsterCounts = (pairs: ReadonlyArray<readonly [number, number]> = []) =>
+  pairs.map(([id, count]) => ({ monster: at(MONSTER_ENUM, id), count }));
+
+/**
+ * Expands a stored compact battle report into the shape the launcher renders.
+ * Absent optionals become 0 / []. Out-of-range enum ids become "unknown" rather
+ * than throwing — a report is best-effort data, not a contract.
+ */
+export const decodeAttackReport = (c: CompactAttackReport): AttackReportView => {
+  const championKey = c.atk.c === -1 ? null : CHAMPION_ENUM[c.atk.c];
+  const champion =
+    c.atk.c === -1
+      ? null
+      : championKey
+        ? (championStats[championKey as keyof typeof championStats]?.name ?? championKey)
+        : "unknown";
+
+  return {
+    version: c.v,
+    damagePercent: c.d,
+    durationSeconds: c.dur,
+    outcome: OUTCOMES[c.o] ?? "timeout",
+    lootTotals: { r1: c.loot[0], r2: c.loot[1], r3: c.loot[2], r4: c.loot[3] },
+    buildings: c.b.map((b) => ({
+      type: b.t,
+      x: b.x,
+      y: b.y,
+      hp: b.hp,
+      maxHp: b.mhp,
+      looted: b.l ?? 0,
+      damageDealt: b.dd ?? 0,
+      kills: b.k ?? 0,
+      monstersLost: monsterCounts(b.ml),
+    })),
+    attackingForce: {
+      monsters: monsterCounts(c.atk.m),
+      champion,
+      monsterLosses: monsterCounts(c.atk.ml),
+    },
+    siege: (c.s ?? []).map(([id, count]) => ({ type: at(SIEGE_ENUM, id), count })),
+    catapult: (c.cat ?? []).map(([id, count]) => ({
+      powerUp: at(POWERUP_ENUM, id),
+      count,
+    })),
+  };
+};

--- a/server/src/services/attacklogs/attackReportEnums.fixture.json
+++ b/server/src/services/attacklogs/attackReportEnums.fixture.json
@@ -1,0 +1,10 @@
+{
+  "monsters": [
+    "C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10",
+    "C11", "C12", "C13", "C14", "C15", "C16", "C17", "C18", "C19",
+    "IC1", "IC2", "IC3", "IC4", "IC5", "IC6", "IC7", "IC8"
+  ],
+  "champions": ["G1", "G2", "G3", "G4", "G5"],
+  "siege": ["decoy", "vacuum", "jars"],
+  "powerups": ["tw0", "tw1", "tw2", "pb0", "pb1", "pb2", "pb3", "pu0", "pu1", "pu2", "pu3"]
+}

--- a/server/src/services/attacklogs/attackReportEnums.test.ts
+++ b/server/src/services/attacklogs/attackReportEnums.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import fixture from "./attackReportEnums.fixture.json" with { type: "json" };
+import {
+  CHAMPION_ENUM,
+  MONSTER_ENUM,
+  POWERUP_ENUM,
+  SIEGE_ENUM,
+} from "./attackReportEnums.js";
+
+test("enum arrays match the shared fixture exactly", () => {
+  // @ts-ignore - fixture is generic string[], enums have literal types, but values match
+  expect(Array.from(MONSTER_ENUM)).toEqual(fixture.monsters);
+  // @ts-ignore
+  expect(Array.from(CHAMPION_ENUM)).toEqual(fixture.champions);
+  // @ts-ignore
+  expect(Array.from(SIEGE_ENUM)).toEqual(fixture.siege);
+  // @ts-ignore
+  expect(Array.from(POWERUP_ENUM)).toEqual(fixture.powerups);
+});
+
+test("no enum array has duplicate entries", () => {
+  for (const arr of [MONSTER_ENUM, CHAMPION_ENUM, SIEGE_ENUM, POWERUP_ENUM]) {
+    expect(new Set(arr).size).toBe(arr.length);
+  }
+});

--- a/server/src/services/attacklogs/attackReportEnums.ts
+++ b/server/src/services/attacklogs/attackReportEnums.ts
@@ -1,0 +1,29 @@
+/**
+ * Enum tables for the compact attack battle report.
+ *
+ * APPEND-ONLY. Never reorder or remove an entry — the index IS the wire value,
+ * and old reports stored in attack_logs.attackreport reference it by position.
+ *
+ * The single source of truth is attackReportEnums.fixture.json; this file and the
+ * AS3 mirror (client/scripts/AttackReportEnums.as) are both checked against it.
+ *
+ * Sources:
+ *  - monsters:  server/src/game-data/stats/monsterStats.ts key order (C1..C19, IC1..IC8)
+ *  - champions: server/src/game-data/stats/championStats.ts (G1..G5)
+ *  - siege:     client/scripts/com/monsters/siege/weapons/{Decoy,Vacuum,Jars}.as ID
+ *  - powerups:  client/scripts/com/monsters/effects/ResourceBombs.as catapult-item list
+ */
+
+export const MONSTER_ENUM = [
+  "C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10",
+  "C11", "C12", "C13", "C14", "C15", "C16", "C17", "C18", "C19",
+  "IC1", "IC2", "IC3", "IC4", "IC5", "IC6", "IC7", "IC8",
+] as const;
+
+export const CHAMPION_ENUM = ["G1", "G2", "G3", "G4", "G5"] as const;
+
+export const SIEGE_ENUM = ["decoy", "vacuum", "jars"] as const;
+
+export const POWERUP_ENUM = [
+  "tw0", "tw1", "tw2", "pb0", "pb1", "pb2", "pb3", "pu0", "pu1", "pu2", "pu3",
+] as const;

--- a/server/src/services/attacklogs/persistBattleReport.ts
+++ b/server/src/services/attacklogs/persistBattleReport.ts
@@ -1,5 +1,5 @@
 import { AttackLogs } from "../../models/attacklogs.model.js";
-import { postgres, redis } from "../../server.js";
+import { postgres } from "../../server.js";
 import { logger } from "../../utils/logger.js";
 import { CompactAttackReportSchema } from "../../schemas/AttackReportSchema.js";
 
@@ -17,19 +17,25 @@ interface Args {
  *
  * Correlates on (attacker, defender, attackid); newest row wins if somehow more
  * than one matches. Does not flush — the caller owns the unit of work.
+ *
+ * Returns the list of Redis keys the caller must delete AFTER it flushes (so a
+ * concurrent GET /attacklogs cannot re-cache the stale row in the gap between
+ * this call and the flush), or `null` when nothing was written.
  */
-export const persistBattleReport = async (args: Args): Promise<void> => {
+export const persistBattleReport = async (
+  args: Args
+): Promise<string[] | null> => {
   const { attackerUserId, defenderUserId, attackId, rawReport } = args;
 
   try {
-    if (rawReport === undefined || rawReport === null) return;
+    if (rawReport === undefined || rawReport === null) return null;
 
     const parsed = CompactAttackReportSchema.safeParse(rawReport);
     if (!parsed.success) {
       logger.debug(
         `Discarding malformed battle report from user ${attackerUserId}: ${parsed.error.message}`
       );
-      return;
+      return null;
     }
 
     // attack_logs.attackid can theoretically be 0 (Save.attackid defaults to 0),
@@ -39,7 +45,7 @@ export const persistBattleReport = async (args: Args): Promise<void> => {
       logger.debug(
         `Battle report from user ${attackerUserId} had no usable attackid (${attackId})`
       );
-      return;
+      return null;
     }
 
     const row = await postgres.em.findOne(
@@ -56,7 +62,7 @@ export const persistBattleReport = async (args: Args): Promise<void> => {
       logger.debug(
         `No attack_logs row for attacker ${attackerUserId} / defender ${defenderUserId} / attackid ${attackId}; battle report dropped`
       );
-      return;
+      return null;
     }
 
     const [r1, r2, r3, r4] = parsed.data.loot;
@@ -64,28 +70,33 @@ export const persistBattleReport = async (args: Args): Promise<void> => {
     row.loot = { r1, r2, r3, r4 };
     postgres.em.persist(row);
 
-    await bustAttackLogCaches(attackerUserId, defenderUserId, row.id);
+    return attackLogCacheKeys(attackerUserId, defenderUserId, row.id);
   } catch (err) {
     logger.warn(
       `persistBattleReport failed for user ${attackerUserId}: ${(err as Error).message}`
     );
+    return null;
   }
 };
 
 /**
- * getAttackLogs caches under attackLogs:<uid>:<filter> for filter in
- * {undefined, myattacks, peopleattackingme, both}; getAttackLogDetail caches
- * under attackLogDetail:<id>. Clear every key this report could have staled.
+ * The Redis keys a persisted battle report staled:
+ *  - getAttackLogs caches under attackLogs:<uid>:<filterType> for filterType in
+ *    {myattacks, peopleattackingme, both} — the three normalised AttackLogFilter
+ *    values (getAttackLogs keys on filterType, never the raw query string).
+ *  - getAttackLogDetail caches under attackLogDetail:<id>.
+ *
+ * The caller deletes these AFTER flushing the row.
  */
-const bustAttackLogCaches = async (
+export const attackLogCacheKeys = (
   attackerUserId: number,
   defenderUserId: number,
   logId: number
-) => {
-  const filters = ["undefined", "myattacks", "peopleattackingme", "both"];
+): string[] => {
+  const filters = ["myattacks", "peopleattackingme", "both"];
   const keys: string[] = [`attackLogDetail:${logId}`];
   for (const uid of [attackerUserId, defenderUserId]) {
     for (const f of filters) keys.push(`attackLogs:${uid}:${f}`);
   }
-  await Promise.all(keys.map((k) => redis.del(k)));
+  return keys;
 };

--- a/server/src/services/attacklogs/persistBattleReport.ts
+++ b/server/src/services/attacklogs/persistBattleReport.ts
@@ -1,0 +1,91 @@
+import { AttackLogs } from "../../models/attacklogs.model.js";
+import { postgres, redis } from "../../server.js";
+import { logger } from "../../utils/logger.js";
+import { CompactAttackReportSchema } from "../../schemas/AttackReportSchema.js";
+
+interface Args {
+  attackerUserId: number;
+  defenderUserId: number;
+  attackId: number;
+  rawReport: unknown;
+}
+
+/**
+ * Validates an uploaded battle report and attaches it to the attack_logs row for
+ * this attack. Best-effort: any problem (missing report, bad shape, no matching
+ * row) is logged and swallowed — the caller's base save must still succeed.
+ *
+ * Correlates on (attacker, defender, attackid); newest row wins if somehow more
+ * than one matches. Does not flush — the caller owns the unit of work.
+ */
+export const persistBattleReport = async (args: Args): Promise<void> => {
+  const { attackerUserId, defenderUserId, attackId, rawReport } = args;
+
+  try {
+    if (rawReport === undefined || rawReport === null) return;
+
+    const parsed = CompactAttackReportSchema.safeParse(rawReport);
+    if (!parsed.success) {
+      logger.debug(
+        `Discarding malformed battle report from user ${attackerUserId}: ${parsed.error.message}`
+      );
+      return;
+    }
+
+    // attack_logs.attackid can theoretically be 0 (Save.attackid defaults to 0),
+    // but baseModeAttack/infernoModeAttack always randomise it to 1–99999 before
+    // createAttackLog, so a real row is always >= 1. Never correlate on 0.
+    if (!Number.isFinite(attackId) || attackId <= 0) {
+      logger.debug(
+        `Battle report from user ${attackerUserId} had no usable attackid (${attackId})`
+      );
+      return;
+    }
+
+    const row = await postgres.em.findOne(
+      AttackLogs,
+      {
+        attacker_userid: attackerUserId,
+        defender_userid: defenderUserId,
+        attackid: attackId,
+      },
+      { orderBy: { attacktime: "DESC" } }
+    );
+
+    if (!row) {
+      logger.debug(
+        `No attack_logs row for attacker ${attackerUserId} / defender ${defenderUserId} / attackid ${attackId}; battle report dropped`
+      );
+      return;
+    }
+
+    const [r1, r2, r3, r4] = parsed.data.loot;
+    row.attackreport = parsed.data;
+    row.loot = { r1, r2, r3, r4 };
+    postgres.em.persist(row);
+
+    await bustAttackLogCaches(attackerUserId, defenderUserId, row.id);
+  } catch (err) {
+    logger.warn(
+      `persistBattleReport failed for user ${attackerUserId}: ${(err as Error).message}`
+    );
+  }
+};
+
+/**
+ * getAttackLogs caches under attackLogs:<uid>:<filter> for filter in
+ * {undefined, myattacks, peopleattackingme, both}; getAttackLogDetail caches
+ * under attackLogDetail:<id>. Clear every key this report could have staled.
+ */
+const bustAttackLogCaches = async (
+  attackerUserId: number,
+  defenderUserId: number,
+  logId: number
+) => {
+  const filters = ["undefined", "myattacks", "peopleattackingme", "both"];
+  const keys: string[] = [`attackLogDetail:${logId}`];
+  for (const uid of [attackerUserId, defenderUserId]) {
+    for (const f of filters) keys.push(`attackLogs:${uid}:${f}`);
+  }
+  await Promise.all(keys.map((k) => redis.del(k)));
+};

--- a/server/src/services/base/createAttackLog.ts
+++ b/server/src/services/base/createAttackLog.ts
@@ -25,6 +25,7 @@ export const createAttackLog = async (attacker: User, defender: User, save: Save
     defender_pic_square: defender.pic_square,
 
     type: save.type,
+    attackid: save.attackid,
     x: save.cell?.x || null,
     y: save.cell?.y || null,
 


### PR DESCRIPTION
## Attack battle reports — PR 1a (data pipeline)

The launcher's **Attack Logs** page has a per-row **"View Details"** button that
currently opens a *"not yet available"* modal, because no structured data backs it.
Today the attack is simulated on the attacker's Flash client, which uploads only a
**localized HTML string** (`ATTACK.LogRead()`); the `attack_logs` row is created at
attack start with `loot: {}` / `attackreport: {}` and never backfilled.

This PR adds the **data pipeline** so a real data sheet has something to render.
The launcher UI is a separate follow-up PR against `bymr-desktop-launcher`.

### What it does

- **AS3 client** — a new all-static `AttackReport` accumulator collects a structured
  report *beside the existing `ATTACK.Log()` call sites* during the sim: per-affected-building
  type/pos/HP/loot, attacking force (monsters flung + champion), siege weapons, catapult
  power-ups, overall damage %, duration, outcome. Serialized on attack-end into a compact,
  enum-coded JSON string (`saveData.battlereport`).
- **Server** — `BaseSaveSchema` gains a `battlereport` field; `baseSave` validates it against
  a zod schema with hard anti-bloat caps, correlates it to the `attack_logs` row via a new
  nullable `attackid` column (migration included), and stores the compact blob in the existing
  `attack_logs.attackreport` jsonb column. `attack_logs.loot` (long unused) is populated too.
- **New endpoint** — `GET /api/:apiVersion/attacklogs/:id` returns a decoded, friendly
  `AttackReportView` (enum ids expanded to names), authorized to the attacker or defender only,
  Redis-cached. The existing list endpoint gets a field projection so it no longer ships the
  full report.

### Scope / deliberate omissions (→ a follow-up PR 1b)

`b[].dd` (defensive damage dealt), `b[].k` (kills), `b[].ml` (bunker/champion monsters lost),
`atk.ml` (attacker losses) are **not** produced here — they need combat-path attribution
threaded through `PROJECTILES.Spawn` → `PROJECTILE` and a separate `CreepBase` path, which
roughly doubles the client surface and is the most fragile part. The schema keeps these fields
optional; the decoder fills them `0` / `[]`, so the launcher renders those columns as zero
until 1b lands.

### Design principles

- **Best-effort**: a missing / malformed / oversized / uncorrelatable report never fails the
  player's base save, never throws, never bans. Building damage was already client-authoritative;
  the server validates *shape and size* only.
- **Enum tables** (`attackReportEnums.ts` / `.fixture.json` / AS3 `AttackReportEnums.as`) are
  byte-identical, append-only, index = wire value; a test guards the drift.
- Compact JSON in `jsonb` + Postgres TOAST — no extra compression lib.

### Testing

- `bun test` (new to `server/`): enum-drift guard, schema cap rejection, decoder round-trip —
  14 tests.
- `server/scripts/verify-battle-report.ts`: exercises `persistBattleReport` + `decodeAttackReport`
  against local Postgres/Redis incl. the malformed / mismatched-`attackid` negative cases — 18/18.
- **Manual E2E**: verified against a real MR3 flatten through the Flash client —
  `GET /attacklogs/:id` returns the decoded view with correct flung-monster counts, champion,
  per-building loot, and outcome; list endpoint confirmed to exclude the report body.
  `server/scripts/setup-mr3-attack-test.ts` (dev-only) sets up an attackable opponent.
- Not yet exercised manually: siege/catapult paths, partial-damage (hp > 0), retreat outcome,
  MR2/inferno/tribe (tribe attacks legitimately produce no report → `{ report: null }`).

### Known follow-ups

- Building `x`/`y` are screen-pixel coords, not grid coords (sanctioned v1 shortcut).
- `attack_logs.loot` is the attacker-client's reported total; the server separately caps the
  defender's actual resource transfer, so the report can overstate the loss (pre-existing
  game loot-accounting).
- `?filter=<invalid>` still caches under an unbustable key (low-severity, self-inflicted).


### Relation to the #183 POC

This supersedes the stalled POC in #183 (`feature/attack-logs-reports`). That branch correlated attack-end by *watching `save.attackid`* — first a 1-second polling loop, then Postgres triggers + SQL functions — and @React1-X pushed back (2025-11-17):

> "the complexity has now shifted into the database layer … for the sake of consistency on the server we should try [to] avoid [triggers/functions]. A lightweight, server-side event emitter is still the cleanest, most explicit, and most maintainable approach long-term."

This PR follows that direction:

- **No DB triggers or functions.** The migration is a single `ADD COLUMN attackid` + one index; all processing is plain TypeScript.
- **No polling / no watchers.** The report is persisted synchronously in `baseSave` when the client's end-of-attack `over` save arrives — the attack-ended event *is* that request.
- **Consistent with the codebase.** `persistBattleReport(...)` is called inline from `baseSave.ts` exactly like the existing `attackLootHandler` / `championHandler` / `monsterUpdateHandler`.

**One deliberate deviation from the literal wording:** it is a direct `await` call, not an `EventEmitter` + listener. Reasons — there is no event-emitter/pub-sub pattern anywhere in the server today (an emitter would be the inconsistency React1-X wants to avoid), and `persistBattleReport` must run *inside* `baseSave`'s unit of work (persist the row before the flush, bust the cache after), which needs an awaited inline call, not a fire-and-forget event. Happy to add an emitter layer if the maintainers prefer it.

Also: #183's core motivation — *"`save.attackreport` being overwritten on every attack"* — is solved here for the structured data, which now lives on the per-attack `attack_logs` row and is never overwritten. The HTML `save.attackreport` stays ephemeral, which is fine: it only feeds the in-game post-attack popup, which only needs the current attack.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

