### PR TITLE
refactor(client): replaced string-based UI action lookup with type-safe interface casts

### DIFF
--- a/client/scripts/ACADEMYPOPUP.as
+++ b/client/scripts/ACADEMYPOPUP.as
@@ -1,5 +1,7 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.managers.InstanceManager;
    import flash.display.Bitmap;
@@ -7,7 +9,7 @@ package
    import flash.display.DisplayObject;
    import flash.events.MouseEvent;
    
-   public class ACADEMYPOPUP extends ACADEMYPOPUP_CLIP
+   public class ACADEMYPOPUP extends ACADEMYPOPUP_CLIP implements IHideActionHandler, IHelpActionHandler
    {
       
       public static var _page:int = 1;

--- a/client/scripts/ALLIANCEPOPUP.as
+++ b/client/scripts/ALLIANCEPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.alliances.ALLIANCES;
    import com.monsters.alliances.AllianceConstants;
    import com.monsters.alliances.AllianceTabBase;
@@ -12,7 +13,7 @@ package
    import flash.display.MovieClip;
    import flash.events.MouseEvent;
 
-   public class ALLIANCEPOPUP extends MovieClip
+   public class ALLIANCEPOPUP extends MovieClip implements IHideActionHandler
    {
       private static const W:int = 860;
       private static const H:int = 580;

--- a/client/scripts/BUILDINGOPTIONSPOPUP.as
+++ b/client/scripts/BUILDINGOPTIONSPOPUP.as
@@ -10,8 +10,9 @@ package
    import flash.display.MovieClip;
    import flash.events.MouseEvent;
    import flash.text.TextFieldAutoSize;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    
-   public class BUILDINGOPTIONSPOPUP extends BUILDINGOPTIONSPOPUP_CLIP
+   public class BUILDINGOPTIONSPOPUP extends BUILDINGOPTIONSPOPUP_CLIP implements IHideActionHandler
    {
        
       
@@ -1123,7 +1124,7 @@ package
          }
       }
       
-      public function Hide() : void
+      public function Hide(event:MouseEvent = null) : void
       {
          try
          {

--- a/client/scripts/BUILDINGSPOPUP.as
+++ b/client/scripts/BUILDINGSPOPUP.as
@@ -1,11 +1,12 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.inventory.InventoryManager;
    import com.monsters.managers.InstanceManager;
    import flash.display.MovieClip;
    import flash.events.MouseEvent;
    
-   public class BUILDINGSPOPUP extends BUILDINGSPOPUP_CLIP
+   public class BUILDINGSPOPUP extends BUILDINGSPOPUP_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/CATAPULTITEM.as
+++ b/client/scripts/CATAPULTITEM.as
@@ -1,12 +1,14 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.effects.ResourceBombs;
    import flash.display.Bitmap;
    import flash.display.BitmapData;
    import flash.display.Sprite;
+   import flash.events.MouseEvent;
    
-   public class CATAPULTITEM extends CATAPULTITEM_view
+   public class CATAPULTITEM extends CATAPULTITEM_view implements IHideActionHandler
    {
        
       
@@ -121,7 +123,7 @@ package
          this._popup.visible = true;
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          this._popup.visible = false;
       }

--- a/client/scripts/CATAPULTITEM.as
+++ b/client/scripts/CATAPULTITEM.as
@@ -1,6 +1,5 @@
 package
 {
-   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.effects.ResourceBombs;
    import flash.display.Bitmap;
@@ -8,7 +7,7 @@ package
    import flash.display.Sprite;
    import flash.events.MouseEvent;
    
-   public class CATAPULTITEM extends CATAPULTITEM_view implements IHideActionHandler
+   public class CATAPULTITEM extends CATAPULTITEM_view
    {
        
       

--- a/client/scripts/CATAPULTPOPUP.as
+++ b/client/scripts/CATAPULTPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.effects.ResourceBombs;
    import flash.display.Bitmap;
@@ -8,7 +9,7 @@ package
    import flash.events.TimerEvent;
    import flash.utils.Timer;
    
-   public class CATAPULTPOPUP extends CATAPULTPOPUP_view
+   public class CATAPULTPOPUP extends CATAPULTPOPUP_view implements IHideActionHandler
    {
        
       
@@ -257,7 +258,7 @@ package
          }
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          if(_mc.parent)
          {

--- a/client/scripts/CHAMPIONCAGEPOPUP.as
+++ b/client/scripts/CHAMPIONCAGEPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.kingOfTheHill.KOTHHandler;
    import com.monsters.monsters.champions.ChampionBase;
@@ -18,7 +19,7 @@ package
    import gs.*;
    import gs.easing.*;
    
-   public class CHAMPIONCAGEPOPUP extends GUARDIANCAGEPOPUP_CLIP
+   public class CHAMPIONCAGEPOPUP extends GUARDIANCAGEPOPUP_CLIP implements IHideActionHandler
    {
       
       public static var _page:int = 0;

--- a/client/scripts/CHAMPIONCHAMBERPOPUP.as
+++ b/client/scripts/CHAMPIONCHAMBERPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.display.ScrollSetH;
    import flash.display.Bitmap;
@@ -10,7 +11,7 @@ package
    import gs.TweenLite;
    import gs.easing.*;
    
-   public class CHAMPIONCHAMBERPOPUP extends GUARDIANCHAMBERPOPUP_CLIP
+   public class CHAMPIONCHAMBERPOPUP extends GUARDIANCHAMBERPOPUP_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/CHAMPIONNAMEPOPUP.as
+++ b/client/scripts/CHAMPIONNAMEPOPUP.as
@@ -1,8 +1,9 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.events.MouseEvent;
    
-   public class CHAMPIONNAMEPOPUP extends GUARDIANNAMEPOPUP_CLIP
+   public class CHAMPIONNAMEPOPUP extends GUARDIANNAMEPOPUP_CLIP implements IHideActionHandler
    {
        
       
@@ -48,7 +49,7 @@ package
          BASE.Save();
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          var _loc1_:String = String(CHAMPIONCAGE._guardians["G" + CREATURES._guardian._type].name);
          CREATURES._guardian._name = _loc1_;

--- a/client/scripts/CHAMPIONSELECTPOPUP.as
+++ b/client/scripts/CHAMPIONSELECTPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.display.ScrollSetH;
    import com.monsters.monsters.champions.ChampionBase;
@@ -9,7 +10,7 @@ package
    import flash.display.Sprite;
    import flash.events.MouseEvent;
    
-   public class CHAMPIONSELECTPOPUP extends GUARDIANSELECTPOPUP_CLIP
+   public class CHAMPIONSELECTPOPUP extends GUARDIANSELECTPOPUP_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/CREATURELOCKERPOPUP.as
+++ b/client/scripts/CREATURELOCKERPOPUP.as
@@ -1,5 +1,7 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
    import flash.display.BitmapData;
@@ -9,7 +11,7 @@ package
    import gs.*;
    import gs.easing.*;
    
-   public class CREATURELOCKERPOPUP extends CREATURELOCKERPOPUP_CLIP
+   public class CREATURELOCKERPOPUP extends CREATURELOCKERPOPUP_CLIP implements IHideActionHandler, IHelpActionHandler
    {
       
       private static const _CREATURES_PER_PAGE:int = 4;

--- a/client/scripts/DEFENSEEVENTPOPUP.as
+++ b/client/scripts/DEFENSEEVENTPOPUP.as
@@ -1,11 +1,12 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
    import flash.display.BitmapData;
    import flash.events.MouseEvent;
    
-   public class DEFENSEEVENTPOPUP extends DEFENSEEVENTPOPUP_CLIP
+   public class DEFENSEEVENTPOPUP extends DEFENSEEVENTPOPUP_CLIP implements IHideActionHandler
    {
       
       private static var _open:Boolean = false;
@@ -71,7 +72,7 @@ package
          this.Hide();
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          _open = false;
          POPUPS.Next();

--- a/client/scripts/DEFENSEEVENTPOPUP_WM1.as
+++ b/client/scripts/DEFENSEEVENTPOPUP_WM1.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
    import flash.display.BitmapData;
@@ -12,7 +13,7 @@ package
    * 
    * This file archives the original implementation for reference and renamed to DEFENSEEVENTPOPUP_WM1.
    */
-   public class DEFENSEEVENTPOPUP_WM1 extends DEFENSEEVENTPOPUP_CLIP
+   public class DEFENSEEVENTPOPUP_WM1 extends DEFENSEEVENTPOPUP_CLIP implements IHideActionHandler
    {
       
       private static var _open:Boolean = false;
@@ -105,7 +106,7 @@ package
          POPUPS.Next();
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          _open = false;
          POPUPS.Next();

--- a/client/scripts/HATCHERYCCPOPUP.as
+++ b/client/scripts/HATCHERYCCPOPUP.as
@@ -1,5 +1,7 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.display.ScrollSet;
    import com.monsters.managers.InstanceManager;
@@ -14,7 +16,7 @@ package
    import gs.TweenLite;
    import gs.easing.Circ;
    
-   public class HATCHERYCCPOPUP extends HATCHERYCCPOPUP_CLIP
+   public class HATCHERYCCPOPUP extends HATCHERYCCPOPUP_CLIP implements IHideActionHandler, IHelpActionHandler
    {
        
       

--- a/client/scripts/HATCHERYPOPUP.as
+++ b/client/scripts/HATCHERYPOPUP.as
@@ -1,5 +1,7 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.display.ScrollSet;
    import flash.display.Bitmap;
@@ -12,7 +14,7 @@ package
    import gs.TweenLite;
    import gs.easing.Circ;
    
-   public class HATCHERYPOPUP extends HATCHERYPOPUP_CLIP
+   public class HATCHERYPOPUP extends HATCHERYPOPUP_CLIP implements IHideActionHandler, IHelpActionHandler
    {
        
       

--- a/client/scripts/HOUSINGPOPUP.as
+++ b/client/scripts/HOUSINGPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.display.ScrollSet;
    import com.monsters.managers.InstanceManager;
@@ -11,7 +12,7 @@ package
    import flash.events.MouseEvent;
    import flash.geom.Point;
    
-   public class HOUSINGPOPUP extends HOUSINGPOPUP_CLIP
+   public class HOUSINGPOPUP extends HOUSINGPOPUP_CLIP implements IHideActionHandler
    {
        
       
@@ -473,7 +474,7 @@ package
          INFERNOPORTAL.AscendMonsters();
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          HOUSING.Hide();
       }

--- a/client/scripts/HousingPersistentPopup.as
+++ b/client/scripts/HousingPersistentPopup.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.display.ScrollSet;
    import com.monsters.managers.InstanceManager;
@@ -14,7 +15,7 @@ package
    import flash.display.Sprite;
    import flash.events.MouseEvent;
    
-   public class HousingPersistentPopup extends HousingPersistentPopup_CLIP
+   public class HousingPersistentPopup extends HousingPersistentPopup_CLIP implements IHideActionHandler
    {
        
       
@@ -914,7 +915,7 @@ package
          this.m_monsterBarList[param1].bJuice.buttonMode = false;
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          HOUSING.Hide();
       }

--- a/client/scripts/INFERNO_ASCENSION_POPUP.as
+++ b/client/scripts/INFERNO_ASCENSION_POPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.cc.utils.SecNum;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
@@ -7,7 +8,7 @@ package
    import flash.events.MouseEvent;
    import flash.geom.Point;
    
-   public class INFERNO_ASCENSION_POPUP extends InfernoTransferPopup_CLIP
+   public class INFERNO_ASCENSION_POPUP extends InfernoTransferPopup_CLIP implements IHideActionHandler
    {
        
       
@@ -192,7 +193,7 @@ package
          this.Hide();
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          INFERNOPORTAL.HideAscendMonstersDialog();
       }

--- a/client/scripts/MESSAGE.as
+++ b/client/scripts/MESSAGE.as
@@ -1,10 +1,11 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.debug.Console;
    import flash.events.*;
    import flash.text.TextFieldAutoSize;
    
-   public class MESSAGE extends MESSAGE_CLIP
+   public class MESSAGE extends MESSAGE_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/MONSTERBAITERPOPUP.as
+++ b/client/scripts/MONSTERBAITERPOPUP.as
@@ -1,11 +1,13 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.display.MovieClip;
    import flash.events.Event;
    import flash.events.MouseEvent;
    import flash.geom.Point;
    
-   public class MONSTERBAITERPOPUP extends MONSTERBAITERPOPUP_CLIP
+   public class MONSTERBAITERPOPUP extends MONSTERBAITERPOPUP_CLIP implements IHideActionHandler, IHelpActionHandler
    {
       
       private static const BAITER_BAR_WIDTH:int = 535;
@@ -238,7 +240,7 @@ package
          }
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          MONSTERBAITER.Hide();
       }

--- a/client/scripts/MONSTERBUNKERPOPUP.as
+++ b/client/scripts/MONSTERBUNKERPOPUP.as
@@ -1,5 +1,7 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.cc.utils.SecNum;
    import com.monsters.display.ImageCache;
    import com.monsters.display.ScrollSet;
@@ -12,7 +14,7 @@ package
    import flash.events.MouseEvent;
    import flash.geom.Point;
    
-   public class MONSTERBUNKERPOPUP extends MONSTERBUNKERPOPUP_CLIP
+   public class MONSTERBUNKERPOPUP extends MONSTERBUNKERPOPUP_CLIP implements IHideActionHandler, IHelpActionHandler
    {
        
       

--- a/client/scripts/MONSTERLABPOPUP.as
+++ b/client/scripts/MONSTERLABPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.display.ScrollSet;
    import flash.display.Bitmap;
@@ -9,7 +10,7 @@ package
    import flash.events.MouseEvent;
    import flash.text.TextField;
    
-   public class MONSTERLABPOPUP extends MONSTERLABPOPUP_CLIP
+   public class MONSTERLABPOPUP extends MONSTERLABPOPUP_CLIP implements IHideActionHandler
    {
       
       public static var _page:int = 1;

--- a/client/scripts/PLANNERPOPUP.as
+++ b/client/scripts/PLANNERPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.managers.InstanceManager;
    import flash.display.MovieClip;
    import flash.events.Event;
@@ -7,7 +8,7 @@ package
    import flash.geom.Point;
    import flash.geom.Rectangle;
    
-   public class PLANNERPOPUP extends PLANNERPOPUP_CLIP
+   public class PLANNERPOPUP extends PLANNERPOPUP_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/PersistentMonsterBunker.as
+++ b/client/scripts/PersistentMonsterBunker.as
@@ -1,5 +1,7 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.display.ScrollSet;
    import com.monsters.managers.InstanceManager;
@@ -10,7 +12,7 @@ package
    import flash.events.MouseEvent;
    import flash.geom.Point;
    
-   public class PersistentMonsterBunker extends MonsterBunkerPopup_Persistent_CLIP
+   public class PersistentMonsterBunker extends MonsterBunkerPopup_Persistent_CLIP implements IHideActionHandler, IHelpActionHandler
    {
       
       private static const kBarWidth:int = 535;

--- a/client/scripts/QUESTSPOPUP.as
+++ b/client/scripts/QUESTSPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.maproom_advanced.PopupInfoMonster;
    import com.monsters.siege.SiegeWeapons;
@@ -9,7 +10,7 @@ package
    import flash.display.MovieClip;
    import flash.events.*;
    
-   public class QUESTSPOPUP extends QUESTSPOPUP_CLIP
+   public class QUESTSPOPUP extends QUESTSPOPUP_CLIP implements IHideActionHandler
    {
        
       
@@ -402,7 +403,7 @@ package
          };
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          QUESTS.Hide();
       }

--- a/client/scripts/SALESPECIALSPOPUP.as
+++ b/client/scripts/SALESPECIALSPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.BuildingAssetContainer;
    import flash.display.DisplayObject;
    import flash.display.MovieClip;
@@ -9,7 +10,7 @@ package
    import gs.TweenLite;
    import gs.easing.*;
    
-   public class SALESPECIALSPOPUP extends SALESPECIALSPOPUP_CLIP
+   public class SALESPECIALSPOPUP extends SALESPECIALSPOPUP_CLIP implements IHideActionHandler
    {
       
       public static var imageContainer:BuildingAssetContainer;

--- a/client/scripts/SIEGEWEAPONPOPUP.as
+++ b/client/scripts/SIEGEWEAPONPOPUP.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.effects.ResourceBombs;
    import com.monsters.siege.SiegeWeaponProperty;
@@ -26,7 +27,7 @@ package
    import gs.TweenLite;
    import gs.easing.*;
    
-   public class SIEGEWEAPONPOPUP extends SIEGEWEAPONPOPUP_view
+   public class SIEGEWEAPONPOPUP extends SIEGEWEAPONPOPUP_view implements IHideActionHandler
    {
        
       
@@ -524,7 +525,7 @@ package
          ResourceBombs.BombRemove();
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          this._t.stop();
          this._t.removeEventListener(TimerEvent.TIMER,this.UpdateTimer);

--- a/client/scripts/STOREPOPUP.as
+++ b/client/scripts/STOREPOPUP.as
@@ -1,8 +1,9 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.events.MouseEvent;
    
-   public class STOREPOPUP extends STOREPOPUP_CLIP
+   public class STOREPOPUP extends STOREPOPUP_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/WMIEXTENSIONPOPUP.as
+++ b/client/scripts/WMIEXTENSIONPOPUP.as
@@ -1,11 +1,12 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
    import flash.display.BitmapData;
    import flash.events.MouseEvent;
    
-   public class WMIEXTENSIONPOPUP extends WMIEXTENSIONPOPUP_CLIP
+   public class WMIEXTENSIONPOPUP extends WMIEXTENSIONPOPUP_CLIP implements IHideActionHandler
    {
       
       private static var _open:Boolean = false;
@@ -45,7 +46,7 @@ package
          return _open;
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          _open = false;
          POPUPS.Next();

--- a/client/scripts/WMIEXTENSIONPOPUP_WM1.as
+++ b/client/scripts/WMIEXTENSIONPOPUP_WM1.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
    import flash.display.BitmapData;
@@ -12,7 +13,7 @@ package
    * 
    * This file archives the original implementation for reference and renamed to WMIEXTENSIONPOPUP_WM1.
    */
-   public class WMIEXTENSIONPOPUP_WM1 extends WMIEXTENSIONPOPUP_CLIP
+   public class WMIEXTENSIONPOPUP_WM1 extends WMIEXTENSIONPOPUP_CLIP implements IHideActionHandler
    {
       
       private static var _open:Boolean = false;
@@ -52,7 +53,7 @@ package
          return _open;
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          _open = false;
          POPUPS.Next();

--- a/client/scripts/WMIROUNDCOMPLETE.as
+++ b/client/scripts/WMIROUNDCOMPLETE.as
@@ -1,12 +1,13 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.managers.InstanceManager;
    import flash.display.Bitmap;
    import flash.display.BitmapData;
    import flash.events.MouseEvent;
    
-   public class WMIROUNDCOMPLETE extends ROUNDCOMPLETEPOPUP_CLIP
+   public class WMIROUNDCOMPLETE extends ROUNDCOMPLETEPOPUP_CLIP implements IHideActionHandler
    {
       
       private static var _open:Boolean = false;
@@ -259,7 +260,7 @@ package
          }
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          _open = false;
          POPUPS.Next();

--- a/client/scripts/WMIROUNDCOMPLETE_WM1.as
+++ b/client/scripts/WMIROUNDCOMPLETE_WM1.as
@@ -1,5 +1,6 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
    import flash.display.BitmapData;
@@ -12,7 +13,7 @@ package
    * 
    * This file archives the original implementation for reference and renamed to WMIROUNDCOMPLETE_WM1.
    */
-   public class WMIROUNDCOMPLETE_WM1 extends ROUNDCOMPLETEPOPUP_CLIP
+   public class WMIROUNDCOMPLETE_WM1 extends ROUNDCOMPLETEPOPUP_CLIP implements IHideActionHandler
    {
       
       private static var _wave:Number;
@@ -277,7 +278,7 @@ package
          }
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          _open = false;
          POPUPS.Next();

--- a/client/scripts/com/bymrefitted/ui/interfaces/IFullScreenActionHandler.as
+++ b/client/scripts/com/bymrefitted/ui/interfaces/IFullScreenActionHandler.as
@@ -1,0 +1,15 @@
+package com.bymrefitted.ui.interfaces
+{
+   import flash.events.MouseEvent;
+
+   /**
+    * Interface for windows that support the "FullScreen" action.
+    */
+   public interface IFullScreenActionHandler
+   {
+      /**
+       * Handles the FullScreen action triggered by a MouseEvent.
+       */
+      function FullScreen(param1:MouseEvent = null):void;
+   }
+}

--- a/client/scripts/com/bymrefitted/ui/interfaces/IHelpActionHandler.as
+++ b/client/scripts/com/bymrefitted/ui/interfaces/IHelpActionHandler.as
@@ -1,0 +1,15 @@
+package com.bymrefitted.ui.interfaces
+{
+   import flash.events.MouseEvent;
+
+   /**
+    * Interface for windows that support the "Help" operation, e.g. showing help information.
+    */
+   public interface IHelpActionHandler
+   {
+      /**
+       * Shows the help information for the window.
+       */
+      function Help(param1:MouseEvent = null):void;
+   }
+}

--- a/client/scripts/com/bymrefitted/ui/interfaces/IHideActionHandler.as
+++ b/client/scripts/com/bymrefitted/ui/interfaces/IHideActionHandler.as
@@ -1,0 +1,15 @@
+package com.bymrefitted.ui.interfaces
+{
+   import flash.events.MouseEvent;
+
+   /**
+    * Interface for windows that support the "Hide" operation, e.g. closing the window.
+    */
+   public interface IHideActionHandler
+   {
+      /**
+       * Hides the window, typically by closing it.
+       */
+      function Hide(param1:MouseEvent = null):void;
+   }
+}

--- a/client/scripts/com/monsters/baseplanner/popups/BasePlannerPopup.as
+++ b/client/scripts/com/monsters/baseplanner/popups/BasePlannerPopup.as
@@ -1,5 +1,6 @@
 package com.monsters.baseplanner.popups
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.baseplanner.BasePlanner;
    import com.monsters.baseplanner.PlannerDesignView;
    import com.monsters.baseplanner.PlannerExplorer;
@@ -15,7 +16,7 @@ package com.monsters.baseplanner.popups
    import flash.geom.Point;
    import flash.text.TextFieldAutoSize;
    
-   public class BasePlannerPopup extends Sprite
+   public class BasePlannerPopup extends Sprite implements IHideActionHandler
    {
       
       private static var _layoutSpacing:Point = new Point(10,10);

--- a/client/scripts/com/monsters/baseplanner/popups/transfer/BasePlannerTransferConfirmation.as
+++ b/client/scripts/com/monsters/baseplanner/popups/transfer/BasePlannerTransferConfirmation.as
@@ -1,10 +1,11 @@
 package com.monsters.baseplanner.popups.transfer
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.baseplanner.events.BasePlannerEvent;
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class BasePlannerTransferConfirmation extends BasePlannerTransferConfirmation_CLIP
+   public class BasePlannerTransferConfirmation extends BasePlannerTransferConfirmation_CLIP implements IHideActionHandler
    {
        
       
@@ -37,7 +38,7 @@ package com.monsters.baseplanner.popups.transfer
          dispatchEvent(new Event(Event.CLOSE));
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          dispatchEvent(new Event(Event.CLOSE));
       }

--- a/client/scripts/com/monsters/display/ScrollSet.as
+++ b/client/scripts/com/monsters/display/ScrollSet.as
@@ -1,6 +1,5 @@
 package com.monsters.display
 {
-   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.display.MovieClip;
    import flash.display.Sprite;
    import flash.events.Event;
@@ -8,7 +7,7 @@ package com.monsters.display
    import flash.geom.Rectangle;
    import gs.TweenLite;
    
-   public class ScrollSet extends ScrollSet_CLIP implements IHideActionHandler
+   public class ScrollSet extends ScrollSet_CLIP
    {
       
       public static const BROWN:int = 0;

--- a/client/scripts/com/monsters/display/ScrollSet.as
+++ b/client/scripts/com/monsters/display/ScrollSet.as
@@ -1,5 +1,6 @@
 package com.monsters.display
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.display.MovieClip;
    import flash.display.Sprite;
    import flash.events.Event;
@@ -7,7 +8,7 @@ package com.monsters.display
    import flash.geom.Rectangle;
    import gs.TweenLite;
    
-   public class ScrollSet extends ScrollSet_CLIP
+   public class ScrollSet extends ScrollSet_CLIP implements IHideActionHandler
    {
       
       public static const BROWN:int = 0;

--- a/client/scripts/com/monsters/event_store/EventStoreItemSelectedPopup.as
+++ b/client/scripts/com/monsters/event_store/EventStoreItemSelectedPopup.as
@@ -1,5 +1,6 @@
 package com.monsters.event_store
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.replayableEvents.ReplayableEventHandler;
    import com.monsters.rewarding.RewardHandler;
@@ -8,7 +9,7 @@ package com.monsters.event_store
    import flash.display.BitmapData;
    import flash.events.MouseEvent;
    
-   public class EventStoreItemSelectedPopup extends EventStoreItemSelectedPopupMC
+   public class EventStoreItemSelectedPopup extends EventStoreItemSelectedPopupMC implements IHideActionHandler
    {
       
       private static var s_Instance:EventStoreItemSelectedPopup = null;
@@ -90,7 +91,7 @@ package com.monsters.event_store
          this.m_PreviewImage.bitmapData = param2;
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          if(this.m_PrizeBeingDisplayed == null)
          {

--- a/client/scripts/com/monsters/event_store/EventStorePopup.as
+++ b/client/scripts/com/monsters/event_store/EventStorePopup.as
@@ -1,5 +1,6 @@
 package com.monsters.event_store
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.replayableEvents.ReplayableEventHandler;
    import config.singletonlock.SingletonLock;
@@ -9,7 +10,7 @@ package com.monsters.event_store
    import flash.display.Sprite;
    import flash.events.MouseEvent;
    
-   public class EventStorePopup extends EventStorePopupMC
+   public class EventStorePopup extends EventStorePopupMC implements IHideActionHandler
    {
       
       private static var s_Instance:EventStorePopup = null;
@@ -86,7 +87,7 @@ package com.monsters.event_store
          this.m_TitleImage.x = -(this.m_TitleImage.width * 0.5);
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          if(this.m_IsShowing == false)
          {

--- a/client/scripts/com/monsters/maproom/MapRoom.as
+++ b/client/scripts/com/monsters/maproom/MapRoom.as
@@ -1,12 +1,13 @@
 package com.monsters.maproom
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.maproom.views.*;
    import flash.display.MovieClip;
    import flash.display.Sprite;
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class MapRoom extends old_maproom
+   public class MapRoom extends old_maproom implements IHideActionHandler
    {
       
       public static var top:Sprite;
@@ -143,7 +144,7 @@ package com.monsters.maproom
          this.players.Get();
       }
       
-      public function Hide(... rest) : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          var _loc2_:Function = null;
          if(BRIDGE.Hide)

--- a/client/scripts/com/monsters/maproom/views/MapView.as
+++ b/client/scripts/com/monsters/maproom/views/MapView.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom.views
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.maproom.*;
    import flash.display.Bitmap;
@@ -14,7 +15,7 @@ package com.monsters.maproom.views
    import gs.TweenLite;
    import gs.easing.Quad;
    
-   public class MapView extends MapView_CLIP
+   public class MapView extends MapView_CLIP implements IHideActionHandler
    {
       
       private static var instance:MapView;
@@ -299,7 +300,7 @@ package com.monsters.maproom.views
          this.players.Get();
       }
       
-      public function Hide(... rest) : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          stage.removeEventListener(MouseEvent.MOUSE_UP,this.stageUp);
       }

--- a/client/scripts/com/monsters/maproom3/MapRoom3.as
+++ b/client/scripts/com/monsters/maproom3/MapRoom3.as
@@ -8,6 +8,7 @@ package com.monsters.maproom3
    import com.monsters.maproom_manager.IMapRoomCell;
    import flash.events.Event;
    import flash.events.IOErrorEvent;
+   import flash.events.MouseEvent;
    import flash.events.SecurityErrorEvent;
    import flash.geom.Point;
    import flash.net.URLLoader;
@@ -168,7 +169,7 @@ package com.monsters.maproom3
          m_MapRoom3Window.Init(this.m_LastCenterPoint);
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          this.m_Open = false;
          this.m_LastCenterPoint = m_MapRoom3Window.centerPoint;

--- a/client/scripts/com/monsters/maproom3/MapRoom3CellMouseover.as
+++ b/client/scripts/com/monsters/maproom3/MapRoom3CellMouseover.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom3
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.alliances.ALLIANCES;
    import com.monsters.display.ImageCache;
    import com.monsters.mailbox.Message;
@@ -19,7 +20,7 @@ package com.monsters.maproom3
    import flash.text.TextField;
    import flash.text.TextFormat;
    
-   public class MapRoom3CellMouseover extends Sprite
+   public class MapRoom3CellMouseover extends Sprite implements IHideActionHandler
    {
       
       private static const PORTRAIT_WIDTH:int = 50;
@@ -269,7 +270,7 @@ package com.monsters.maproom3
          this.ShowButtons(param4);
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          this.ClearInfo();
          visible = false;

--- a/client/scripts/com/monsters/maproom3/MapRoom3CellMouseover.as
+++ b/client/scripts/com/monsters/maproom3/MapRoom3CellMouseover.as
@@ -1,6 +1,5 @@
 package com.monsters.maproom3
 {
-   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.alliances.ALLIANCES;
    import com.monsters.display.ImageCache;
    import com.monsters.mailbox.Message;
@@ -20,7 +19,7 @@ package com.monsters.maproom3
    import flash.text.TextField;
    import flash.text.TextFormat;
    
-   public class MapRoom3CellMouseover extends Sprite implements IHideActionHandler
+   public class MapRoom3CellMouseover extends Sprite
    {
       
       private static const PORTRAIT_WIDTH:int = 50;
@@ -270,7 +269,7 @@ package com.monsters.maproom3
          this.ShowButtons(param4);
       }
       
-      public function Hide(param1:MouseEvent = null) : void
+      public function Hide() : void
       {
          this.ClearInfo();
          visible = false;

--- a/client/scripts/com/monsters/maproom3/bookmarks/BookmarksPopup.as
+++ b/client/scripts/com/monsters/maproom3/bookmarks/BookmarksPopup.as
@@ -1,6 +1,8 @@
 package com.monsters.maproom3.bookmarks
 {
-   public class BookmarksPopup extends MapRoom3BookmarksPopup
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
+   import flash.events.MouseEvent;
+   public class BookmarksPopup extends MapRoom3BookmarksPopup implements IHideActionHandler
    {
       
       private static const MAX_BOOKMARKS_DISPLAY_LIST_LENGTH:uint = 10;
@@ -29,7 +31,7 @@ package com.monsters.maproom3.bookmarks
          return new BookmarksPopupMenuItem(param1);
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          POPUPS.Next();
          if(this.m_BookmarkDisplayList != null)

--- a/client/scripts/com/monsters/maproom3/popups/MapRoom3AttackFinishedPopup.as
+++ b/client/scripts/com/monsters/maproom3/popups/MapRoom3AttackFinishedPopup.as
@@ -1,11 +1,12 @@
 package com.monsters.maproom3.popups
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.maproom_manager.MapRoomManager;
    import config.singletonlock.SingletonLock;
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class MapRoom3AttackFinishedPopup extends popup_attackend_CLIP
+   public class MapRoom3AttackFinishedPopup extends popup_attackend_CLIP implements IHideActionHandler
    {
       
       private static var s_Instance:MapRoom3AttackFinishedPopup = null;
@@ -41,7 +42,7 @@ package com.monsters.maproom3.popups
          POPUPS.Push(this);
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          POPUPS.Next();
       }

--- a/client/scripts/com/monsters/maproom3/popups/MapRoom3ConfirmMigrationPopup.as
+++ b/client/scripts/com/monsters/maproom3/popups/MapRoom3ConfirmMigrationPopup.as
@@ -1,10 +1,11 @@
 package com.monsters.maproom3.popups
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.maproom_manager.MapRoomManager;
    import config.singletonlock.SingletonLock;
    import flash.events.MouseEvent;
    
-   public class MapRoom3ConfirmMigrationPopup extends popup_new_map_confirm
+   public class MapRoom3ConfirmMigrationPopup extends popup_new_map_confirm implements IHideActionHandler
    {
       
       private static var s_Instance:MapRoom3ConfirmMigrationPopup = null;
@@ -47,7 +48,7 @@ package com.monsters.maproom3.popups
          this.m_IsShowing = true;
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          btnJuice.removeEventListener(MouseEvent.CLICK,this.OnConfirmButtonClicked);
          btnCancel.removeEventListener(MouseEvent.CLICK,this.OnCancelButtonClicked);

--- a/client/scripts/com/monsters/maproom3/popups/MapRoom3RelocatePopup.as
+++ b/client/scripts/com/monsters/maproom3/popups/MapRoom3RelocatePopup.as
@@ -1,12 +1,13 @@
 package com.monsters.maproom3.popups
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.enums.EnumYardType;
    import com.monsters.maproom3.data.MapRoom3FriendData;
    import com.monsters.maproom_manager.MapRoomManager;
    import config.singletonlock.SingletonLock;
    import flash.events.MouseEvent;
    
-   public class MapRoom3RelocatePopup extends MapRoom3RelocateMainYardPopup
+   public class MapRoom3RelocatePopup extends MapRoom3RelocateMainYardPopup implements IHideActionHandler
    {
       
       private static var s_Instance:MapRoom3RelocatePopup = null;
@@ -77,7 +78,7 @@ package com.monsters.maproom3.popups
          contentsContainer.addChild(this.m_DisplayList);
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          if(this.m_IsShowing == false)
          {

--- a/client/scripts/com/monsters/maproom3/popups/Maproom3JumpPopup.as
+++ b/client/scripts/com/monsters/maproom3/popups/Maproom3JumpPopup.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom3.popups
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.enums.EnumYardType;
    import com.monsters.maproom_manager.IMapRoomCell;
    import com.monsters.maproom_manager.MapRoomManager;
@@ -8,7 +9,7 @@ package com.monsters.maproom3.popups
    import flash.events.MouseEvent;
    import flash.ui.Keyboard;
    
-   public class Maproom3JumpPopup extends MapRoomPopupJump
+   public class Maproom3JumpPopup extends MapRoomPopupJump implements IHideActionHandler
    {
       
       public static const k_clickedJump:String = "clickedJumpButton";
@@ -61,7 +62,7 @@ package com.monsters.maproom3.popups
          dispatchEvent(new Event(k_clickedJump));
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          tX.removeEventListener(KeyboardEvent.KEY_UP,this.keyUpOnX);
          tY.removeEventListener(KeyboardEvent.KEY_UP,this.keyUpOnY);

--- a/client/scripts/com/monsters/maproom_advanced/MapRoom.as
+++ b/client/scripts/com/monsters/maproom_advanced/MapRoom.as
@@ -1401,7 +1401,7 @@ package com.monsters.maproom_advanced
          Tutorial.ShowIfNeeded();
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          if(_open)
          {

--- a/client/scripts/com/monsters/maproom_advanced/MapRoomPopup.as
+++ b/client/scripts/com/monsters/maproom_advanced/MapRoomPopup.as
@@ -1,5 +1,8 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IFullScreenActionHandler;
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.alliances.AllyInfo;
    import com.monsters.display.ImageCache;
    import com.monsters.enums.EnumYardType;
@@ -15,8 +18,8 @@ package com.monsters.maproom_advanced
    import flash.geom.Point;
    import flash.geom.Rectangle;
    import flash.net.URLRequest;
-   
-   internal class MapRoomPopup extends MapRoomPopup_CLIP
+
+   internal class MapRoomPopup extends MapRoomPopup_CLIP implements IFullScreenActionHandler, IHelpActionHandler, IHideActionHandler
    {
        
       
@@ -1701,12 +1704,12 @@ package com.monsters.maproom_advanced
          this.BuffHide(null);
       }
       
-      public function Help() : void
+      public function Help(event: MouseEvent = null) : void
       {
          Tutorial.ForceShowAll();
       }
       
-      public function FullScreen() : void
+      public function FullScreen(event: MouseEvent = null) : void
       {
          if(GLOBAL.isFullScreen)
          {

--- a/client/scripts/com/monsters/maproom_advanced/PopupAttackA.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupAttackA.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
 
    import com.cc.utils.SecNum;
    import com.monsters.alliances.*;
@@ -20,7 +21,7 @@ package com.monsters.maproom_advanced
    import flash.events.MouseEvent;
    import flash.net.URLRequest;
 
-   internal class PopupAttackA extends PopupAttackA_CLIP
+   internal class PopupAttackA extends PopupAttackA_CLIP implements IHideActionHandler
    {
       private var _cell:MapRoomCell;
 

--- a/client/scripts/com/monsters/maproom_advanced/PopupInfoEnemy.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupInfoEnemy.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    
    import com.cc.utils.SecNum;
    import com.monsters.alliances.*;
@@ -19,7 +20,7 @@ package com.monsters.maproom_advanced
    import flash.geom.Point;
    import flash.net.URLRequest;
    
-   internal class PopupInfoEnemy extends PopupInfoEnemy_CLIP
+   internal class PopupInfoEnemy extends PopupInfoEnemy_CLIP implements IHideActionHandler
    {
       
       private static var _takeoverCost:SecNum;

--- a/client/scripts/com/monsters/maproom_advanced/PopupInfoMine.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupInfoMine.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ScrollSet;
    import com.monsters.enums.EnumYardType;
    import com.monsters.mailbox.Message;
@@ -10,7 +11,7 @@ package com.monsters.maproom_advanced
    import gs.TweenLite;
    import gs.easing.Elastic;
    
-   internal class PopupInfoMine extends PopupInfoMine_CLIP
+   internal class PopupInfoMine extends PopupInfoMine_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/com/monsters/maproom_advanced/PopupInfoViewOnly.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupInfoViewOnly.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    
    import com.monsters.display.ImageCache;
    import com.monsters.enums.EnumYardType;
@@ -11,7 +12,7 @@ package com.monsters.maproom_advanced
    import flash.events.MouseEvent;
    import flash.net.URLRequest;
    
-   internal class PopupInfoViewOnly extends PopupInfoViewOnly_CLIP
+   internal class PopupInfoViewOnly extends PopupInfoViewOnly_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/com/monsters/maproom_advanced/PopupLostMainBase.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupLostMainBase.as
@@ -1,11 +1,12 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.maproom_manager.MapRoomManager;
    import flash.events.IOErrorEvent;
    import flash.events.MouseEvent;
    import flash.geom.Point;
    
-   public class PopupLostMainBase extends MapRoomPopup_LostMainBase_CLIP
+   public class PopupLostMainBase extends MapRoomPopup_LostMainBase_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/com/monsters/maproom_advanced/PopupMigrate.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupMigrate.as
@@ -1,12 +1,13 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
    import flash.display.BitmapData;
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class PopupMigrate extends MapRoomPopup_Migrate_CLIP
+   public class PopupMigrate extends MapRoomPopup_Migrate_CLIP implements IHideActionHandler
    {
       
       private static var instance:PopupMigrate;
@@ -73,7 +74,7 @@ package com.monsters.maproom_advanced
          instance = null;
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          if(Boolean(this._closeHandler))
          {

--- a/client/scripts/com/monsters/maproom_advanced/PopupMonstersA.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupMonstersA.as
@@ -1,12 +1,13 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.cc.utils.SecNum;
    import com.monsters.display.ScrollSet;
    import flash.display.MovieClip;
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   internal class PopupMonstersA extends PopupMonstersA_CLIP
+   internal class PopupMonstersA extends PopupMonstersA_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/com/monsters/maproom_advanced/PopupMonstersB.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupMonstersB.as
@@ -1,10 +1,11 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ScrollSet;
    import flash.display.MovieClip;
    import flash.events.MouseEvent;
    
-   internal class PopupMonstersB extends PopupMonstersB_CLIP
+   internal class PopupMonstersB extends PopupMonstersB_CLIP implements IHideActionHandler
    {
        
       

--- a/client/scripts/com/monsters/maproom_advanced/PopupRelocateMe.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupRelocateMe.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    
    import com.cc.utils.SecNum;
    import com.monsters.maproom_manager.MapRoomManager;
@@ -9,7 +10,7 @@ package com.monsters.maproom_advanced
    import flash.events.MouseEvent;
    import flash.geom.Point;
    
-   internal class PopupRelocateMe extends PopupRelocateMe_CLIP
+   internal class PopupRelocateMe extends PopupRelocateMe_CLIP implements IHideActionHandler
    {
        
       
@@ -125,7 +126,7 @@ package com.monsters.maproom_advanced
          }
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          GLOBAL.BlockerRemove();
          if(this.parent)

--- a/client/scripts/com/monsters/maproom_advanced/PopupTakeover.as
+++ b/client/scripts/com/monsters/maproom_advanced/PopupTakeover.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom_advanced
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    
    import com.cc.utils.SecNum;
    import com.monsters.display.ImageCache;
@@ -10,7 +11,7 @@ package com.monsters.maproom_advanced
    import flash.events.MouseEvent;
    import flash.geom.Point;
    
-   internal class PopupTakeover extends MapRoomPopup_takeover_CLIP
+   internal class PopupTakeover extends MapRoomPopup_takeover_CLIP implements IHideActionHandler
    {
       
       private static const TAKEOVER_CAP:int = 65000000;
@@ -145,7 +146,7 @@ package com.monsters.maproom_advanced
          });
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          GLOBAL.BlockerRemove();
          this.parent.removeChild(this);

--- a/client/scripts/com/monsters/maproom_inferno/DescentMapRoom.as
+++ b/client/scripts/com/monsters/maproom_inferno/DescentMapRoom.as
@@ -1,12 +1,13 @@
 package com.monsters.maproom_inferno
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.maproom_inferno.views.*;
    import flash.display.MovieClip;
    import flash.display.Sprite;
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class DescentMapRoom extends MapRoomPopup_InfernoDescent
+   public class DescentMapRoom extends MapRoomPopup_InfernoDescent implements IHideActionHandler
    {
       
       public static var top:Sprite;
@@ -131,7 +132,7 @@ package com.monsters.maproom_inferno
          this.players.Get();
       }
       
-      public function Hide(... rest) : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          if(BRIDGE.Hide)
          {

--- a/client/scripts/com/monsters/maproom_inferno/MapRoom.as
+++ b/client/scripts/com/monsters/maproom_inferno/MapRoom.as
@@ -1,12 +1,13 @@
 package com.monsters.maproom_inferno
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.maproom_inferno.views.*;
    import flash.display.MovieClip;
    import flash.display.Sprite;
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class MapRoom extends old_maproom
+   public class MapRoom extends old_maproom implements IHideActionHandler
    {
       
       public static var top:Sprite;
@@ -139,7 +140,7 @@ package com.monsters.maproom_inferno
          this.players.Get();
       }
       
-      public function Hide(... rest) : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          var _loc2_:Function = null;
          if(BRIDGE.Hide)

--- a/client/scripts/com/monsters/maproom_inferno/views/DescentBasePopup.as
+++ b/client/scripts/com/monsters/maproom_inferno/views/DescentBasePopup.as
@@ -1,11 +1,13 @@
 package com.monsters.maproom_inferno.views
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
+   import flash.events.MouseEvent;
    import flash.events.TimerEvent;
    import flash.utils.Timer;
    import gs.TweenLite;
    import gs.easing.Elastic;
    
-   public class DescentBasePopup extends DescentBasePopup_CLIP
+   public class DescentBasePopup extends DescentBasePopup_CLIP implements IHideActionHandler
    {
        
       
@@ -122,7 +124,7 @@ package com.monsters.maproom_inferno.views
          this._t.addEventListener(TimerEvent.TIMER,this.DepthCheck);
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          this._t.stop();
          this._t.removeEventListener(TimerEvent.TIMER,this.DepthCheck);

--- a/client/scripts/com/monsters/maproom_inferno/views/DescentDebuffPopup.as
+++ b/client/scripts/com/monsters/maproom_inferno/views/DescentDebuffPopup.as
@@ -1,11 +1,12 @@
 package com.monsters.maproom_inferno.views
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.display.MovieClip;
    import flash.events.MouseEvent;
    import flash.events.TimerEvent;
    import flash.utils.Timer;
    
-   public class DescentDebuffPopup extends descentDebuff_info_CLIP
+   public class DescentDebuffPopup extends descentDebuff_info_CLIP implements IHideActionHandler
    {
        
       
@@ -81,7 +82,7 @@ package com.monsters.maproom_inferno.views
          UI2._top.addChild(this);
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          this._t.stop();
          this._t.removeEventListener(TimerEvent.TIMER,this.DepthCheck);

--- a/client/scripts/com/monsters/maproom_inferno/views/DescentView.as
+++ b/client/scripts/com/monsters/maproom_inferno/views/DescentView.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom_inferno.views
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.maproom_inferno.*;
    import flash.display.Bitmap;
@@ -14,7 +15,7 @@ package com.monsters.maproom_inferno.views
    import gs.TweenLite;
    import gs.easing.Quad;
    
-   public class DescentView extends DescentView_CLIP
+   public class DescentView extends DescentView_CLIP implements IHideActionHandler
    {
       
       private static var instance:DescentView;
@@ -304,7 +305,7 @@ package com.monsters.maproom_inferno.views
          this.players.Get();
       }
       
-      public function Hide(... rest) : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          stage.removeEventListener(MouseEvent.MOUSE_UP,this.stageUp);
       }

--- a/client/scripts/com/monsters/maproom_inferno/views/MapView.as
+++ b/client/scripts/com/monsters/maproom_inferno/views/MapView.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom_inferno.views
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.maproom.views.MapView_CLIP;
    import com.monsters.maproom_inferno.*;
@@ -15,7 +16,7 @@ package com.monsters.maproom_inferno.views
    import gs.TweenLite;
    import gs.easing.Quad;
    
-   public class MapView extends MapView_CLIP
+   public class MapView extends MapView_CLIP implements IHideActionHandler
    {
       
       private static var instance:MapView;
@@ -294,7 +295,7 @@ package com.monsters.maproom_inferno.views
          this.players.Get();
       }
       
-      public function Hide(... rest) : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          stage.removeEventListener(MouseEvent.MOUSE_UP,this.stageUp);
       }

--- a/client/scripts/com/monsters/maproom_manager/IMapRoom.as
+++ b/client/scripts/com/monsters/maproom_manager/IMapRoom.as
@@ -1,5 +1,6 @@
 package com.monsters.maproom_manager
 {
+   import flash.events.MouseEvent;
    import flash.utils.Dictionary;
    
    public interface IMapRoom
@@ -32,7 +33,7 @@ package com.monsters.maproom_manager
       
       function ShowDelayed(param1:Boolean = false) : void;
       
-      function Hide() : void;
+      function Hide(param1:MouseEvent = null) : void;
       
       function Tick() : void;
       

--- a/client/scripts/com/monsters/missions/MISSIONS_INFO.as
+++ b/client/scripts/com/monsters/missions/MISSIONS_INFO.as
@@ -1,5 +1,6 @@
 package com.monsters.missions
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.maproom_advanced.PopupInfoMonster;
    import com.monsters.siege.SiegeWeapons;
@@ -9,7 +10,7 @@ package com.monsters.missions
    import flash.display.MovieClip;
    import flash.events.MouseEvent;
    
-   public class MISSIONS_INFO extends MISSIONS_INFO_CLIP
+   public class MISSIONS_INFO extends MISSIONS_INFO_CLIP implements IHideActionHandler
    {
        
       
@@ -195,7 +196,7 @@ package com.monsters.missions
          };
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          QUESTS.Hide();
       }

--- a/client/scripts/com/monsters/radio/RADIOSETTINGSPOPUP.as
+++ b/client/scripts/com/monsters/radio/RADIOSETTINGSPOPUP.as
@@ -1,9 +1,10 @@
 package com.monsters.radio
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class RADIOSETTINGSPOPUP extends RADIOSETTINGSPOPUP_CLIP
+   public class RADIOSETTINGSPOPUP extends RADIOSETTINGSPOPUP_CLIP implements IHideActionHandler
    {
        
       
@@ -196,7 +197,7 @@ package com.monsters.radio
          tEmailInput.removeEventListener(MouseEvent.CLICK,this.onEmailClear);
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          var _loc1_:Checkbox = cbNews as Checkbox;
          var _loc2_:Checkbox = cbAttack as Checkbox;

--- a/client/scripts/com/monsters/replayableEvents/ReplayableEventUI.as
+++ b/client/scripts/com/monsters/replayableEvents/ReplayableEventUI.as
@@ -1,5 +1,6 @@
 package com.monsters.replayableEvents
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.chat.Chat;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
@@ -9,7 +10,7 @@ package com.monsters.replayableEvents
    import flash.events.MouseEvent;
    import flash.utils.Timer;
    
-   public class ReplayableEventUI extends EventsBar_CLIP implements IReplayableEventUI
+   public class ReplayableEventUI extends EventsBar_CLIP implements IReplayableEventUI, IHideActionHandler
    {
       
       public static var CLICKED_ACTION:String = "eventBarAction";
@@ -214,7 +215,7 @@ package com.monsters.replayableEvents
          dispatchEvent(new Event(CLICKED_INFO));
       }
       
-      private function Hide() : void
+      public function Hide(event:MouseEvent = null) : void
       {
          if(Boolean(this) && Boolean(this.parent))
          {

--- a/client/scripts/com/monsters/replayableEvents/ReplayableEventUI.as
+++ b/client/scripts/com/monsters/replayableEvents/ReplayableEventUI.as
@@ -1,6 +1,5 @@
 package com.monsters.replayableEvents
 {
-   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.chat.Chat;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
@@ -10,7 +9,7 @@ package com.monsters.replayableEvents
    import flash.events.MouseEvent;
    import flash.utils.Timer;
    
-   public class ReplayableEventUI extends EventsBar_CLIP implements IReplayableEventUI, IHideActionHandler
+   public class ReplayableEventUI extends EventsBar_CLIP implements IReplayableEventUI
    {
       
       public static var CLICKED_ACTION:String = "eventBarAction";
@@ -215,7 +214,7 @@ package com.monsters.replayableEvents
          dispatchEvent(new Event(CLICKED_INFO));
       }
       
-      public function Hide(event:MouseEvent = null) : void
+      private function Hide() : void
       {
          if(Boolean(this) && Boolean(this.parent))
          {

--- a/client/scripts/com/monsters/replayableEvents/attacking/monsterMadness/MonsterMadnessInfoBar.as
+++ b/client/scripts/com/monsters/replayableEvents/attacking/monsterMadness/MonsterMadnessInfoBar.as
@@ -1,6 +1,5 @@
 package com.monsters.replayableEvents.attacking.monsterMadness
 {
-   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.chat.Chat;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
@@ -8,7 +7,7 @@ package com.monsters.replayableEvents.attacking.monsterMadness
    import flash.events.MouseEvent;
    import flash.utils.Timer;
    
-   public class MonsterMadnessInfoBar extends MonsterMadnessBar_CLIP implements IHideActionHandler
+   public class MonsterMadnessInfoBar extends MonsterMadnessBar_CLIP
    {
        
       

--- a/client/scripts/com/monsters/replayableEvents/attacking/monsterMadness/MonsterMadnessInfoBar.as
+++ b/client/scripts/com/monsters/replayableEvents/attacking/monsterMadness/MonsterMadnessInfoBar.as
@@ -1,5 +1,6 @@
 package com.monsters.replayableEvents.attacking.monsterMadness
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.chat.Chat;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
@@ -7,7 +8,7 @@ package com.monsters.replayableEvents.attacking.monsterMadness
    import flash.events.MouseEvent;
    import flash.utils.Timer;
    
-   public class MonsterMadnessInfoBar extends MonsterMadnessBar_CLIP
+   public class MonsterMadnessInfoBar extends MonsterMadnessBar_CLIP implements IHideActionHandler
    {
        
       
@@ -141,7 +142,7 @@ package com.monsters.replayableEvents.attacking.monsterMadness
          mcImage.addChild(new Bitmap(param2));
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          if(Boolean(this) && Boolean(this.parent))
          {

--- a/client/scripts/com/monsters/siege/SiegeBuildingPopup.as
+++ b/client/scripts/com/monsters/siege/SiegeBuildingPopup.as
@@ -1,5 +1,6 @@
 package com.monsters.siege
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.display.ScrollSet;
    import com.monsters.siege.weapons.SiegeWeapon;
@@ -18,7 +19,7 @@ package com.monsters.siege
    import flash.text.TextField;
    import flash.utils.Timer;
    
-   public class SiegeBuildingPopup extends SIEGEBUILDINGPOPUP_CLIP
+   public class SiegeBuildingPopup extends SIEGEBUILDINGPOPUP_CLIP implements IHideActionHandler
    {
        
       
@@ -693,7 +694,7 @@ package com.monsters.siege
          mcResources.visible = true;
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          this._timer.stop();
          SiegeBuilding.Hide();

--- a/client/scripts/com/monsters/subscriptions/ui/SubscriptionJoinPopup.as
+++ b/client/scripts/com/monsters/subscriptions/ui/SubscriptionJoinPopup.as
@@ -1,5 +1,6 @@
 package com.monsters.subscriptions.ui
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import com.monsters.subscriptions.SubscriptionHandler;
    import flash.display.Bitmap;
@@ -8,7 +9,7 @@ package com.monsters.subscriptions.ui
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class SubscriptionJoinPopup extends subscriptions_promo_popup
+   public class SubscriptionJoinPopup extends subscriptions_promo_popup implements IHideActionHandler
    {
        
       
@@ -130,7 +131,7 @@ package com.monsters.subscriptions.ui
          }
       }
       
-      public function Hide() : void
+      public function Hide(param1:MouseEvent = null) : void
       {
          mcArrowLeft.removeEventListener(MouseEvent.CLICK,this.onArrowClickPrev);
          mcArrowRight.removeEventListener(MouseEvent.CLICK,this.onArrowClickNext);

--- a/client/scripts/com/monsters/subscriptions/ui/controlPanel/MembershipPopup.as
+++ b/client/scripts/com/monsters/subscriptions/ui/controlPanel/MembershipPopup.as
@@ -1,10 +1,11 @@
 package com.monsters.subscriptions.ui.controlPanel
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.subscriptions.SubscriptionHandler;
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class MembershipPopup extends subscriptions_membership_popup
+   public class MembershipPopup extends subscriptions_membership_popup implements IHideActionHandler
    {
        
       

--- a/client/scripts/com/monsters/subscriptions/ui/controlPanel/SubscriptionCancelPopup.as
+++ b/client/scripts/com/monsters/subscriptions/ui/controlPanel/SubscriptionCancelPopup.as
@@ -1,10 +1,11 @@
 package com.monsters.subscriptions.ui.controlPanel
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.subscriptions.SubscriptionHandler;
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class SubscriptionCancelPopup extends subscriptions_cancelconfirm_popup
+   public class SubscriptionCancelPopup extends subscriptions_cancelconfirm_popup implements IHideActionHandler
    {
        
       

--- a/client/scripts/com/monsters/subscriptions/ui/controlPanel/SubscriptionControlPanelPopup.as
+++ b/client/scripts/com/monsters/subscriptions/ui/controlPanel/SubscriptionControlPanelPopup.as
@@ -1,5 +1,6 @@
 package com.monsters.subscriptions.ui.controlPanel
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.rewarding.RewardHandler;
    import com.monsters.subscriptions.SubscriptionHandler;
    import com.monsters.subscriptions.rewards.DAVEStatueReward;
@@ -9,7 +10,7 @@ package com.monsters.subscriptions.ui.controlPanel
    import flash.events.Event;
    import flash.events.MouseEvent;
    
-   public class SubscriptionControlPanelPopup extends subscriptions_controlPanel_popup
+   public class SubscriptionControlPanelPopup extends subscriptions_controlPanel_popup implements IHideActionHandler
    {
       
       public static const SAVE:String = "saveChanges";

--- a/client/scripts/frame.as
+++ b/client/scripts/frame.as
@@ -1,5 +1,8 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IFullScreenActionHandler;
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.display.Bitmap;
    import flash.display.DisplayObject;
    import flash.display.MovieClip;
@@ -204,9 +207,10 @@ package
       
       private function BtnClose(param1:MouseEvent = null) : void
       {
-         if("Hide" in parent)
+         var handler: IHideActionHandler = parent as IHideActionHandler;
+         if(handler != null)
          {
-            (parent as Object).Hide();
+            handler.Hide(param1);
          }
          else if(Boolean(this._customCloseFunction))
          {
@@ -302,18 +306,21 @@ package
       
       private function BtnHelp(param1:MouseEvent = null) : void
       {
-         if("Help" in parent)
+         var handler:IHelpActionHandler = parent as IHelpActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).Help();
+            handler.Help(param1);
          }
       }
       
       private function BtnFullScreen(param1:MouseEvent = null) : void
       {
          GLOBAL.goFullScreen();
-         if("FullScreen" in parent)
+         
+         var handler:IFullScreenActionHandler = parent as IFullScreenActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).FullScreen();
+            handler.FullScreen(param1);
          }
       }
    }

--- a/client/scripts/frame1.as
+++ b/client/scripts/frame1.as
@@ -1,5 +1,8 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IFullScreenActionHandler;
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.display.Bitmap;
    import flash.display.DisplayObject;
    import flash.display.MovieClip;
@@ -287,9 +290,10 @@ package
       
       private function BtnClose(param1:MouseEvent = null) : void
       {
-         if("Hide" in parent)
+         var handler: IHideActionHandler = parent as IHideActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).Hide();
+            handler.Hide(param1);
          }
          else
          {
@@ -299,18 +303,21 @@ package
       
       private function BtnHelp(param1:MouseEvent = null) : void
       {
-         if("Help" in parent)
+         var handler:IHelpActionHandler = parent as IHelpActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).Help();
+            handler.Help(param1);
          }
       }
       
       private function BtnFullScreen(param1:MouseEvent = null) : void
       {
          GLOBAL.goFullScreen();
-         if("FullScreen" in parent)
+
+         var handler:IFullScreenActionHandler = parent as IFullScreenActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).FullScreen();
+            handler.FullScreen(param1);
          }
       }
    }

--- a/client/scripts/frame2.as
+++ b/client/scripts/frame2.as
@@ -1,5 +1,8 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IFullScreenActionHandler;
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.display.Bitmap;
    import flash.display.DisplayObject;
    import flash.display.MovieClip;
@@ -53,7 +56,7 @@ package
          var _loc4_:MovieClip = null;
          this.Clear();
          this._customCloseFunction = param2;
-         _loc3_ = "Help" in parent;
+         _loc3_ = parent is IHelpActionHandler;
          this._bottomLeft = new Bitmap(new frame2_bottom_left(0,0));
          this._bottomRight = new Bitmap(new frame2_bottom_right(0,0));
          this._topLeft = new Bitmap(new frame2_top_left(0,0));
@@ -214,9 +217,10 @@ package
       
       private function BtnClose(param1:MouseEvent = null) : void
       {
-         if("Hide" in parent)
+         var handler: IHideActionHandler = parent as IHideActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).Hide();
+            handler.Hide(param1);
          }
          else if(Boolean(this._customCloseFunction))
          {
@@ -230,18 +234,21 @@ package
       
       private function BtnHelp(param1:MouseEvent = null) : void
       {
-         if("Help" in parent)
+         var handler:IHelpActionHandler = parent as IHelpActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).Help();
+            handler.Help(param1);
          }
       }
       
       private function BtnFullScreen(param1:MouseEvent = null) : void
       {
          GLOBAL.goFullScreen();
-         if("FullScreen" in parent)
+
+         var handler:IFullScreenActionHandler = parent as IFullScreenActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).FullScreen();
+            handler.FullScreen(param1);
          }
       }
    }

--- a/client/scripts/frame3.as
+++ b/client/scripts/frame3.as
@@ -1,5 +1,8 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IFullScreenActionHandler;
+   import com.bymrefitted.ui.interfaces.IHelpActionHandler;
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import flash.display.Bitmap;
    import flash.display.DisplayObject;
    import flash.display.MovieClip;
@@ -52,7 +55,7 @@ package
          var _loc4_:MovieClip = null;
          this.Clear();
          this._customCloseFunction = param2;
-         _loc3_ = "Help" in parent;
+         _loc3_ = parent is IHelpActionHandler;
          this._bottomLeft = new Bitmap(new frame3_bottom_left(0,0));
          this._bottomRight = new Bitmap(new frame3_bottom_right(0,0));
          this._topLeft = new Bitmap(new frame3_top_left(0,0));
@@ -213,9 +216,10 @@ package
       
       private function BtnClose(param1:MouseEvent = null) : void
       {
-         if("Hide" in parent)
+         var handler: IHideActionHandler = parent as IHideActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).Hide();
+            handler.Hide(param1);
          }
          else if(Boolean(this._customCloseFunction))
          {
@@ -229,18 +233,21 @@ package
       
       private function BtnHelp(param1:MouseEvent = null) : void
       {
-         if("Help" in parent)
+         var handler:IHelpActionHandler = parent as IHelpActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).Help();
+            handler.Help(param1);
          }
       }
       
       private function BtnFullScreen(param1:MouseEvent = null) : void
       {
          GLOBAL.goFullScreen();
-         if("FullScreen" in parent)
+
+         var handler:IFullScreenActionHandler = parent as IFullScreenActionHandler;
+         if(handler != null)
          {
-            (parent as MovieClip).FullScreen();
+            handler.FullScreen(param1);
          }
       }
    }

--- a/client/scripts/popup_prefab_enlarge.as
+++ b/client/scripts/popup_prefab_enlarge.as
@@ -1,11 +1,12 @@
 package
 {
+   import com.bymrefitted.ui.interfaces.IHideActionHandler;
    import com.monsters.display.ImageCache;
    import flash.display.Bitmap;
    import flash.display.BitmapData;
    import flash.events.MouseEvent;
    
-   public class popup_prefab_enlarge extends popup_prefab_enlarge_CLIP
+   public class popup_prefab_enlarge extends popup_prefab_enlarge_CLIP implements IHideActionHandler
    {
        
       


### PR DESCRIPTION
## Summary

Replaces the client's runtime, string-based UI action lookup with type-safe interface casts, so the contract between a window and its frame is enforced by the compiler instead of by naming convention.

## Background

A *frame* is the window chrome: it draws the window background and border, and owns the actions common to every window — fullscreen, help, and hide/close. There are four variants (`frame`, `frame1`, `frame2`, `frame3`).

Frames are always used as a **child of the popup they decorate**. That is by design, and it is what makes their use of `parent` meaningful: when the user clicks the frame's close button, the frame walks back up to `parent` — the popup that owns it — and asks that popup to close itself. The same goes for help and fullscreen.

The problem was how the frame decided whether its parent could handle an action. It probed for a method by *name*, at runtime:

```as3
if("Hide" in parent)
{
   (parent as MovieClip).Hide();
}
```

Nothing about that is visible to the compiler. Renaming or removing `Hide()` on a popup silently breaks that popup's close button, with no build error and no obvious failure until someone clicks it. In the other direction, any class that happens to expose a member called `Hide` — for whatever unrelated reason — becomes a valid target by accident. The relationship between a frame and the window hosting it was real, load-bearing, and completely undeclared.

## The change

Three interfaces now declare that contract explicitly, under `com.bymrefitted.ui.interfaces`:

| Interface | Method | Implementers |
| --- | --- | --- |
| `IHideActionHandler` | `Hide(param1:MouseEvent = null)` | 72 |
| `IHelpActionHandler` | `Help(param1:MouseEvent = null)` | 8 |
| `IFullScreenActionHandler` | `FullScreen(param1:MouseEvent = null)` | 1 |

Every window the frame chrome previously reached by name now declares which of these actions it supports, and the frames cast instead of probing:

```as3
var handler:IHideActionHandler = parent as IHideActionHandler;
if(handler != null)
{
   handler.Hide(param1);
}
```

The help button's visibility check in `frame2`/`frame3` becomes `parent is IHelpActionHandler` in place of `"Help" in parent`.

Each implementing window gains the optional `MouseEvent` parameter on its handler to satisfy the interface signature. `IMapRoom.Hide()` was widened to `Hide(param1:MouseEvent = null)` for the same reason, keeping it consistent with its implementers.

No `"Hide" in`, `"Help" in` or `"FullScreen" in` lookups remain anywhere in `client/scripts`.

## Behaviour

Behaviour-preserving. Two details worth knowing:

- The frame now forwards the originating `MouseEvent` to the handler, where it previously called `Hide()` with no arguments. The parameter is optional and currently ignored by every implementer, so direct calls such as `QUESTS.Hide()` are unaffected.
- `frame.as` previously cast via `(parent as Object).Hide()`, which succeeded against *any* parent object. It now fails the cast cleanly and falls through to `_customCloseFunction` when the parent is not an `IHideActionHandler` — the behaviour `frame1`/`frame2`/`frame3` already had.

Classes that merely happen to own an instance method named `Hide` are deliberately left untagged — for example `INFERNOPORTAL`, which is a `BFOUNDATION` building rather than a window, and was never an intended close target. Making the contract explicit is precisely what lets us exclude them.

## Testing

- The client compiles.
- Manually tested across a broad range of general windows: close, help and fullscreen buttons all behave as before, and the help button still appears only on windows that actually implement `Help`.

## Note on AI usage

🤖 PR description Generated with [Claude Code](https://claude.com/claude-code), reviewed by me.

I used GitHub Copilot and Claude during the implementation of this PR.

I manually implemented the new interfaces, their usage inside the `frame` classes and updated the first 10 POPUP classes to implement the respective interfaces and optionally patch the method signatures of the affected methods.
GitHub Copilot then used my changes as a reference to implement the rest. I reviewed all changes myself, fixed a few errors and then tested the client UI in depth.