### PR TITLE
Add opt-in no-shiny mode that blocks spending, not earning

### DIFF
--- a/server/src/app.routes.ts
+++ b/server/src/app.routes.ts
@@ -24,6 +24,7 @@ import { forgotPassword } from "./controllers/auth/forgotPassword.js";
 import { resetPassword } from "./controllers/auth/resetPassword.js";
 import { changeUsername } from "./controllers/auth/changeUsername.js";
 import { getAccount } from "./controllers/auth/getAccount.js";
+import { updateSettings } from "./controllers/auth/updateSettings.js";
 
 import { baseLoad } from "./controllers/base/load/baseLoad.js";
 import { baseSave } from "./controllers/base/save/baseSave.js";
@@ -83,6 +84,7 @@ router.post("/api/:apiVersion/player/reset-password", resetPassword);
 router.get("/api/:apiVersion/supportedLangs", apiVersion, logRequest, supportedLangs);
 router.get("/api/:apiVersion/player/account", apiVersion, verifyUserAuth, getAccount);
 router.post("/api/:apiVersion/player/changeusername", apiVersion, verifyUserAuth, changeUsernameLimiter, logRequest, changeUsername);
+router.post("/api/:apiVersion/player/settings", apiVersion, verifyUserAuth, logRequest, updateSettings);
 
 /**  ────────────────────────────────────────────────
 * 📦 Base

--- a/server/src/controllers/auth/getAccount.ts
+++ b/server/src/controllers/auth/getAccount.ts
@@ -21,6 +21,7 @@ export const getAccount: KoaController = async (ctx) => {
     discord_verified: user.discord_verified,
     canChangeUsername: !cooldown,
     nextChangeAt: cooldown?.toISOString() ?? null,
+    settings: { shinyLocked: user.shiny_locked },
   };
 
   ctx.status = Status.OK;

--- a/server/src/controllers/auth/updateSettings.ts
+++ b/server/src/controllers/auth/updateSettings.ts
@@ -1,0 +1,30 @@
+import type { KoaController } from "../../utils/KoaController.js";
+import { User } from "../../models/user.model.js";
+import { postgres } from "../../server.js";
+import { Status } from "../../enums/StatusCodes.js";
+import { UpdateSettingsSchema } from "../../schemas/AuthSchemas.js";
+
+/**
+ * Controller to update the authenticated user's account settings.
+ *
+ * Callers send the whole settings block and it is echoed back, so the caller can render
+ * the resulting state without a second request. Clients that never call this - the Android
+ * and raw builds - are unaffected: the column defaults to false, and every guard reads it
+ * from the account rather than from the request.
+ *
+ * @param {Context} ctx - The Koa context object.
+ * @returns {Promise<void>} - A promise that resolves when the controller is complete.
+ */
+export const updateSettings: KoaController = async (ctx) => {
+  const user: User = ctx.authUser;
+  const { shinyLocked } = UpdateSettingsSchema.parse(ctx.request.body);
+
+  user.shiny_locked = shinyLocked;
+  await postgres.em.flush();
+
+  ctx.status = Status.OK;
+  ctx.body = {
+    error: 0,
+    settings: { shinyLocked: user.shiny_locked },
+  };
+};

--- a/server/src/controllers/base/load/modes/baseModeAttack.ts
+++ b/server/src/controllers/base/load/modes/baseModeAttack.ts
@@ -13,11 +13,12 @@ import { getGeneratedCells, cellKey } from "../../../../services/maproom/v3/gene
 import { createAttackLog } from "../../../../services/base/createAttackLog.js";
 import { updateResources, Operation } from "../../../../services/base/updateResources.js";
 import { isAttackActive } from "../../../../services/base/isAttackActive.js";
-import { baseUnderAttackErr, baseProtectedErr, userOnlineErr, truceActiveErr } from "../../../../errors/errors.js";
+import { baseUnderAttackErr, baseProtectedErr, userOnlineErr, truceActiveErr, shinyLockedErr } from "../../../../errors/errors.js";
 import { redis } from "../../../../server.js";
 import { isTruceActive } from "../../../../services/mail/isTruceActive.js";
 import { MR1_TRIBE_IDS } from "../../../../game-data/tribes/v1/index.js";
 import { registerAttacker } from "../../../../services/maproom/v1/registerAttacker.js";
+import { isShinyLocked } from "../../../../services/user/shinyLock.js";
 import type { BuildingData } from "../../../../types/BuildingData.js";
 import {
   generateNoise,
@@ -137,6 +138,10 @@ export const baseModeAttack = async ({ user, baseid, mapversion, attackCost }: B
       const [r1, r2, r3] = attackCost.resources;
       updateResources({ r1, r2, r3 }, userSave.resources!, Operation.SUBTRACT);
     } else if (attackCost.shiny) {
+      const shinyLocked = isShinyLocked(user);
+
+      if (shinyLocked) throw shinyLockedErr();
+      
       userSave.credits = Math.max(0, userSave.credits - attackCost.shiny);
     }
   }

--- a/server/src/controllers/base/save/handlers/purchaseHandler.ts
+++ b/server/src/controllers/base/save/handlers/purchaseHandler.ts
@@ -3,34 +3,48 @@ import { storeItems } from "../../../../game-data/store/storeItems.js";
 import { Save } from "../../../../models/save.model.js";
 import { updateCredits } from "../../../../services/base/updateCredits.js";
 import { getCurrentDateTime } from "../../../../utils/getCurrentDateTime.js";
+import { isShinyLocked } from "../../../../services/user/shinyLock.js";
+import { isShinyGain } from "../../../../game-data/store/purchaseKeys.js";
 import type { JsonObject } from "../../../../types/JsonObject.js";
 
+/**
+ * Applies a purchase to the save: grants the item, sets any expiry, then settles the cost.
+ *
+ * @param {Context} ctx - The Koa context object
+ * @param {[string, number]} purchaseData - The item key and quantity sent by the client
+ * @param {Save} save - The save the purchase applies to
+ */
 export const purchaseHandler = (ctx: Context, purchaseData: [string, number], save: Save) => {
+  if (!purchaseData) return;
+
+  const [item, quantity] = purchaseData;
+
+  const isGain = isShinyGain(item);
+  const shinyLocked = isShinyLocked(ctx.authUser);
+
+  if (shinyLocked && !isGain) return;
+
   const currentTime = getCurrentDateTime();
 
-  if (purchaseData) {
-    const [item, quantity] = purchaseData;
+  const storeData: JsonObject = save.storedata || {};
+  storeData[item] = {
+    q: (storeData[item]?.q || 0) + quantity,
+  };
 
-    const storeData: JsonObject = save.storedata || {};
-    storeData[item] = {
-      q: (storeData[item]?.q || 0) + quantity,
-    };
-
-    // Determine expiry if the item has a duration
-    const storeItem = storeItems[item];
-    if ((storeItem?.du ?? 0) > 0) {
-      storeData[item].e = currentTime + storeItem.du;
-    }
-
-    save.storedata = storeData;
-
-    // Apply damage protection for protection items, stacking onto any existing active protection
-    if (item === "PRO1" || item === "PRO2" || item === "PRO3") {
-      const baseTime = save.protected > currentTime ? save.protected : currentTime;
-    
-      save.protected = baseTime + storeItem.du * quantity;
-    }
-
-    updateCredits(ctx, save, item, quantity);
+  // Determine expiry if the item has a duration
+  const storeItem = storeItems[item];
+  if ((storeItem?.du ?? 0) > 0) {
+    storeData[item].e = currentTime + storeItem.du;
   }
+
+  save.storedata = storeData;
+
+  // Apply damage protection for protection items, stacking onto any existing active protection
+  if (item === "PRO1" || item === "PRO2" || item === "PRO3") {
+    const baseTime = save.protected > currentTime ? save.protected : currentTime;
+
+    save.protected = baseTime + storeItem.du * quantity;
+  }
+
+  updateCredits(ctx, save, item, quantity);
 };

--- a/server/src/controllers/base/save/updateSaved.ts
+++ b/server/src/controllers/base/save/updateSaved.ts
@@ -14,6 +14,7 @@ import { baseModeView } from "../load/modes/baseModeView.js";
 import { infernoModeView } from "../load/modes/infernoModeView.js";
 import { extractTownHall } from "../../../utils/extractTownHall.js";
 import { mapSaveData } from "../../../services/base/mapSaveData.js";
+import { visibleCredits } from "../../../services/user/shinyLock.js";
 
 const UpdateSavedSchema = z.object({
   type: z.string(),
@@ -75,11 +76,13 @@ export const updateSaved: KoaController = async (ctx) => {
   flags.maproom2 = userSave.mr2upgraded || (townHall && townHall.l >= 6) ? 1 : 0;
   flags.mr2upgraded = userSave.mr2upgraded ? 1 : 0;
 
+  const credits = visibleCredits(user, userSave.credits);
+
   const responseBody = {
     error: 0,
     flags,
     ...filteredSave,
-    credits: userSave.credits
+    credits
   };
 
   ctx.status = Status.OK;

--- a/server/src/controllers/inferno/infernoSave.ts
+++ b/server/src/controllers/inferno/infernoSave.ts
@@ -19,6 +19,7 @@ import { defenderLootHandler } from "../base/save/handlers/defenderLootHandler.j
 import { purchaseHandler } from "../base/save/handlers/purchaseHandler.js";
 import { resourcesHandler } from "../base/save/handlers/resourceHandler.js";
 import { damageProtection } from "../../services/maproom/v2/damageProtection.js";
+import { visibleCredits } from "../../services/user/shinyLock.js";
 
 export const infernoSave: KoaController = async (ctx) => {
   const user: User = ctx.authUser;
@@ -144,13 +145,14 @@ export const infernoSave: KoaController = async (ctx) => {
     await postgres.em.flush();
 
     const filteredSave = FilterFrontendKeys(baseSave);
+    const credits = visibleCredits(user, userSave.credits);
 
     ctx.status = Status.OK;
     ctx.body = {
       error: 0,
       ...filteredSave,
       champion: [],
-      credits: userSave.credits,
+      credits,
     };
   } catch (err) {
     logger.error(`Failed to save inferno base for user: ${user.username}: ${err}`);

--- a/server/src/controllers/maproom/v2/getArea.ts
+++ b/server/src/controllers/maproom/v2/getArea.ts
@@ -13,6 +13,7 @@ import { getLastSeen } from "../../../services/maproom/getLastSeen.js";
 import { getTruces } from "../../../services/maproom/getTruces.js";
 import { BaseType } from "../../../enums/Base.js";
 import { mapRoomDisabledErr } from "../../../errors/errors.js";
+import { visibleCredits } from "../../../services/user/shinyLock.js";
 
 /**
  * Schema for validating the request body when getting area data.
@@ -149,6 +150,8 @@ export const getArea: KoaController = async (ctx) => {
     }
   }
 
+  const credits = visibleCredits(user, save.credits);
+
   ctx.status = Status.OK;
   ctx.body = {
     error: 0,
@@ -157,7 +160,7 @@ export const getArea: KoaController = async (ctx) => {
     data: cells,
     ...(sendresources === 1 && {
       resources: save.resources,
-      credits: save.credits,
+      credits,
     }),
   };
 };

--- a/server/src/controllers/maproom/v2/migrateBase.ts
+++ b/server/src/controllers/maproom/v2/migrateBase.ts
@@ -12,8 +12,9 @@ import {
 import { joinOrCreateWorld } from "../../../services/maproom/v2/joinOrCreateWorld.js";
 import { leaveWorld } from "../../../services/maproom/v2/leaveWorld.js";
 import { MapRoomCell } from "../../../enums/MapRoom.js";
-import { relocateOutpostErr } from "../../../errors/errors.js";
+import { relocateOutpostErr, shinyLockedErr } from "../../../errors/errors.js";
 import { MigrateBaseSchema } from "../../../schemas/MigrateBaseSchema.js";
+import { isShinyLocked } from "../../../services/user/shinyLock.js";
 
 /**
  * Cooldown period for base migration.
@@ -38,6 +39,10 @@ export const migrateBase: KoaController = async (ctx) => {
   const { baseid, resources, shiny, type } = MigrateBaseSchema.parse(ctx.request.body);
 
   const currentUser: User = ctx.authUser;
+  const shinyLocked = isShinyLocked(currentUser);
+
+  if (shiny && shinyLocked) throw shinyLockedErr();
+
   await postgres.em.populate(currentUser, ["save"]);
 
   const userSave = currentUser.save!;

--- a/server/src/controllers/maproom/v2/takeoverCell.ts
+++ b/server/src/controllers/maproom/v2/takeoverCell.ts
@@ -13,7 +13,8 @@ import {
 import { getCurrentDateTime } from "../../../utils/getCurrentDateTime.js";
 import { validateRange } from "../../../services/maproom/v2/validateRange.js";
 import { TakeoverCellSchema } from "../../../schemas/TakeoverCellSchema.js";
-import { takeoverCellErr } from "../../../errors/errors.js";
+import { takeoverCellErr, shinyLockedErr } from "../../../errors/errors.js";
+import { isShinyLocked } from "../../../services/user/shinyLock.js";
 
 /**
  * Controller to handle the takeover of a cell on the world map via shiny or resources.
@@ -29,6 +30,10 @@ export const takeoverCell: KoaController = async (ctx) => {
   const { baseid, resources, shiny } = TakeoverCellSchema.parse(ctx.request.body);
 
   const currentUser: User = ctx.authUser;
+  const shinyLocked = isShinyLocked(currentUser);
+
+  if (shiny && shinyLocked) throw shinyLockedErr();
+
   await postgres.em.populate(currentUser, ["save"]);
 
   const userSave = currentUser.save!;

--- a/server/src/database/migrations/20260908_AddShinyLockedToUser.ts
+++ b/server/src/database/migrations/20260908_AddShinyLockedToUser.ts
@@ -1,0 +1,17 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * Adds user.shiny_locked to drive no-shiny mode.
+ *
+ * The flag only masks shiny on the way out and refuses it on the way in. It never
+ * writes save.credits, so existing balances are correct as they stand and no backfill
+ * is needed beyond defaulting every account to unlocked.
+ */
+export class AddShinyLockedToUser extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "bym"."user"
+        ADD COLUMN IF NOT EXISTS "shiny_locked" boolean NOT NULL DEFAULT false;
+    `);
+  }
+}

--- a/server/src/errors/errors.ts
+++ b/server/src/errors/errors.ts
@@ -196,3 +196,11 @@ export const truceActiveErr = () =>
     isClientFriendly: false,
   });
 
+export const shinyLockedErr = () =>
+  new ClientSafeError({
+    message: "Shiny is turned off on your account, so it cannot be spent. You can turn it back on from your account page in the launcher.",
+    status: Status.FORBIDDEN,
+    data: {},
+    isClientFriendly: true,
+  });
+

--- a/server/src/game-data/store/purchaseKeys.ts
+++ b/server/src/game-data/store/purchaseKeys.ts
@@ -28,3 +28,24 @@ export const rewardCredits: Record<string, number> = {
   "QINVITE5":  45,    // Quest Invite 5 Friends
   "QINVITE10": 65,    // Quest Invite 10 Friends
 };
+
+/**
+ * Mushroom pickups, keyed by item ID with the shiny each one grants.
+ */
+export const mushroomCredits: Record<string, number> = {
+  "MUSHROOM1": 3,
+  "MUSHROOM2": 8,
+  "MUSHROOM3": 3,
+};
+
+/**
+ * Whether an item adds shiny rather than costing it.
+ *
+ * Mushroom pickups and quest rewards are the only two categories that credit the player -
+ * everything else debits. No-shiny mode uses this to let earnings through while still
+ * refusing every spend.
+ *
+ * @param {string} item - The item identifier from the purchase
+ * @returns {boolean} True if the item pays the player rather than charging them
+ */
+export const isShinyGain = (item: string): boolean => item in mushroomCredits || item in rewardCredits;

--- a/server/src/models/user.model.ts
+++ b/server/src/models/user.model.ts
@@ -32,6 +32,9 @@ export class User {
   @Property({ type: "boolean", default: false })
   banned: boolean = false;
 
+  @Property({ type: "boolean", default: false })
+  shiny_locked: boolean = false;
+
   @FrontendKey
   @Property({ type: "string", unique: true })
   @Index()

--- a/server/src/schemas/AuthSchemas.ts
+++ b/server/src/schemas/AuthSchemas.ts
@@ -75,6 +75,15 @@ export const UserRegistrationSchema = z.object({
 export const ChangeUsernameSchema = z.object({ username: usernameSchema });
 
 /**
+ * Schema to validate an account settings update.
+ * - Callers send the whole settings block, not a partial one.
+ * - shinyLocked toggles no-shiny mode.
+ */
+export const UpdateSettingsSchema = z.object({
+  shinyLocked: z.boolean(),
+});
+
+/**
  * Schema to validate password reset data.
  * - Password must meet the password schema requirements.
  * - Token must be a string.

--- a/server/src/services/base/mapSaveData.ts
+++ b/server/src/services/base/mapSaveData.ts
@@ -3,16 +3,18 @@ import { Save } from "../../models/save.model.js";
 import { User } from "../../models/user.model.js";
 import { FilterFrontendKeys } from "../../utils/FrontendKey.js";
 import { getOutpostOwnerSave } from "./getOutpostOwnerSave.js";
+import { isShinyLocked, visibleCredits } from "../user/shinyLock.js";
 
 /**
  * State that belongs to the player rather than to any one of their yards. Served from
  * the main save whenever a player looks at a base they own, so an outpost reports the
  * same credits, resources and progress as the main yard rather than a stale copy.
  *
+ * @param {User} user - The viewer, whose no-shiny setting decides what credits reads
  * @param {Save} userSave - The viewer's main yard save
  */
-const mapOwnerState = (userSave: Save) => ({
-  credits: userSave.credits,
+const mapOwnerState = (user: User, userSave: Save) => ({
+  credits: visibleCredits(user, userSave.credits),
   fan: userSave.fan,
   resources: userSave.resources,
   lockerdata: userSave.lockerdata,
@@ -62,9 +64,13 @@ export const buildSaveData = (save: Save, user: User, ownerSave: Save | null): P
 
   const isOwner = save.type !== BaseType.INFERNO && save.userid === user.userid;
 
-  if (isOwner && user.save) return Object.assign(filteredSave, mapOwnerState(user.save));
+  if (isOwner && user.save) return Object.assign(filteredSave, mapOwnerState(user, user.save));
 
   if (ownerSave) filteredSave.resources = ownerSave.resources;
+
+  const shinyLocked = isShinyLocked(user);
+  
+  if (shinyLocked) filteredSave.credits = 0;
 
   return filteredSave;
 };

--- a/server/src/services/base/updateCredits.ts
+++ b/server/src/services/base/updateCredits.ts
@@ -1,18 +1,18 @@
 import { Save } from "../../models/save.model.js";
 import { logger } from "../../utils/logger.js";
 import { type StoreItem, storeItems } from "../../game-data/store/storeItems.js";
-import { purchaseKeys, rewardCredits } from "../../game-data/store/purchaseKeys.js";
+import { mushroomCredits, purchaseKeys, rewardCredits } from "../../game-data/store/purchaseKeys.js";
 import { User } from "../../models/user.model.js";
+import { isShinyLocked } from "../user/shinyLock.js";
 import type { Context } from "koa";
-
-interface Mushrooms {
-  MUSHROOM1: number;
-  MUSHROOM2: number;
-  MUSHROOM3: number;
-}
 
 /**
  *  Keeps track of shiny (credits) spent and obtained.
+ *
+ * A locked account still collects mushrooms and quest rewards - those land in the stored
+ * balance and surface when the option is switched off. Only the spending branches below
+ * are refused.
+ *
  * @param {Save} save - The object representing the user's save data.
  * @param {string} item - The item identifier for which credits are spent or obtained.
  * @param {number} quantity - The quantity of the item affecting credit changes.
@@ -27,9 +27,8 @@ export const updateCredits = (ctx: Context, save: Save, item: string, quantity: 
   }
 
   // Handle mushrooms
-  const mushroomCredits: Mushrooms = { MUSHROOM1: 3, MUSHROOM2: 8, MUSHROOM3: 3 };
   if (item in mushroomCredits) {
-    userSave.credits += mushroomCredits[item as keyof Mushrooms];
+    userSave.credits += mushroomCredits[item];
     return;
   }
 
@@ -40,6 +39,10 @@ export const updateCredits = (ctx: Context, save: Save, item: string, quantity: 
     if (!collected) userSave.credits += rewardCredits[item];
     return;
   }
+
+  const shinyLocked = isShinyLocked(user);
+  
+  if (shinyLocked) return;
 
   // Handle purchases not in the store
   if (purchaseKeys.has(item)) {

--- a/server/src/services/user/shinyLock.ts
+++ b/server/src/services/user/shinyLock.ts
@@ -1,0 +1,18 @@
+import { User } from "../../models/user.model.js";
+
+/**
+ * Whether the account has opted into no-shiny mode.
+ *
+ * @param {User} user - The requesting account
+ * @returns {boolean} True while shiny is locked
+ */
+export const isShinyLocked = (user: User): boolean => user.shiny_locked;
+
+/**
+ * The shiny balance to report to the client.
+ *
+ * @param {User} user - The requesting account
+ * @param {number} credits - The real balance from the owner's main save
+ * @returns {number} The balance the client should see
+ */
+export const visibleCredits = (user: User, credits: number): number => isShinyLocked(user) ? 0 : credits;


### PR DESCRIPTION
# Add opt-in no-shiny mode

Adds an account setting that lets a player turn shiny off. While it is on, the game reads
0 shiny everywhere and nothing can be bought, rushed or unlocked with it — but the player
keeps earning normally, and their real balance is never touched.

The toggle lives on the launcher account page (separate PR in `bymr-rust-launcher`).

<br>

## What it does

| | Locked | Unlocked (default) |
|---|---|---|
| Shiny shown in game | always `0` | real balance |
| Spending (store, rush, attack cost, takeover, relocate) | refused | normal |
| Earning (mushrooms, quest rewards) | **normal** | normal |
| Stored `save.credits` | untouched, keeps accruing | normal |

Turning it back off restores the balance exactly, including the monthly grant and anything
earned while it was on. Nothing is forfeited.

<br>

## How it works

The setting is a single boolean on the account — `user.shiny_locked`, default `false`. The
guarantee that the balance is never rewritten means the flag can only be applied at the
edges: **masked on the way out, refused on the way in.** Nothing zeroes the column.

### Read side — masking

`credits` carries `@FrontendKey`, so it rides along on every serialized save. It is masked
at the five places it leaves the server:

- `services/base/mapSaveData.ts` — covers `/base/load`, `/base/save`, `/base/updatesaved`
- `controllers/base/save/updateSaved.ts`
- `controllers/inferno/infernoSave.ts`
- `controllers/maproom/v2/getArea.ts`

Masking applies to **every** response a locked account receives, not just its own wallet —
the client adopts whatever `credits` it is handed, including when viewing another player's
base.

### Write side — guards

- `handlers/purchaseHandler.ts` — drops a spend before `storedata` is written
- `modes/baseModeAttack.ts` — MR3 shiny attack cost
- `maproom/v2/takeoverCell.ts` — MR2 cell takeover
- `maproom/v2/migrateBase.ts` — MR2 relocate

The three map-room paths **throw** rather than skipping the cost, since ignoring it would
hand over a free attack, cell or relocation. All three throw before any flush, so nothing
partial is written.

### Earning vs. spending

`updateCredits` already branched on the four purchase categories, and only two of them add
to the balance. The guard sits below those two, so its position states the rule:

```ts
// Handle mushrooms
// Handle quest rewards that grant credits

// Everything below this point spends, so a locked account stops here.
if (isShinyLocked(user)) return;
```

`purchaseHandler` needs the same distinction earlier, before it writes `storedata`, so
`isShinyGain()` in `game-data/store/purchaseKeys.ts` is the single place that says which
items credit rather than debit.

Gains have to take the **full** purchase path, not just the credit line: the quest branch
reads `storedata` to tell whether a reward was already collected, so skipping that write
would pay the same reward out on every save.

<br>

## API

```
POST /api/:apiVersion/player/settings   { "shinyLocked": true }
  -> { "error": 0, "settings": { "shinyLocked": true } }

GET  /api/:apiVersion/player/account
  -> { ..., "settings": { "shinyLocked": false } }
```

Both behind `verifyUserAuth`. Callers send the whole settings block, not a partial one.

<br>

## Migration

`20260908_AddShinyLockedToUser` adds `user.shiny_locked boolean NOT NULL DEFAULT false`.
Metadata-only on PG 11+, no table rewrite. No backfill needed — existing balances are
already correct, since the feature never writes `save.credits`.